### PR TITLE
37 implement coin display and state updates

### DIFF
--- a/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
@@ -4,12 +4,14 @@ import com.machikoro.client.domain.enums.GamePhase
 
 data class GameScreenState(
     val gamePhase: GamePhase,
-    val connectionStatus: ConnectionStatus
+    val connectionStatus: ConnectionStatus,
+    val players: List<PlayerCoinState>
 ) {
     companion object {
         fun initial() = GameScreenState(
             gamePhase = GamePhase.NONE,
-            connectionStatus = ConnectionStatus.IDLE
+            connectionStatus = ConnectionStatus.IDLE,
+            players = emptyList()
         )
     }
 }

--- a/app/src/main/java/com/machikoro/client/domain/model/state/PlayerCoinState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/PlayerCoinState.kt
@@ -1,0 +1,9 @@
+package com.machikoro.client.domain.model.state
+
+data class PlayerCoinState(
+    val id: String,
+    val displayName: String,
+    val coins: Int,
+    val isCurrentPlayer: Boolean = false,
+    val isActivePlayer: Boolean = false
+)

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -3,6 +3,7 @@ package com.machikoro.client.network.websocket
 import android.util.Log
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
+import com.machikoro.client.domain.model.state.PlayerCoinState
 import java.net.URI
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -24,8 +25,12 @@ class OkHttpWebSocketClient(
     override val gamePhase: StateFlow<GamePhase>
         get() = mutableGamePhase.asStateFlow()
 
+    override val players: StateFlow<List<PlayerCoinState>>
+        get() = mutablePlayers.asStateFlow()
+
     private val mutableConnectionStatus = MutableStateFlow(ConnectionStatus.IDLE)
     private val mutableGamePhase = MutableStateFlow(GamePhase.NONE)
+    private val mutablePlayers = MutableStateFlow<List<PlayerCoinState>>(emptyList())
     private val frameBuffer = StringBuilder()
 
     @Volatile
@@ -65,7 +70,7 @@ class OkHttpWebSocketClient(
         currentSocket?.close(NORMAL_CLOSURE_STATUS, "Client disconnect")
         Log.d(TAG, "Disconnect requested by client")
         mutableConnectionStatus.value = ConnectionStatus.DISCONNECTED
-        mutableGamePhase.value = GamePhase.NONE
+        resetGameState()
     }
 
     private val listener = object : WebSocketListener() {
@@ -95,14 +100,14 @@ class OkHttpWebSocketClient(
             webSocket.close(code, reason)
             clearSocket()
             mutableConnectionStatus.value = ConnectionStatus.DISCONNECTED
-            mutableGamePhase.value = GamePhase.NONE
+            resetGameState()
         }
 
         override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
             Log.d(TAG, "WebSocket closed: $code / $reason")
             clearSocket()
             mutableConnectionStatus.value = ConnectionStatus.DISCONNECTED
-            mutableGamePhase.value = GamePhase.NONE
+            resetGameState()
         }
 
         override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
@@ -114,7 +119,7 @@ class OkHttpWebSocketClient(
             )
             clearSocket()
             mutableConnectionStatus.value = ConnectionStatus.ERROR
-            mutableGamePhase.value = GamePhase.NONE
+            resetGameState()
         }
     }
 
