### PR TITLE
feat(#33): expose game phase from WebSocket client and parse GAME_ACTION messages

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     implementation(libs.okhttp)
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.json)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -1,6 +1,7 @@
 package com.machikoro.client.network.websocket
 
 import android.util.Log
+import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import java.net.URI
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -10,6 +11,8 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
+import org.json.JSONException
+import org.json.JSONObject
 
 class OkHttpWebSocketClient(
     private val websocketUrl: String,
@@ -18,7 +21,11 @@ class OkHttpWebSocketClient(
     override val connectionStatus: StateFlow<ConnectionStatus>
         get() = mutableConnectionStatus.asStateFlow()
 
+    override val gamePhase: StateFlow<GamePhase>
+        get() = mutableGamePhase.asStateFlow()
+
     private val mutableConnectionStatus = MutableStateFlow(ConnectionStatus.IDLE)
+    private val mutableGamePhase = MutableStateFlow(GamePhase.NONE)
     private val frameBuffer = StringBuilder()
 
     @Volatile
@@ -58,6 +65,7 @@ class OkHttpWebSocketClient(
         currentSocket?.close(NORMAL_CLOSURE_STATUS, "Client disconnect")
         Log.d(TAG, "Disconnect requested by client")
         mutableConnectionStatus.value = ConnectionStatus.DISCONNECTED
+        mutableGamePhase.value = GamePhase.NONE
     }
 
     private val listener = object : WebSocketListener() {
@@ -87,12 +95,14 @@ class OkHttpWebSocketClient(
             webSocket.close(code, reason)
             clearSocket()
             mutableConnectionStatus.value = ConnectionStatus.DISCONNECTED
+            mutableGamePhase.value = GamePhase.NONE
         }
 
         override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
             Log.d(TAG, "WebSocket closed: $code / $reason")
             clearSocket()
             mutableConnectionStatus.value = ConnectionStatus.DISCONNECTED
+            mutableGamePhase.value = GamePhase.NONE
         }
 
         override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
@@ -104,6 +114,7 @@ class OkHttpWebSocketClient(
             )
             clearSocket()
             mutableConnectionStatus.value = ConnectionStatus.ERROR
+            mutableGamePhase.value = GamePhase.NONE
         }
     }
 
@@ -116,13 +127,30 @@ class OkHttpWebSocketClient(
                 sendJoinMessage()
             }
 
-            "MESSAGE" -> Log.d(TAG, "STOMP message received: ${frame.body}")
+            "MESSAGE" -> {
+                Log.d(TAG, "STOMP message received: ${frame.body}")
+                parseGameActionPhase(frame.body)?.let { mutableGamePhase.value = it }
+            }
 
             "ERROR" -> {
                 Log.e(TAG, "STOMP error frame received: ${frame.body}")
                 mutableConnectionStatus.value = ConnectionStatus.ERROR
             }
         }
