### PR TITLE
feat(#34): add GameScreenViewModel collecting connection and game phase

### DIFF
--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
@@ -1,0 +1,50 @@
+package com.machikoro.client.ui.game
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.machikoro.client.domain.model.state.GameScreenState
+import com.machikoro.client.network.websocket.WebSocketClient
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class GameScreenViewModel(
+    private val webSocketClient: WebSocketClient
+) : ViewModel() {
+    val state: StateFlow<GameScreenState>
+        get() = mutableState.asStateFlow()
+
+    private val mutableState = MutableStateFlow(GameScreenState.initial())
+
+    init {
+        viewModelScope.launch {
+            webSocketClient.connectionStatus.collect { connectionStatus ->
+                mutableState.update { current ->
+                    current.copy(connectionStatus = connectionStatus)
+                }
+            }
+        }
+        viewModelScope.launch {
+            webSocketClient.gamePhase.collect { gamePhase ->
+                mutableState.update { current ->
+                    current.copy(gamePhase = gamePhase)
+                }
+            }
+        }
+    }
+
+    class Factory(
+        private val webSocketClient: WebSocketClient
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            require(modelClass.isAssignableFrom(GameScreenViewModel::class.java)) {
+                "Unknown ViewModel class: ${modelClass.name}"
+            }
+            return GameScreenViewModel(webSocketClient) as T
+        }
+    }
+}

--- a/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
@@ -1,0 +1,116 @@
+package com.machikoro.client.ui.game
+
+import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.model.state.ConnectionStatus
+import com.machikoro.client.network.websocket.WebSocketClient
+import com.machikoro.client.ui.start.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GameScreenViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun initialStateUsesInitialValues() = runTest {
+        val viewModel = GameScreenViewModel(FakeWebSocketClient())
+
+        advanceUntilIdle()
+
+        assertEquals(GamePhase.NONE, viewModel.state.value.gamePhase)
+        assertEquals(ConnectionStatus.IDLE, viewModel.state.value.connectionStatus)
+    }
+
+    @Test
+    fun connectionStatusUpdatesAreReflectedInState() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = GameScreenViewModel(fakeClient)
+
+        fakeClient.emitConnectionStatus(ConnectionStatus.CONNECTING)
+        advanceUntilIdle()
+        assertEquals(ConnectionStatus.CONNECTING, viewModel.state.value.connectionStatus)
+
+        fakeClient.emitConnectionStatus(ConnectionStatus.CONNECTED)
+        advanceUntilIdle()
+        assertEquals(ConnectionStatus.CONNECTED, viewModel.state.value.connectionStatus)
+
+        fakeClient.emitConnectionStatus(ConnectionStatus.ERROR)
+        advanceUntilIdle()
+        assertEquals(ConnectionStatus.ERROR, viewModel.state.value.connectionStatus)
+    }
+
+    @Test
+    fun gamePhaseUpdatesAreReflectedInState() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = GameScreenViewModel(fakeClient)
+
+        fakeClient.emitGamePhase(GamePhase.ROLL_DICE)
+        advanceUntilIdle()
+        assertEquals(GamePhase.ROLL_DICE, viewModel.state.value.gamePhase)
+
+        fakeClient.emitGamePhase(GamePhase.RESOLVE_EFFECTS)
+        advanceUntilIdle()
+        assertEquals(GamePhase.RESOLVE_EFFECTS, viewModel.state.value.gamePhase)
+
+        fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
+        advanceUntilIdle()
+        assertEquals(GamePhase.BUY_OR_BUILD, viewModel.state.value.gamePhase)
+
+        fakeClient.emitGamePhase(GamePhase.END_TURN)
+        advanceUntilIdle()
+        assertEquals(GamePhase.END_TURN, viewModel.state.value.gamePhase)
+    }
+
+    @Test
+    fun connectionStatusAndGamePhaseUpdateIndependently() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = GameScreenViewModel(fakeClient)
+
+        fakeClient.emitConnectionStatus(ConnectionStatus.CONNECTED)
+        fakeClient.emitGamePhase(GamePhase.ROLL_DICE)
+        advanceUntilIdle()
+
+        assertEquals(ConnectionStatus.CONNECTED, viewModel.state.value.connectionStatus)
+        assertEquals(GamePhase.ROLL_DICE, viewModel.state.value.gamePhase)
+
+        fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
+        advanceUntilIdle()
+        assertEquals(ConnectionStatus.CONNECTED, viewModel.state.value.connectionStatus)
+        assertEquals(GamePhase.BUY_OR_BUILD, viewModel.state.value.gamePhase)
+
+        fakeClient.emitConnectionStatus(ConnectionStatus.DISCONNECTED)
+        advanceUntilIdle()
+        assertEquals(ConnectionStatus.DISCONNECTED, viewModel.state.value.connectionStatus)
+        assertEquals(GamePhase.BUY_OR_BUILD, viewModel.state.value.gamePhase)
+    }
+
+    private class FakeWebSocketClient : WebSocketClient {
+        override val connectionStatus: StateFlow<ConnectionStatus>
+            get() = mutableConnectionStatus
+
+        override val gamePhase: StateFlow<GamePhase>
+            get() = mutableGamePhase
+
+        private val mutableConnectionStatus = MutableStateFlow(ConnectionStatus.IDLE)
+        private val mutableGamePhase = MutableStateFlow(GamePhase.NONE)
+
+        override fun connect() = Unit
+
+        override fun disconnect() = Unit
+
+        fun emitConnectionStatus(status: ConnectionStatus) {
+            mutableConnectionStatus.value = status
+        }
+
+        fun emitGamePhase(phase: GamePhase) {
+            mutableGamePhase.value = phase
+        }
+    }
+}


### PR DESCRIPTION
Closes #34
Sub-issue of #17
Builds on #76 (exposes `gamePhase` from `WebSocketClient`)

## Summary
- Add `GameScreenViewModel` that collects `connectionStatus` and `gamePhase` flows from `WebSocketClient` into a combined `GameScreenState`.
- Mirrors the existing `StartScreenViewModel` pattern: `MutableStateFlow` + `asStateFlow()` exposure, `viewModelScope.launch` per source flow with `update { copy(...) }`, nested `Factory` for `ViewModelProvider.Factory`.
- No `MainActivity` wiring and no Compose screen — scope is limited to the ViewModel, in line with how #33 exposed the `gamePhase` flow without rendering it.

## Test plan
- [x] `./gradlew testDebugUnitTest` — new `GameScreenViewModelTest` has 4 tests, all pass (initial state, connection updates, phase updates, independent progression).
- [x] `./gradlew jacocoTestCoverageVerification` — 80% per-class gate still satisfied.
- [x] `./gradlew lintDebug` — 0 errors; pre-existing warnings only, none touching `ui/game`.