### PR TITLE
feat(#32): add GameScreenState data class for game screen UI state

### DIFF
--- a/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
@@ -1,0 +1,15 @@
+package com.machikoro.client.domain.model.state
+
+import com.machikoro.client.domain.enums.GamePhase
+
+data class GameScreenState(
+    val gamePhase: GamePhase,
+    val connectionStatus: ConnectionStatus
+) {
+    companion object {
+        fun initial() = GameScreenState(
+            gamePhase = GamePhase.NONE,
+            connectionStatus = ConnectionStatus.IDLE
+        )
+    }
+}

--- a/app/src/test/java/com/machikoro/client/domain/model/state/GameScreenStateTest.kt
+++ b/app/src/test/java/com/machikoro/client/domain/model/state/GameScreenStateTest.kt
@@ -1,0 +1,15 @@
+package com.machikoro.client.domain.model.state
+
+import com.machikoro.client.domain.enums.GamePhase
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GameScreenStateTest {
+    @Test
+    fun initialUsesNoneGamePhaseAndIdleConnectionStatus() {
+        val state = GameScreenState.initial()
+
+        assertEquals(GamePhase.NONE, state.gamePhase)
+        assertEquals(ConnectionStatus.IDLE, state.connectionStatus)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `GameScreenState` data class in `domain/model/state/` bundling `gamePhase` and `connectionStatus` for the upcoming game screen.
- Adds an `initial()` factory returning `GamePhase.NONE` / `ConnectionStatus.IDLE`, following the `StartScreenState.placeholder()` pattern.
- Adds `GameScreenStateTest` covering the `initial()` factory.

Closes #32. Sub-issue of #17. Builds on #74.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest --tests "com.machikoro.client.domain.model.state.GameScreenStateTest"` passes
- [x] Verify on CI