@@ -182,6 +187,12 @@ class OkHttpWebSocketClient(
         synchronized(this) {
             webSocket = null
         }
+    }
+
+    private fun resetGameState() {
+        mutableGamePhase.value = GamePhase.NONE
+        // Keep #37 coin display clean after game end/disconnect until #45 reset flow owns this state.
+        mutablePlayers.value = emptyList()
     }
 
     private fun websocketHostHeader(): String {

--- a/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
@@ -2,12 +2,16 @@ package com.machikoro.client.network.websocket
 
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
+import com.machikoro.client.domain.model.state.PlayerCoinState
 import kotlinx.coroutines.flow.StateFlow
 
 interface WebSocketClient {
     val connectionStatus: StateFlow<ConnectionStatus>
 
     val gamePhase: StateFlow<GamePhase>
+
+    // Backend coin payload is still pending; expose the UI-ready state now for #37.
+    val players: StateFlow<List<PlayerCoinState>>
 
     fun connect()
 

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -3,9 +3,18 @@ package com.machikoro.client.ui.game
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -14,12 +23,16 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.GameScreenState
+import com.machikoro.client.domain.model.state.PlayerCoinState
 import com.machikoro.client.domain.model.state.toDisplayText
 import com.machikoro.client.ui.theme.ClientTheme
 
@@ -31,14 +44,121 @@ fun GameScreen(
     modifier: Modifier = Modifier
 ) {
     Box(modifier = modifier.fillMaxSize()) {
+        CoinDisplay(
+            players = state.players,
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .statusBarsPadding()
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+        )
+
         if (state.gamePhase != GamePhase.NONE) {
             GamePhaseBanner(
                 phase = state.gamePhase,
-                modifier = Modifier.align(Alignment.TopCenter)
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = coinDisplayTopPadding(state.players))
             )
         }
     }
 }
+
+@Composable
+private fun CoinDisplay(
+    players: List<PlayerCoinState>,
+    modifier: Modifier = Modifier
+) {
+    if (players.isEmpty()) {
+        return
+    }
+
+    LazyRow(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        items(
+            items = players,
+            key = { it.id }
+        ) { player ->
+            PlayerCoinBadge(
+                player = player,
+                modifier = Modifier.padding(end = 8.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlayerCoinBadge(
+    player: PlayerCoinState,
+    modifier: Modifier = Modifier
+) {
+    val containerColor = when {
+        player.isCurrentPlayer -> MaterialTheme.colorScheme.primary
+        player.isActivePlayer -> MaterialTheme.colorScheme.tertiary
+        else -> MaterialTheme.colorScheme.surfaceVariant
+    }
+    val contentColor = when {
+        player.isCurrentPlayer -> MaterialTheme.colorScheme.onPrimary
+        player.isActivePlayer -> MaterialTheme.colorScheme.onTertiary
+        else -> MaterialTheme.colorScheme.onSurfaceVariant
+    }
+
+    Surface(
+        color = containerColor,
+        contentColor = contentColor,
+        shape = RoundedCornerShape(8.dp),
+        tonalElevation = 3.dp,
+        modifier = modifier
+            .widthIn(min = 118.dp, max = 180.dp)
+            .semantics {
+                contentDescription = "${player.displayName}: ${player.coins} coins"
+            }
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
+        ) {
+            CoinIcon(
+                modifier = Modifier.padding(end = 8.dp)
+            )
+            Column {
+                Text(
+                    text = player.displayName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1
+                )
+                Text(
+                    text = "${player.coins} coins",
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CoinIcon(modifier: Modifier = Modifier) {
+    Surface(
+        shape = CircleShape,
+        color = Color(0xFFFFD54F),
+        contentColor = Color(0xFF5D4100),
+        modifier = modifier.size(28.dp)
+    ) {
+        Text(
+            text = "\$",
+            style = MaterialTheme.typography.bodyLarge,
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 3.dp)
+        )
+    }
+}
+
+private fun coinDisplayTopPadding(players: List<PlayerCoinState>) = if (players.isEmpty()) 0.dp else 68.dp
 
 @Composable
 private fun GamePhaseBanner(
@@ -82,7 +202,8 @@ private fun GameScreenRollDicePreview() {
         GameScreen(
             state = GameScreenState(
                 gamePhase = GamePhase.ROLL_DICE,
-                connectionStatus = ConnectionStatus.CONNECTED
+                connectionStatus = ConnectionStatus.CONNECTED,
+                players = previewPlayers()
             )
         )
     }
@@ -95,7 +216,8 @@ private fun GameScreenBuyOrBuildPreview() {
         GameScreen(
             state = GameScreenState(
                 gamePhase = GamePhase.BUY_OR_BUILD,
-                connectionStatus = ConnectionStatus.CONNECTED
+                connectionStatus = ConnectionStatus.CONNECTED,
+                players = previewPlayers()
             )
         )
     }
@@ -108,3 +230,23 @@ private fun GameScreenNonePreview() {
         GameScreen(state = GameScreenState.initial())
     }
 }
+
+private fun previewPlayers() = listOf(
+    PlayerCoinState(
+        id = "player-1",
+        displayName = "You",
+        coins = 6,
+        isCurrentPlayer = true,
+        isActivePlayer = true
+    ),
+    PlayerCoinState(
+        id = "player-2",
+        displayName = "SoupCube",
+        coins = 3
+    ),
+    PlayerCoinState(
+        id = "player-3",
+        displayName = "doniliks",
+        coins = 0
+    )
+)

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
@@ -34,6 +34,13 @@ class GameScreenViewModel(
                 }
             }
         }
+        viewModelScope.launch {
+            webSocketClient.players.collect { players ->
+                mutableState.update { current ->
+                    current.copy(players = players)
+                }
+            }
+        }
     }
 
     class Factory(

--- a/app/src/test/java/com/machikoro/client/domain/model/state/GameScreenStateTest.kt
+++ b/app/src/test/java/com/machikoro/client/domain/model/state/GameScreenStateTest.kt
@@ -11,5 +11,6 @@ class GameScreenStateTest {
 
         assertEquals(GamePhase.NONE, state.gamePhase)
         assertEquals(ConnectionStatus.IDLE, state.connectionStatus)
+        assertEquals(emptyList<PlayerCoinState>(), state.players)
     }
 }

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -2,6 +2,7 @@ package com.machikoro.client.network.websocket
 
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
+import com.machikoro.client.domain.model.state.PlayerCoinState
 import java.io.IOException
 import okhttp3.Protocol
 import okhttp3.Request
@@ -170,6 +171,16 @@ class OkHttpWebSocketClientTest {
     }
 
     @Test
+    fun playersStartEmpty() {
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "ws://10.0.2.2:8080/ws",
+            webSocketFactory = FakeWebSocketFactory()
+        )
+
+        assertEquals(emptyList<PlayerCoinState>(), client.players.value)
+    }
+
+    @Test
     fun gameActionMessageUpdatesGamePhase() {
         val factory = FakeWebSocketFactory()
         val client = OkHttpWebSocketClient(
@@ -228,6 +239,24 @@ class OkHttpWebSocketClientTest {
         )
 
         assertEquals(GamePhase.NONE, client.gamePhase.value)
+    }
+
+    @Test
+    fun messageWithoutCoinPayloadLeavesPlayersUnchanged() {
+        val factory = FakeWebSocketFactory()
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "ws://10.0.2.2:8080/ws",
+            webSocketFactory = factory
+        )
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
+        factory.simulateText(
+            gameActionFrame("""{"type":"GAME_ACTION","payload":{"turnPhase":"ROLL_DICE"}}""")
+        )
+
+        assertEquals(emptyList<PlayerCoinState>(), client.players.value)
     }
 
     @Test

--- a/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
@@ -2,6 +2,7 @@ package com.machikoro.client.ui.game
 
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
+import com.machikoro.client.domain.model.state.PlayerCoinState
 import com.machikoro.client.network.websocket.WebSocketClient
 import com.machikoro.client.ui.start.MainDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -26,6 +27,7 @@ class GameScreenViewModelTest {
 
         assertEquals(GamePhase.NONE, viewModel.state.value.gamePhase)
         assertEquals(ConnectionStatus.IDLE, viewModel.state.value.connectionStatus)
+        assertEquals(emptyList<PlayerCoinState>(), viewModel.state.value.players)
     }
 
     @Test
@@ -91,6 +93,54 @@ class GameScreenViewModelTest {
         assertEquals(GamePhase.BUY_OR_BUILD, viewModel.state.value.gamePhase)
     }
 
+    @Test
+    fun playerCoinUpdatesAreReflectedInState() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = GameScreenViewModel(fakeClient)
+        val players = listOf(
+            PlayerCoinState(
+                id = "player-1",
+                displayName = "You",
+                coins = 3,
+                isCurrentPlayer = true
+            ),
+            PlayerCoinState(
+                id = "player-2",
+                displayName = "SoupCube",
+                coins = 5,
+                isActivePlayer = true
+            )
+        )
+
+        fakeClient.emitPlayers(players)
+        advanceUntilIdle()
+
+        assertEquals(players, viewModel.state.value.players)
+    }
+
+    @Test
+    fun playerCoinUpdatesReplacePreviousValuesForIncreasesAndDecreases() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = GameScreenViewModel(fakeClient)
+
+        fakeClient.emitPlayers(
+            listOf(
+                PlayerCoinState(id = "player-1", displayName = "You", coins = 3),
+                PlayerCoinState(id = "player-2", displayName = "SoupCube", coins = 5)
+            )
+        )
+        advanceUntilIdle()
+
+        val updatedPlayers = listOf(
+            PlayerCoinState(id = "player-1", displayName = "You", coins = 8),
+            PlayerCoinState(id = "player-2", displayName = "SoupCube", coins = 2)
+        )
+        fakeClient.emitPlayers(updatedPlayers)
+        advanceUntilIdle()
+
+        assertEquals(updatedPlayers, viewModel.state.value.players)
+    }
+
     private class FakeWebSocketClient : WebSocketClient {
         override val connectionStatus: StateFlow<ConnectionStatus>
             get() = mutableConnectionStatus
@@ -98,8 +148,12 @@ class GameScreenViewModelTest {
         override val gamePhase: StateFlow<GamePhase>
             get() = mutableGamePhase
 
+        override val players: StateFlow<List<PlayerCoinState>>
+            get() = mutablePlayers
+
         private val mutableConnectionStatus = MutableStateFlow(ConnectionStatus.IDLE)
         private val mutableGamePhase = MutableStateFlow(GamePhase.NONE)
+        private val mutablePlayers = MutableStateFlow<List<PlayerCoinState>>(emptyList())
 
         override fun connect() = Unit
 
@@ -111,6 +165,10 @@ class GameScreenViewModelTest {
 
         fun emitGamePhase(phase: GamePhase) {
             mutableGamePhase.value = phase
+        }
+
+        fun emitPlayers(players: List<PlayerCoinState>) {
+            mutablePlayers.value = players
         }
     }
 }

--- a/app/src/test/java/com/machikoro/client/ui/start/StartScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/start/StartScreenViewModelTest.kt
@@ -2,6 +2,7 @@ package com.machikoro.client.ui.start
 
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
+import com.machikoro.client.domain.model.state.PlayerCoinState
 import com.machikoro.client.network.websocket.WebSocketClient
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -52,8 +53,12 @@ class StartScreenViewModelTest {
         override val gamePhase: StateFlow<GamePhase>
             get() = mutableGamePhase
 
+        override val players: StateFlow<List<PlayerCoinState>>
+            get() = mutablePlayers
+
         private val mutableConnectionStatus = MutableStateFlow(ConnectionStatus.IDLE)
         private val mutableGamePhase = MutableStateFlow(GamePhase.NONE)
+        private val mutablePlayers = MutableStateFlow<List<PlayerCoinState>>(emptyList())
 
         override fun connect() = Unit
 


### PR DESCRIPTION
Adds the client-side foundation for issue #37: player coin state, ViewModel binding, and a visible coin display on the game screen.

#### Changes

1. Added PlayerCoinState
2. Added players to GameScreenState
3. Exposed player coin state through WebSocketClient
4. Rendered player coin badges in GameScreen
5. Clears coin state on disconnect/reset paths

#### Tests

- Added state/ViewModel/WebSocket tests for empty and updated coin state
- Updated fake WebSocket clients for the new players flow