+    }
+
+    private fun parseGameActionPhase(body: String): GamePhase? {
+        if (body.isBlank()) return null
+        val json = try {
+            JSONObject(body)
+        } catch (e: JSONException) {
+            Log.w(TAG, "Failed to parse MESSAGE frame as JSON: ${e.message}")
+            return null
+        }
+        if (json.optString("type") != GAME_ACTION_TYPE) return null
+        val payload = json.optJSONObject("payload") ?: return null
+        val phaseName = payload.optString("turnPhase").takeIf { it.isNotEmpty() } ?: return null
+        return runCatching { GamePhase.valueOf(phaseName) }.getOrNull()
     }
 
     private fun subscribeToPublicTopic() {
@@ -174,5 +202,6 @@ class OkHttpWebSocketClient(
     companion object {
         private const val NORMAL_CLOSURE_STATUS = 1000
         private const val TAG = "OkHttpWebSocketClient"
+        private const val GAME_ACTION_TYPE = "GAME_ACTION"
     }
 }

--- a/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
@@ -1,10 +1,13 @@
 package com.machikoro.client.network.websocket
 
+import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import kotlinx.coroutines.flow.StateFlow
 
 interface WebSocketClient {
     val connectionStatus: StateFlow<ConnectionStatus>
+
+    val gamePhase: StateFlow<GamePhase>
 
     fun connect()
 

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -1,5 +1,6 @@
 package com.machikoro.client.network.websocket
 
+import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import java.io.IOException
 import okhttp3.Protocol
@@ -157,6 +158,234 @@ class OkHttpWebSocketClientTest {
 
         assertEquals(ConnectionStatus.ERROR, client.connectionStatus.value)
     }
+
+    @Test
+    fun gamePhaseStartsAsNone() {
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "ws://10.0.2.2:8080/ws",
+            webSocketFactory = FakeWebSocketFactory()
+        )
+
+        assertEquals(GamePhase.NONE, client.gamePhase.value)
+    }
+
+    @Test
+    fun gameActionMessageUpdatesGamePhase() {
+        val factory = FakeWebSocketFactory()
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "ws://10.0.2.2:8080/ws",
+            webSocketFactory = factory
+        )
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
+        factory.simulateText(
+            gameActionFrame("""{"type":"GAME_ACTION","sender":"server","payload":{"turnPhase":"ROLL_DICE"}}""")
+        )
+
+        assertEquals(GamePhase.ROLL_DICE, client.gamePhase.value)
+    }
+
+    @Test
+    fun gameActionMessagesAdvanceThroughAllPhases() {
+        val factory = FakeWebSocketFactory()
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "ws://10.0.2.2:8080/ws",
+            webSocketFactory = factory
+        )
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
+
+        listOf(
+            GamePhase.ROLL_DICE,
+            GamePhase.RESOLVE_EFFECTS,
+            GamePhase.BUY_OR_BUILD,
+            GamePhase.END_TURN
+        ).forEach { phase ->
+            factory.simulateText(
+                gameActionFrame("""{"type":"GAME_ACTION","payload":{"turnPhase":"${phase.name}"}}""")
+            )
+            assertEquals(phase, client.gamePhase.value)
+        }
+    }
+
+    @Test
+    fun nonGameActionMessageDoesNotChangeGamePhase() {
+        val factory = FakeWebSocketFactory()
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "ws://10.0.2.2:8080/ws",
+            webSocketFactory = factory
+        )
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
+        factory.simulateText(
+            gameActionFrame("""{"type":"CHAT","sender":"someone","content":"hello"}""")
+        )
+
+        assertEquals(GamePhase.NONE, client.gamePhase.value)
+    }
+
+    @Test
+    fun malformedJsonMessageDoesNotCrashAndLeavesGamePhaseUnchanged() {
+        val factory = FakeWebSocketFactory()
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "ws://10.0.2.2:8080/ws",
+            webSocketFactory = factory
+        )
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
+        factory.simulateText(gameActionFrame("not even json"))
+
+        assertEquals(GamePhase.NONE, client.gamePhase.value)
+    }
+
+    @Test
+    fun gameActionWithoutPayloadLeavesGamePhaseUnchanged() {
+        val factory = FakeWebSocketFactory()
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "ws://10.0.2.2:8080/ws",
+            webSocketFactory = factory
+        )
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
+        factory.simulateText(
+            gameActionFrame("""{"type":"GAME_ACTION","sender":"server"}""")
+        )
+
+        assertEquals(GamePhase.NONE, client.gamePhase.value)
+    }
+
+    @Test
+    fun gameActionWithUnknownTurnPhaseLeavesGamePhaseUnchanged() {
+        val factory = FakeWebSocketFactory()
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "ws://10.0.2.2:8080/ws",
+            webSocketFactory = factory
+        )
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
+        factory.simulateText(
+            gameActionFrame("""{"type":"GAME_ACTION","payload":{"turnPhase":"NOT_A_PHASE"}}""")
+        )
+
+        assertEquals(GamePhase.NONE, client.gamePhase.value)
+    }
+
+    @Test
+    fun gameActionWithMissingTurnPhaseLeavesGamePhaseUnchanged() {
+        val factory = FakeWebSocketFactory()
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "ws://10.0.2.2:8080/ws",
+            webSocketFactory = factory
+        )
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
+        factory.simulateText(
+            gameActionFrame("""{"type":"GAME_ACTION","payload":{"other":"value"}}""")
+        )
+
+        assertEquals(GamePhase.NONE, client.gamePhase.value)
+    }
+
+    @Test
+    fun disconnectResetsGamePhaseToNone() {
+        val factory = FakeWebSocketFactory()
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "ws://10.0.2.2:8080/ws",
+            webSocketFactory = factory
+        )
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
+        factory.simulateText(
+            gameActionFrame("""{"type":"GAME_ACTION","payload":{"turnPhase":"BUY_OR_BUILD"}}""")
+        )
+        assertEquals(GamePhase.BUY_OR_BUILD, client.gamePhase.value)
+
+        client.disconnect()
+
+        assertEquals(GamePhase.NONE, client.gamePhase.value)
+    }
+
+    @Test
+    fun closingResetsGamePhaseToNone() {
+        val factory = FakeWebSocketFactory()
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "ws://10.0.2.2:8080/ws",
+            webSocketFactory = factory
+        )
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
+        factory.simulateText(
+            gameActionFrame("""{"type":"GAME_ACTION","payload":{"turnPhase":"RESOLVE_EFFECTS"}}""")
+        )
+        assertEquals(GamePhase.RESOLVE_EFFECTS, client.gamePhase.value)
+
+        factory.simulateClosing()
+
+        assertEquals(GamePhase.NONE, client.gamePhase.value)
+    }
+
+    @Test
+    fun closedResetsGamePhaseToNone() {
+        val factory = FakeWebSocketFactory()
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "ws://10.0.2.2:8080/ws",
+            webSocketFactory = factory
+        )
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
+        factory.simulateText(
+            gameActionFrame("""{"type":"GAME_ACTION","payload":{"turnPhase":"END_TURN"}}""")
+        )
+        assertEquals(GamePhase.END_TURN, client.gamePhase.value)
+
+        factory.simulateClosed()
+
+        assertEquals(GamePhase.NONE, client.gamePhase.value)
+    }
+
+    @Test
+    fun failureResetsGamePhaseToNone() {
+        val factory = FakeWebSocketFactory()
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "ws://10.0.2.2:8080/ws",
+            webSocketFactory = factory
+        )
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
+        factory.simulateText(
+            gameActionFrame("""{"type":"GAME_ACTION","payload":{"turnPhase":"ROLL_DICE"}}""")
+        )
+        assertEquals(GamePhase.ROLL_DICE, client.gamePhase.value)
+
+        factory.simulateFailure(IOException("boom"))
+
+        assertEquals(GamePhase.NONE, client.gamePhase.value)
+    }
+
+    private fun gameActionFrame(body: String): String =
+        "MESSAGE\ndestination:/topic/public\ncontent-type:application/json\n\n$body\u0000"
 
     private class FakeWebSocketFactory : WebSocketFactory {
         lateinit var listener: WebSocketListener

--- a/app/src/test/java/com/machikoro/client/ui/start/StartScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/start/StartScreenViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.machikoro.client.ui.start
 
+import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.network.websocket.WebSocketClient
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -48,7 +49,11 @@ class StartScreenViewModelTest {
         override val connectionStatus: StateFlow<ConnectionStatus>
             get() = mutableConnectionStatus
 
+        override val gamePhase: StateFlow<GamePhase>
+            get() = mutableGamePhase
+
         private val mutableConnectionStatus = MutableStateFlow(ConnectionStatus.IDLE)
+        private val mutableGamePhase = MutableStateFlow(GamePhase.NONE)
 
         override fun connect() = Unit
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ kotlin = "2.2.10"
 composeBom = "2024.09.00"
 okhttp = "4.12.0"
 coroutinesTest = "1.8.1"
+json = "20231013"
 material3 = "1.4.0"
 composeMaterial3 = "1.6.0"
 
@@ -32,6 +33,7 @@ androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-te
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
+json = { group = "org.json", name = "json", version.ref = "json" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Adds `gamePhase: StateFlow<GamePhase>` to the `WebSocketClient` interface.
- `OkHttpWebSocketClient` parses STOMP `MESSAGE` frame bodies with `org.json.JSONObject`, detects `type == "GAME_ACTION"`, and extracts `turnPhase` from the payload (maps to `GamePhase` via `valueOf`).
- Unknown phase names and malformed JSON are ignored without changing state.
- Resets phase to `GamePhase.NONE` on `disconnect()`, `onClosing`, `onClosed`, and `onFailure`.
- Adds `org.json:json` as a `testImplementation` so JVM unit tests can use `JSONObject` (Android's platform version is a stub at local unit-test runtime).

Closes #33. Sub-issue of #17. Builds on #74 and #75.

## Test plan
- [x] `./gradlew :app:testDebugUnitTest` passes (22 `OkHttpWebSocketClientTest` cases: initial state, valid parse, all four phases advance, non-GAME_ACTION ignored, malformed JSON ignored, missing/unknown `turnPhase` ignored, reset-to-NONE on disconnect/closing/closed/failure)
- [x] `./gradlew :app:lintDebug` passes (0 errors)
- [x] `./gradlew :app:jacocoTestCoverageVerification` passes (≥80% per-class)
- [x] `./gradlew :app:assembleDebug` builds
- [x] Verify on CI