### PR TITLE
Feature/integrate rules pdf

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,7 +29,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,8 +64,6 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
     implementation(libs.okhttp)
-    // PDF Viewer
-    implementation("com.github.barteksc:android-pdf-viewer:3.2.0-beta.1")
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,8 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
     implementation(libs.okhttp)
+    // PDF Viewer
+    implementation("com.github.barteksc:android-pdf-viewer:3.2.0-beta.1")
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     androidTestImplementation(libs.androidx.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,16 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/machikoro/client/ui/start/PdfViewerScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/PdfViewerScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.Image
 import java.io.File
@@ -37,6 +38,7 @@ fun PdfViewerScreen(
     onClose: () -> Unit
 ) {
     val context = LocalContext.current
+    val configuration = LocalConfiguration.current
     val currentPage = remember { mutableIntStateOf(0) }
     val totalPages = remember { mutableIntStateOf(0) }
     val currentBitmap = remember { mutableStateOf<Bitmap?>(null) }
@@ -78,8 +80,15 @@ fun PdfViewerScreen(
         }
     }
 
-    // Cleanup
-    DisposableEffect(Unit) {
+    // Re-render when orientation changes
+    LaunchedEffect(configuration.orientation) {
+        pdfRendererRef.value?.let { renderer ->
+            renderPage(renderer, currentPage.value, currentBitmap)
+        }
+    }
+
+    // Cleanup on composable dispose
+    DisposableEffect(onClose) {
         onDispose {
             currentBitmap.value?.recycle()
             pdfRendererRef.value?.close()
@@ -121,9 +130,7 @@ fun PdfViewerScreen(
         ) {
             // Close button with explicit click handling
             Button(
-                onClick = {
-                    onClose()
-                },
+                onClick = onClose,
                 modifier = Modifier.padding(end = 8.dp)
             ) {
                 Text("Close")

--- a/app/src/main/java/com/machikoro/client/ui/start/PdfViewerScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/PdfViewerScreen.kt
@@ -1,6 +1,6 @@
 package com.machikoro.client.ui.start
 
-import android.content.Context
+import android.webkit.WebView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -15,26 +15,23 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import com.machikoro.client.R
-import com.github.barteksc.pdfviewer.PDFView
 import java.io.File
 
 @Composable
 fun PdfViewerScreen(
-    context: Context,
     fileName: String = "rules.pdf",
-    onClose: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onClose: () -> Unit
 ) {
     Box(
         modifier = modifier
             .fillMaxSize()
             .background(Color.White)
     ) {
-        // PDF Viewer
+        // PDF Viewer using WebView
         AndroidView(
             factory = { ctx ->
-                PDFView(ctx, null).apply {
+                WebView(ctx).apply {
                     val file = File(ctx.cacheDir, fileName)
 
                     // Copy from assets if not exists
@@ -46,20 +43,15 @@ fun PdfViewerScreen(
                         }
                     }
 
-                    fromFile(file)
-                        .enableSwipe(true)
-                        .swipeHorizontal(true)
-                        .enableDoubletap(true)
-                        .defaultPage(0)
-                        .enableAnnotationRendering(false)
-                        .enableAntialiasing(true)
-                        .spacing(0)
-                        .autoSpacing(false)
-                        .pageFitPolicy(com.github.barteksc.pdfviewer.scroll.DefaultScrollHandle.FITTED_TO_WIDTH)
-                        .fitEachPage(false)
-                        .pageSnap(true)
-                        .pageFling(true)
-                        .load()
+                    @Suppress("SetJavaScriptEnabled")
+                    settings.apply {
+                        javaScriptEnabled = true
+                        @Suppress("DeprecatedCall")
+                        mixedContentMode = android.webkit.WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+                    }
+
+                    // Load PDF using Google Docs Viewer for better horizontal scaling
+                    loadUrl("https://docs.google.com/gview?embedded=true&url=file://${file.absolutePath}")
                 }
             },
             modifier = Modifier.fillMaxSize()
@@ -71,6 +63,7 @@ fun PdfViewerScreen(
             modifier = Modifier
                 .align(Alignment.TopStart)
                 .padding(top = 16.dp, start = 16.dp)
+                .background(Color.White.copy(alpha = 0.8f), shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp))
         ) {
             Icon(
                 painter = painterResource(id = android.R.drawable.ic_menu_close_clear_cancel),

--- a/app/src/main/java/com/machikoro/client/ui/start/PdfViewerScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/PdfViewerScreen.kt
@@ -11,11 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,7 +26,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.Image
 import java.io.File
@@ -45,7 +40,6 @@ fun PdfViewerScreen(
     val currentPage = remember { mutableIntStateOf(0) }
     val totalPages = remember { mutableIntStateOf(0) }
     val currentBitmap = remember { mutableStateOf<Bitmap?>(null) }
-    val scrollState = rememberScrollState()
     val pdfRendererRef = remember { mutableStateOf<PdfRenderer?>(null) }
     val fileDescriptorRef = remember { mutableStateOf<ParcelFileDescriptor?>(null) }
 
@@ -101,7 +95,6 @@ fun PdfViewerScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .verticalScroll(scrollState)
         ) {
             // PDF content
             currentBitmap.value?.let { bitmap ->
@@ -110,13 +103,14 @@ fun PdfViewerScreen(
                     contentDescription = "PDF Page ${currentPage.value + 1}",
                     modifier = Modifier
                         .fillMaxWidth()
+                        .weight(1f)
                         .background(Color.White),
                     contentScale = ContentScale.FillWidth
                 )
             }
         }
 
-        // Top controls
+        // Top controls - Always visible and clickable
         Row(
             modifier = Modifier
                 .align(Alignment.TopStart)
@@ -125,13 +119,14 @@ fun PdfViewerScreen(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // Close button
-            IconButton(onClick = onClose) {
-                Icon(
-                    painter = painterResource(id = android.R.drawable.ic_menu_close_clear_cancel),
-                    contentDescription = "Close PDF",
-                    tint = MaterialTheme.colorScheme.primary
-                )
+            // Close button with explicit click handling
+            Button(
+                onClick = {
+                    onClose()
+                },
+                modifier = Modifier.padding(end = 8.dp)
+            ) {
+                Text("Close")
             }
 
             // Page indicator

--- a/app/src/main/java/com/machikoro/client/ui/start/PdfViewerScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/PdfViewerScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import java.io.File
 
 @Composable
 fun PdfViewerScreen(
@@ -32,26 +31,17 @@ fun PdfViewerScreen(
         AndroidView(
             factory = { ctx ->
                 WebView(ctx).apply {
-                    val file = File(ctx.cacheDir, fileName)
-
-                    // Copy from assets if not exists
-                    if (!file.exists()) {
-                        ctx.assets.open(fileName).use { input ->
-                            file.outputStream().use { output ->
-                                input.copyTo(output)
-                            }
-                        }
-                    }
-
                     @Suppress("SetJavaScriptEnabled")
                     settings.apply {
                         javaScriptEnabled = true
                         @Suppress("DeprecatedCall")
                         mixedContentMode = android.webkit.WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+                        allowFileAccess = true
                     }
 
-                    // Load PDF using Google Docs Viewer for better horizontal scaling
-                    loadUrl("https://docs.google.com/gview?embedded=true&url=file://${file.absolutePath}")
+                    // Load PDF directly from assets using file:///android_asset/
+                    // This supports horizontal stretching via WebView's built-in PDF viewer
+                    loadUrl("file:///android_asset/$fileName")
                 }
             },
             modifier = Modifier.fillMaxSize()

--- a/app/src/main/java/com/machikoro/client/ui/start/PdfViewerScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/PdfViewerScreen.kt
@@ -1,5 +1,6 @@
 package com.machikoro.client.ui.start
 
+import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.pdf.PdfRenderer
 import android.os.ParcelFileDescriptor
@@ -8,9 +9,15 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -45,6 +52,12 @@ fun PdfViewerScreen(
     val pdfRendererRef = remember { mutableStateOf<PdfRenderer?>(null) }
     val fileDescriptorRef = remember { mutableStateOf<ParcelFileDescriptor?>(null) }
 
+    // Check if in landscape mode
+    val isLandscape = configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+    // Scroll state for portrait mode
+    val verticalScrollState = rememberScrollState()
+
     // Initialize PDF and keep renderer open
     LaunchedEffect(Unit) {
         try {
@@ -64,7 +77,7 @@ fun PdfViewerScreen(
 
             fileDescriptorRef.value = fileDescriptor
             pdfRendererRef.value = pdfRenderer
-            totalPages.value = pdfRenderer.pageCount
+            totalPages.intValue = pdfRenderer.pageCount
 
             // Render first page
             renderPage(pdfRenderer, 0, currentBitmap)
@@ -74,21 +87,21 @@ fun PdfViewerScreen(
     }
 
     // Update bitmap when page changes
-    LaunchedEffect(currentPage.value) {
+    LaunchedEffect(currentPage.intValue) {
         pdfRendererRef.value?.let { renderer ->
-            renderPage(renderer, currentPage.value, currentBitmap)
+            renderPage(renderer, currentPage.intValue, currentBitmap)
         }
     }
 
     // Re-render when orientation changes
     LaunchedEffect(configuration.orientation) {
         pdfRendererRef.value?.let { renderer ->
-            renderPage(renderer, currentPage.value, currentBitmap)
+            renderPage(renderer, currentPage.intValue, currentBitmap)
         }
     }
 
     // Cleanup on composable dispose
-    DisposableEffect(onClose) {
+    DisposableEffect(Unit) {
         onDispose {
             currentBitmap.value?.recycle()
             pdfRendererRef.value?.close()
@@ -96,82 +109,109 @@ fun PdfViewerScreen(
         }
     }
 
+    // Get system bars insets
+    val systemBarsPadding = WindowInsets.systemBars.asPaddingValues()
+
     Box(
         modifier = modifier
             .fillMaxSize()
             .background(Color.White)
+            .padding(systemBarsPadding)
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .padding(top = 56.dp, bottom = if (totalPages.intValue > 1) 56.dp else 0.dp)
         ) {
             // PDF content
-            currentBitmap.value?.let { bitmap ->
-                Image(
-                    bitmap = bitmap.asImageBitmap(),
-                    contentDescription = "PDF Page ${currentPage.value + 1}",
+            if (isLandscape) {
+                // Landscape: fit to height, centered
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    currentBitmap.value?.let { bitmap ->
+                        Image(
+                            bitmap = bitmap.asImageBitmap(),
+                            contentDescription = "PDF Page ${currentPage.intValue + 1}",
+                            modifier = Modifier
+                                .fillMaxHeight()
+                                .background(Color.White),
+                            contentScale = ContentScale.FillHeight
+                        )
+                    }
+                }
+            } else {
+                // Portrait: scrollable, fill width
+                Box(
                     modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(1f)
-                        .background(Color.White),
-                    contentScale = ContentScale.FillWidth
-                )
+                        .fillMaxSize()
+                        .verticalScroll(verticalScrollState)
+                ) {
+                    currentBitmap.value?.let { bitmap ->
+                        Image(
+                            bitmap = bitmap.asImageBitmap(),
+                            contentDescription = "PDF Page ${currentPage.intValue + 1}",
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .background(Color.White),
+                            contentScale = ContentScale.FillWidth
+                        )
+                    }
+                }
             }
         }
 
-        // Top controls - Always visible and clickable
+        // Top controls - Close button and page indicator
         Row(
             modifier = Modifier
                 .align(Alignment.TopStart)
                 .fillMaxWidth()
-                .padding(16.dp),
+                .background(Color.White)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // Close button with explicit click handling
-            Button(
-                onClick = onClose,
-                modifier = Modifier.padding(end = 8.dp)
-            ) {
+            // Close button
+            Button(onClick = onClose) {
                 Text("Close")
             }
 
             // Page indicator
             Text(
-                text = "Page ${currentPage.value + 1} of ${totalPages.value}",
-                style = MaterialTheme.typography.labelMedium,
-                modifier = Modifier.padding(horizontal = 16.dp)
+                text = "Page ${currentPage.intValue + 1} of ${totalPages.intValue}",
+                style = MaterialTheme.typography.labelMedium
             )
         }
 
         // Bottom navigation
-        if (totalPages.value > 1) {
+        if (totalPages.intValue > 1) {
             Row(
                 modifier = Modifier
                     .align(Alignment.BottomCenter)
                     .fillMaxWidth()
-                    .padding(16.dp)
-                    .background(Color.White.copy(alpha = 0.9f)),
+                    .background(Color.White)
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
                 horizontalArrangement = Arrangement.Center,
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Button(
                     onClick = {
-                        if (currentPage.value > 0) {
-                            currentPage.value--
+                        if (currentPage.intValue > 0) {
+                            currentPage.intValue--
                         }
                     },
-                    enabled = currentPage.value > 0
+                    enabled = currentPage.intValue > 0
                 ) {
                     Text("Previous")
                 }
                 Button(
                     onClick = {
-                        if (currentPage.value < totalPages.value - 1) {
-                            currentPage.value++
+                        if (currentPage.intValue < totalPages.intValue - 1) {
+                            currentPage.intValue++
                         }
                     },
-                    enabled = currentPage.value < totalPages.value - 1,
+                    enabled = currentPage.intValue < totalPages.intValue - 1,
                     modifier = Modifier.padding(start = 8.dp)
                 ) {
                     Text("Next")
@@ -184,12 +224,16 @@ fun PdfViewerScreen(
 private fun renderPage(
     pdfRenderer: PdfRenderer,
     pageIndex: Int,
-    currentBitmap: androidx.compose.runtime.MutableState<Bitmap?>
+    currentBitmap: androidx.compose.runtime.MutableState<Bitmap?>,
+    scaleFactor: Float = 3f
 ) {
     try {
         if (pageIndex < pdfRenderer.pageCount) {
             val page = pdfRenderer.openPage(pageIndex)
-            val bitmap = Bitmap.createBitmap(page.width, page.height, Bitmap.Config.ARGB_8888)
+            // Scale up the bitmap for better quality
+            val width = (page.width * scaleFactor).toInt()
+            val height = (page.height * scaleFactor).toInt()
+            val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
             page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
             currentBitmap.value = bitmap
             page.close()
@@ -198,4 +242,3 @@ private fun renderPage(
         e.printStackTrace()
     }
 }
-

--- a/app/src/main/java/com/machikoro/client/ui/start/PdfViewerScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/PdfViewerScreen.kt
@@ -1,20 +1,38 @@
 package com.machikoro.client.ui.start
 
-import android.webkit.WebView
+import android.graphics.Bitmap
+import android.graphics.pdf.PdfRenderer
+import android.os.ParcelFileDescriptor
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.foundation.Image
+import java.io.File
 
 @Composable
 fun PdfViewerScreen(
@@ -22,44 +40,125 @@ fun PdfViewerScreen(
     modifier: Modifier = Modifier,
     onClose: () -> Unit
 ) {
+    val context = LocalContext.current
+    val currentPage = remember { mutableIntStateOf(0) }
+    val totalPages = remember { mutableIntStateOf(0) }
+    val currentBitmap = remember { mutableStateOf<Bitmap?>(null) }
+    val scrollState = rememberScrollState()
+
+    LaunchedEffect(Unit) {
+        try {
+            // Copy PDF from assets to cache
+            val file = File(context.cacheDir, fileName)
+            if (!file.exists()) {
+                context.assets.open(fileName).use { input ->
+                    file.outputStream().use { output ->
+                        input.copyTo(output)
+                    }
+                }
+            }
+
+            // Open PDF with PdfRenderer
+            val fileDescriptor = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
+            val pdfRenderer = PdfRenderer(fileDescriptor)
+            totalPages.value = pdfRenderer.pageCount
+
+            // Render first page
+            if (pdfRenderer.pageCount > 0) {
+                val page = pdfRenderer.openPage(0)
+                val bitmap = Bitmap.createBitmap(page.width, page.height, Bitmap.Config.ARGB_8888)
+                page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+                currentBitmap.value = bitmap
+                page.close()
+            }
+            pdfRenderer.close()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
     Box(
         modifier = modifier
             .fillMaxSize()
             .background(Color.White)
     ) {
-        // PDF Viewer using WebView
-        AndroidView(
-            factory = { ctx ->
-                WebView(ctx).apply {
-                    @Suppress("SetJavaScriptEnabled")
-                    settings.apply {
-                        javaScriptEnabled = true
-                        @Suppress("DeprecatedCall")
-                        mixedContentMode = android.webkit.WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
-                        allowFileAccess = true
-                    }
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+        ) {
+            // PDF content
+            currentBitmap.value?.let { bitmap ->
+                Image(
+                    bitmap = bitmap.asImageBitmap(),
+                    contentDescription = "PDF Page ${currentPage.value + 1}",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color.White),
+                    contentScale = ContentScale.FillWidth
+                )
+            }
+        }
 
-                    // Load PDF directly from assets using file:///android_asset/
-                    // This supports horizontal stretching via WebView's built-in PDF viewer
-                    loadUrl("file:///android_asset/$fileName")
-                }
-            },
-            modifier = Modifier.fillMaxSize()
-        )
-
-        // Close button
-        IconButton(
-            onClick = onClose,
+        // Top controls
+        Row(
             modifier = Modifier
                 .align(Alignment.TopStart)
-                .padding(top = 16.dp, start = 16.dp)
-                .background(Color.White.copy(alpha = 0.8f), shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp))
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            Icon(
-                painter = painterResource(id = android.R.drawable.ic_menu_close_clear_cancel),
-                contentDescription = "Close PDF",
-                tint = MaterialTheme.colorScheme.primary
+            // Close button
+            IconButton(onClick = onClose) {
+                Icon(
+                    painter = painterResource(id = android.R.drawable.ic_menu_close_clear_cancel),
+                    contentDescription = "Close PDF",
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+
+            // Page indicator
+            Text(
+                text = "Page ${currentPage.value + 1} of ${totalPages.value}",
+                style = MaterialTheme.typography.labelMedium,
+                modifier = Modifier.padding(horizontal = 16.dp)
             )
+        }
+
+        // Bottom navigation
+        if (totalPages.value > 1) {
+            Row(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .background(Color.White.copy(alpha = 0.9f)),
+                horizontalArrangement = Arrangement.Center,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Button(
+                    onClick = {
+                        if (currentPage.value > 0) {
+                            currentPage.value--
+                        }
+                    },
+                    enabled = currentPage.value > 0
+                ) {
+                    Text("Previous")
+                }
+                Button(
+                    onClick = {
+                        if (currentPage.value < totalPages.value - 1) {
+                            currentPage.value++
+                        }
+                    },
+                    enabled = currentPage.value < totalPages.value - 1,
+                    modifier = Modifier.padding(start = 8.dp)
+                ) {
+                    Text("Next")
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/machikoro/client/ui/start/PdfViewerScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/PdfViewerScreen.kt
@@ -1,0 +1,83 @@
+package com.machikoro.client.ui.start
+
+import android.content.Context
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.machikoro.client.R
+import com.github.barteksc.pdfviewer.PDFView
+import java.io.File
+
+@Composable
+fun PdfViewerScreen(
+    context: Context,
+    fileName: String = "rules.pdf",
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.White)
+    ) {
+        // PDF Viewer
+        AndroidView(
+            factory = { ctx ->
+                PDFView(ctx, null).apply {
+                    val file = File(ctx.cacheDir, fileName)
+
+                    // Copy from assets if not exists
+                    if (!file.exists()) {
+                        ctx.assets.open(fileName).use { input ->
+                            file.outputStream().use { output ->
+                                input.copyTo(output)
+                            }
+                        }
+                    }
+
+                    fromFile(file)
+                        .enableSwipe(true)
+                        .swipeHorizontal(true)
+                        .enableDoubletap(true)
+                        .defaultPage(0)
+                        .enableAnnotationRendering(false)
+                        .enableAntialiasing(true)
+                        .spacing(0)
+                        .autoSpacing(false)
+                        .pageFitPolicy(com.github.barteksc.pdfviewer.scroll.DefaultScrollHandle.FITTED_TO_WIDTH)
+                        .fitEachPage(false)
+                        .pageSnap(true)
+                        .pageFling(true)
+                        .load()
+                }
+            },
+            modifier = Modifier.fillMaxSize()
+        )
+
+        // Close button
+        IconButton(
+            onClick = onClose,
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(top = 16.dp, start = 16.dp)
+        ) {
+            Icon(
+                painter = painterResource(id = android.R.drawable.ic_menu_close_clear_cancel),
+                contentDescription = "Close PDF",
+                tint = MaterialTheme.colorScheme.primary
+            )
+        }
+    }
+}
+

--- a/app/src/main/java/com/machikoro/client/ui/start/PdfViewerScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/PdfViewerScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -45,7 +46,10 @@ fun PdfViewerScreen(
     val totalPages = remember { mutableIntStateOf(0) }
     val currentBitmap = remember { mutableStateOf<Bitmap?>(null) }
     val scrollState = rememberScrollState()
+    val pdfRendererRef = remember { mutableStateOf<PdfRenderer?>(null) }
+    val fileDescriptorRef = remember { mutableStateOf<ParcelFileDescriptor?>(null) }
 
+    // Initialize PDF and keep renderer open
     LaunchedEffect(Unit) {
         try {
             // Copy PDF from assets to cache
@@ -58,22 +62,34 @@ fun PdfViewerScreen(
                 }
             }
 
-            // Open PDF with PdfRenderer
+            // Open PDF with PdfRenderer and keep it open
             val fileDescriptor = ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY)
             val pdfRenderer = PdfRenderer(fileDescriptor)
+
+            fileDescriptorRef.value = fileDescriptor
+            pdfRendererRef.value = pdfRenderer
             totalPages.value = pdfRenderer.pageCount
 
             // Render first page
-            if (pdfRenderer.pageCount > 0) {
-                val page = pdfRenderer.openPage(0)
-                val bitmap = Bitmap.createBitmap(page.width, page.height, Bitmap.Config.ARGB_8888)
-                page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
-                currentBitmap.value = bitmap
-                page.close()
-            }
-            pdfRenderer.close()
+            renderPage(pdfRenderer, 0, currentBitmap)
         } catch (e: Exception) {
             e.printStackTrace()
+        }
+    }
+
+    // Update bitmap when page changes
+    LaunchedEffect(currentPage.value) {
+        pdfRendererRef.value?.let { renderer ->
+            renderPage(renderer, currentPage.value, currentBitmap)
+        }
+    }
+
+    // Cleanup
+    DisposableEffect(Unit) {
+        onDispose {
+            currentBitmap.value?.recycle()
+            pdfRendererRef.value?.close()
+            fileDescriptorRef.value?.close()
         }
     }
 
@@ -160,6 +176,24 @@ fun PdfViewerScreen(
                 }
             }
         }
+    }
+}
+
+private fun renderPage(
+    pdfRenderer: PdfRenderer,
+    pageIndex: Int,
+    currentBitmap: androidx.compose.runtime.MutableState<Bitmap?>
+) {
+    try {
+        if (pageIndex < pdfRenderer.pageCount) {
+            val page = pdfRenderer.openPage(pageIndex)
+            val bitmap = Bitmap.createBitmap(page.width, page.height, Bitmap.Config.ARGB_8888)
+            page.render(bitmap, null, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+            currentBitmap.value = bitmap
+            page.close()
+        }
+    } catch (e: Exception) {
+        e.printStackTrace()
     }
 }
 

--- a/app/src/main/java/com/machikoro/client/ui/start/RulesHelper.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/RulesHelper.kt
@@ -1,0 +1,40 @@
+package com.machikoro.client.ui.start
+
+import android.content.Context
+import android.content.Intent
+import android.widget.Toast
+import androidx.core.content.FileProvider
+import java.io.File
+
+fun openRulesPdf(context: Context) {
+    try {
+        val fileName = "rules.pdf"
+        val file = File(context.cacheDir, fileName)
+
+        // Copy from assets to cache if not already there
+        if (!file.exists()) {
+            context.assets.open(fileName).use { input ->
+                file.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+        }
+
+        val uri = FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            file
+        )
+
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "application/pdf")
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+
+        context.startActivity(intent)
+    } catch (e: Exception) {
+        Toast.makeText(context, "No PDF viewer app found", Toast.LENGTH_SHORT).show()
+    }
+}
+

--- a/app/src/main/java/com/machikoro/client/ui/start/RulesHelper.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/RulesHelper.kt
@@ -30,6 +30,9 @@ fun openRulesPdf(context: Context) {
             setDataAndType(uri, "application/pdf")
             addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            // Enable fit to width for better horizontal viewing
+            putExtra("fit_to_page", true)
+            putExtra("page_numbers", true)
         }
 
         context.startActivity(intent)

--- a/app/src/main/java/com/machikoro/client/ui/start/RulesHelper.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/RulesHelper.kt
@@ -33,9 +33,24 @@ fun openRulesPdf(context: Context) {
             // Enable fit to width for better horizontal viewing
             putExtra("fit_to_page", true)
             putExtra("page_numbers", true)
+            putExtra("fit_to_width", true)
+            putExtra("fit_to_height", false)
+            // Google PDF Viewer
+            putExtra("com.google.android.gms.cast.EXTRA_CAST_ENABLED", false)
+            // Adobe Reader
+            putExtra("PREF_FIT_CONTENT", "FIT_TO_WIDTH")
         }
 
-        context.startActivity(intent)
+        try {
+            context.startActivity(intent)
+        } catch (e: Exception) {
+            // If specific PDF viewer fails, try generic approach
+            val fallbackIntent = Intent(Intent.ACTION_VIEW).apply {
+                setDataAndType(uri, "application/pdf")
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            }
+            context.startActivity(fallbackIntent)
+        }
     } catch (e: Exception) {
         Toast.makeText(context, "No PDF viewer app found", Toast.LENGTH_SHORT).show()
     }

--- a/app/src/main/java/com/machikoro/client/ui/start/StartScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/StartScreen.kt
@@ -38,7 +38,6 @@ fun StartScreen(
 
     if (showPdfViewer.value) {
         PdfViewerScreen(
-            context = context,
             onClose = { showPdfViewer.value = false }
         )
     } else {

--- a/app/src/main/java/com/machikoro/client/ui/start/StartScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/StartScreen.kt
@@ -6,13 +6,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.IconButton
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -59,16 +61,20 @@ fun StartScreen(
 
         // Rules button in top-right corner
         val context = LocalContext.current
-        IconButton(
+        Button(
             onClick = { openRulesPdf(context) },
             modifier = Modifier
                 .align(Alignment.TopEnd)
-                .padding(top = 16.dp, end = 16.dp)
-                .size(48.dp)
+                .padding(top = 16.dp, end = 16.dp),
+            shape = RoundedCornerShape(8.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color(0xFF64B5F6)
+            )
         ) {
-            Image(
-                painter = painterResource(id = R.drawable.main_rules_icon),
-                contentDescription = "Game Rules"
+            Text(
+                text = "Rules",
+                color = Color.Black,
+                style = MaterialTheme.typography.labelLarge
             )
         }
 

--- a/app/src/main/java/com/machikoro/client/ui/start/StartScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/StartScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -31,70 +33,79 @@ fun StartScreen(
     state: StartScreenState,
     modifier: Modifier = Modifier
 ) {
-    Box(
-        modifier = modifier
-            .fillMaxSize()
-    ) {
-        // Background image on the bottom left
-        Image(
-            painter = painterResource(id = R.drawable.background_left),
-            contentDescription = null,
-            modifier = Modifier.align(Alignment.BottomStart).offset(x = -20.dp, y = 30.dp) // optional
+    val context = LocalContext.current
+    val showPdfViewer = remember { mutableStateOf(false) }
+
+    if (showPdfViewer.value) {
+        PdfViewerScreen(
+            context = context,
+            onClose = { showPdfViewer.value = false }
         )
-
-        // Background image on the bottom right
-        Image(
-            painter = painterResource(id = R.drawable.background_right),
-            contentDescription = null,
-            modifier = Modifier.align(Alignment.BottomEnd).offset(x = 15.dp, y = 30.dp) // optional
-        )
-
-        // Title centered at the top
-        Text(
-            text = "MACHI KORO",
-            style = MaterialTheme.typography.headlineLarge,
-            color = MaterialTheme.colorScheme.secondary,
-            modifier = Modifier
-                .align(Alignment.TopCenter)
-                .padding(top = 55.dp)
-        )
-
-        // Rules button in top-right corner
-        val context = LocalContext.current
-        Button(
-            onClick = { openRulesPdf(context) },
-            modifier = Modifier
-                .align(Alignment.TopEnd)
-                .padding(top = 16.dp, end = 16.dp),
-            shape = RoundedCornerShape(8.dp),
-            colors = ButtonDefaults.buttonColors(
-                containerColor = Color(0xFF64B5F6)
-            )
-        ) {
-            Text(
-                text = "Rules",
-                color = Color.Black,
-                style = MaterialTheme.typography.labelLarge
-            )
-        }
-
-        // Remaining UI content
-        Column(
-            modifier = Modifier
+    } else {
+        Box(
+            modifier = modifier
                 .fillMaxSize()
-                .padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
+            // ...existing code...
+            Image(
+                painter = painterResource(id = R.drawable.background_left),
+                contentDescription = null,
+                modifier = Modifier.align(Alignment.BottomStart).offset(x = -20.dp, y = 30.dp) // optional
+            )
 
-            Text(
-                text = "Connection status: ${state.connectionStatus.toDisplayText()}",
-                style = MaterialTheme.typography.bodyLarge
+            // ...existing code...
+            Image(
+                painter = painterResource(id = R.drawable.background_right),
+                contentDescription = null,
+                modifier = Modifier.align(Alignment.BottomEnd).offset(x = 15.dp, y = 30.dp) // optional
             )
+
+            // ...existing code...
             Text(
-                text = "Lobby/start: ${state.lobbyStatus.toDisplayText()}",
-                style = MaterialTheme.typography.bodyMedium, // test
-                color = MaterialTheme.colorScheme.primary // test
+                text = "MACHI KORO",
+                style = MaterialTheme.typography.headlineLarge,
+                color = MaterialTheme.colorScheme.secondary,
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = 55.dp)
             )
+
+            // ...existing code...
+            Button(
+                onClick = { showPdfViewer.value = true },
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 16.dp, end = 16.dp),
+                shape = RoundedCornerShape(8.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF64B5F6)
+                )
+            ) {
+                Text(
+                    text = "Rules",
+                    color = Color.Black,
+                    style = MaterialTheme.typography.labelLarge
+                )
+            }
+
+            // ...existing code...
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(24.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+
+                Text(
+                    text = "Connection status: ${state.connectionStatus.toDisplayText()}",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                Text(
+                    text = "Lobby/start: ${state.lobbyStatus.toDisplayText()}",
+                    style = MaterialTheme.typography.bodyMedium, // test
+                    color = MaterialTheme.colorScheme.primary // test
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/machikoro/client/ui/start/StartScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/StartScreen.kt
@@ -6,11 +6,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -53,6 +56,21 @@ fun StartScreen(
                 .align(Alignment.TopCenter)
                 .padding(top = 55.dp)
         )
+
+        // Rules button in top-right corner
+        val context = LocalContext.current
+        IconButton(
+            onClick = { openRulesPdf(context) },
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .padding(top = 16.dp, end = 16.dp)
+                .size(48.dp)
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.main_rules_icon),
+                contentDescription = "Game Rules"
+            )
+        }
 
         // Remaining UI content
         Column(

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="pdf_cache" path="/" />
+</paths>
+


### PR DESCRIPTION
This pull request introduces a new in-app PDF viewer for displaying the game rules and adds support for securely sharing the rules PDF file with external PDF viewer apps. The changes include a new `PdfViewerScreen` composable, integration of the viewer into the start screen via a "Rules" button, and the necessary Android manifest and resource updates to enable file sharing using `FileProvider`.

**New PDF Viewing Functionality:**

* Added `PdfViewerScreen` composable for displaying a PDF (rules.pdf) within the app, supporting page navigation and orientation changes.
* Integrated a "Rules" button into the `StartScreen` that opens the in-app PDF viewer when clicked.

**External PDF Sharing Support:**

* Added `openRulesPdf` helper in `RulesHelper.kt` to open the rules PDF in external apps using a secure `FileProvider` URI.
* Updated `AndroidManifest.xml` to declare a `FileProvider` for secure file sharing, referencing a new `file_paths.xml` resource.
* Added `file_paths.xml` to configure `FileProvider` to allow sharing files from the app's cache directory.

**Build Configuration:**

* Enabled code minification for release builds to improve APK size and security.