### PR TITLE
feat: #88 add registration screen and POST /auth/register integration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
     jacoco
 }
 
@@ -63,7 +64,11 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.okhttp)
+    implementation(libs.retrofit)
+    implementation(libs.retrofit.kotlinx.serialization.converter)
+    implementation(libs.kotlinx.serialization.json)
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.json)

--- a/app/src/androidTest/java/com/machikoro/client/ui/AppRootTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/AppRootTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.GameScreenState
+import com.machikoro.client.domain.model.state.RegisterDialogState
 import com.machikoro.client.domain.model.state.StartScreenState
 import com.machikoro.client.domain.model.state.toDisplayText
 import com.machikoro.client.ui.theme.ClientTheme
@@ -26,7 +27,12 @@ class AppRootTest {
             ClientTheme {
                 AppRoot(
                     gameScreenState = GameScreenState.initial(),
-                    startScreenState = StartScreenState.placeholder()
+                    startScreenState = StartScreenState.placeholder(),
+                    registerDialogState = RegisterDialogState(),
+                    onRegisterUsernameChange = {},
+                    onRegisterPasswordChange = {},
+                    onRegisterSubmit = {},
+                    onRegisterDialogReset = {},
                 )
             }
         }
@@ -41,7 +47,12 @@ class AppRootTest {
             ClientTheme {
                 AppRoot(
                     gameScreenState = GameScreenState.initial().copy(gamePhase = GamePhase.ROLL_DICE),
-                    startScreenState = StartScreenState.placeholder()
+                    startScreenState = StartScreenState.placeholder(),
+                    registerDialogState = RegisterDialogState(),
+                    onRegisterUsernameChange = {},
+                    onRegisterPasswordChange = {},
+                    onRegisterSubmit = {},
+                    onRegisterDialogReset = {},
                 )
             }
         }
@@ -57,7 +68,12 @@ class AppRootTest {
             ClientTheme {
                 AppRoot(
                     gameScreenState = GameScreenState.initial().copy(gamePhase = phase),
-                    startScreenState = StartScreenState.placeholder()
+                    startScreenState = StartScreenState.placeholder(),
+                    registerDialogState = RegisterDialogState(),
+                    onRegisterUsernameChange = {},
+                    onRegisterPasswordChange = {},
+                    onRegisterSubmit = {},
+                    onRegisterDialogReset = {},
                 )
             }
         }

--- a/app/src/androidTest/java/com/machikoro/client/ui/start/RegisterDialogTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/start/RegisterDialogTest.kt
@@ -1,0 +1,89 @@
+package com.machikoro.client.ui.start
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.machikoro.client.domain.model.state.RegisterDialogState
+import com.machikoro.client.ui.theme.ClientTheme
+import org.junit.Rule
+import org.junit.Test
+
+class RegisterDialogTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun submitButtonIsDisabledWhenFieldsAreBlank() {
+        composeTestRule.setContent {
+            ClientTheme {
+                RegisterDialog(
+                    state = RegisterDialogState(),
+                    onUsernameChange = {},
+                    onPasswordChange = {},
+                    onSubmit = {},
+                    onDismiss = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Register").assertIsDisplayed().assertIsNotEnabled()
+    }
+
+    @Test
+    fun submitButtonIsEnabledWhenBothFieldsFilled() {
+        composeTestRule.setContent {
+            ClientTheme {
+                RegisterDialog(
+                    state = RegisterDialogState(username = "alice", password = "hunter2"),
+                    onUsernameChange = {},
+                    onPasswordChange = {},
+                    onSubmit = {},
+                    onDismiss = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Register").assertIsDisplayed().assertIsEnabled()
+    }
+
+    @Test
+    fun errorMessageIsRenderedWhenPresent() {
+        composeTestRule.setContent {
+            ClientTheme {
+                RegisterDialog(
+                    state = RegisterDialogState(
+                        username = "alice",
+                        password = "hunter2",
+                        errorMessage = "Username 'alice' is already taken",
+                    ),
+                    onUsernameChange = {},
+                    onPasswordChange = {},
+                    onSubmit = {},
+                    onDismiss = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Username 'alice' is already taken").assertIsDisplayed()
+    }
+
+    @Test
+    fun successStateShowsRegisteredMessageAndCloseButton() {
+        composeTestRule.setContent {
+            ClientTheme {
+                RegisterDialog(
+                    state = RegisterDialogState(registeredUsername = "alice"),
+                    onUsernameChange = {},
+                    onPasswordChange = {},
+                    onSubmit = {},
+                    onDismiss = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Registered as alice").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Close").assertIsDisplayed().assertIsEnabled()
+    }
+}

--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -12,9 +12,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.machikoro.client.config.AppConfig
+import com.machikoro.client.network.auth.AuthApiFactory
 import com.machikoro.client.network.websocket.OkHttpWebSocketClient
 import com.machikoro.client.ui.AppRoot
 import com.machikoro.client.ui.game.GameScreenViewModel
+import com.machikoro.client.ui.start.RegisterDialogViewModel
 import com.machikoro.client.ui.start.StartScreenViewModel
 import com.machikoro.client.ui.theme.ClientTheme
 
@@ -22,11 +24,17 @@ class MainActivity : ComponentActivity() {
     private val webSocketClient by lazy {
         OkHttpWebSocketClient(websocketUrl = AppConfig.websocketUrl)
     }
+    private val authApi by lazy {
+        AuthApiFactory.create(AppConfig.backendBaseUrl)
+    }
     private val startScreenViewModel by viewModels<StartScreenViewModel> {
         StartScreenViewModel.Factory(webSocketClient)
     }
     private val gameScreenViewModel by viewModels<GameScreenViewModel> {
         GameScreenViewModel.Factory(webSocketClient)
+    }
+    private val registerDialogViewModel by viewModels<RegisterDialogViewModel> {
+        RegisterDialogViewModel.Factory(authApi)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -35,11 +43,17 @@ class MainActivity : ComponentActivity() {
         setContent {
             val startScreenState by startScreenViewModel.state.collectAsState()
             val gameScreenState by gameScreenViewModel.state.collectAsState()
+            val registerDialogState by registerDialogViewModel.state.collectAsState()
             ClientTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     AppRoot(
                         gameScreenState = gameScreenState,
                         startScreenState = startScreenState,
+                        registerDialogState = registerDialogState,
+                        onRegisterUsernameChange = registerDialogViewModel::usernameChanged,
+                        onRegisterPasswordChange = registerDialogViewModel::passwordChanged,
+                        onRegisterSubmit = registerDialogViewModel::submit,
+                        onRegisterDialogReset = registerDialogViewModel::reset,
                         modifier = Modifier.padding(innerPadding)
                     )
                 }

--- a/app/src/main/java/com/machikoro/client/domain/model/state/RegisterDialogState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/RegisterDialogState.kt
@@ -1,0 +1,15 @@
+package com.machikoro.client.domain.model.state
+
+data class RegisterDialogState(
+    val username: String = "",
+    val password: String = "",
+    val submitting: Boolean = false,
+    val errorMessage: String? = null,
+    val registeredUsername: String? = null,
+) {
+    val canSubmit: Boolean
+        get() = !submitting &&
+            registeredUsername == null &&
+            username.isNotBlank() &&
+            password.isNotBlank()
+}

--- a/app/src/main/java/com/machikoro/client/network/auth/AuthApi.kt
+++ b/app/src/main/java/com/machikoro/client/network/auth/AuthApi.kt
@@ -1,0 +1,9 @@
+package com.machikoro.client.network.auth
+
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthApi {
+    @POST("/auth/register")
+    suspend fun register(@Body body: RegisterRequest): RegisterResponse
+}

--- a/app/src/main/java/com/machikoro/client/network/auth/AuthApiFactory.kt
+++ b/app/src/main/java/com/machikoro/client/network/auth/AuthApiFactory.kt
@@ -1,0 +1,19 @@
+package com.machikoro.client.network.auth
+
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+
+object AuthApiFactory {
+    private val json = Json {
+        ignoreUnknownKeys = true
+    }
+
+    fun create(baseUrl: String): AuthApi =
+        Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(AuthApi::class.java)
+}

--- a/app/src/main/java/com/machikoro/client/network/auth/AuthDtos.kt
+++ b/app/src/main/java/com/machikoro/client/network/auth/AuthDtos.kt
@@ -1,0 +1,15 @@
+package com.machikoro.client.network.auth
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegisterRequest(
+    val username: String,
+    val password: String,
+)
+
+@Serializable
+data class RegisterResponse(
+    val id: Int,
+    val username: String,
+)

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.GameScreenState
+import com.machikoro.client.domain.model.state.RegisterDialogState
 import com.machikoro.client.domain.model.state.StartScreenState
 import com.machikoro.client.ui.game.GameScreen
 import com.machikoro.client.ui.start.StartScreen
@@ -14,12 +15,25 @@ import com.machikoro.client.ui.theme.ClientTheme
 fun AppRoot(
     gameScreenState: GameScreenState,
     startScreenState: StartScreenState,
+    registerDialogState: RegisterDialogState,
+    onRegisterUsernameChange: (String) -> Unit,
+    onRegisterPasswordChange: (String) -> Unit,
+    onRegisterSubmit: () -> Unit,
+    onRegisterDialogReset: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     if (gameScreenState.gamePhase != GamePhase.NONE) {
         GameScreen(state = gameScreenState, modifier = modifier)
     } else {
-        StartScreen(state = startScreenState, modifier = modifier)
+        StartScreen(
+            state = startScreenState,
+            registerDialogState = registerDialogState,
+            onRegisterUsernameChange = onRegisterUsernameChange,
+            onRegisterPasswordChange = onRegisterPasswordChange,
+            onRegisterSubmit = onRegisterSubmit,
+            onRegisterDialogReset = onRegisterDialogReset,
+            modifier = modifier
+        )
     }
 }
 
@@ -29,7 +43,12 @@ private fun AppRootStartScreenPreview() {
     ClientTheme {
         AppRoot(
             gameScreenState = GameScreenState.initial(),
-            startScreenState = StartScreenState.placeholder()
+            startScreenState = StartScreenState.placeholder(),
+            registerDialogState = RegisterDialogState(),
+            onRegisterUsernameChange = {},
+            onRegisterPasswordChange = {},
+            onRegisterSubmit = {},
+            onRegisterDialogReset = {},
         )
     }
 }
@@ -40,7 +59,12 @@ private fun AppRootGameScreenPreview() {
     ClientTheme {
         AppRoot(
             gameScreenState = GameScreenState.initial().copy(gamePhase = GamePhase.ROLL_DICE),
-            startScreenState = StartScreenState.placeholder()
+            startScreenState = StartScreenState.placeholder(),
+            registerDialogState = RegisterDialogState(),
+            onRegisterUsernameChange = {},
+            onRegisterPasswordChange = {},
+            onRegisterSubmit = {},
+            onRegisterDialogReset = {},
         )
     }
 }

--- a/app/src/main/java/com/machikoro/client/ui/start/RegisterDialog.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/RegisterDialog.kt
@@ -1,0 +1,171 @@
+package com.machikoro.client.ui.start
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.machikoro.client.domain.model.state.RegisterDialogState
+import com.machikoro.client.ui.theme.ClientTheme
+
+@Composable
+fun RegisterDialog(
+    state: RegisterDialogState,
+    onUsernameChange: (String) -> Unit,
+    onPasswordChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var passwordVisible by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        modifier = modifier,
+        onDismissRequest = onDismiss,
+        title = { Text("Register") },
+        text = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(
+                    value = state.username,
+                    onValueChange = onUsernameChange,
+                    label = { Text("Username") },
+                    singleLine = true,
+                    enabled = !state.submitting && state.registeredUsername == null,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = state.password,
+                    onValueChange = onPasswordChange,
+                    label = { Text("Password") },
+                    singleLine = true,
+                    enabled = !state.submitting && state.registeredUsername == null,
+                    visualTransformation = if (passwordVisible) {
+                        VisualTransformation.None
+                    } else {
+                        PasswordVisualTransformation()
+                    },
+                    trailingIcon = {
+                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                            Icon(
+                                imageVector = if (passwordVisible) {
+                                    Icons.Filled.VisibilityOff
+                                } else {
+                                    Icons.Filled.Visibility
+                                },
+                                contentDescription = if (passwordVisible) {
+                                    "Hide password"
+                                } else {
+                                    "Show password"
+                                },
+                            )
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                if (state.errorMessage != null) {
+                    Text(
+                        text = state.errorMessage,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                if (state.registeredUsername != null) {
+                    Text(
+                        text = "Registered as ${state.registeredUsername}",
+                        color = MaterialTheme.colorScheme.primary,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            if (state.registeredUsername != null) {
+                Button(onClick = onDismiss) {
+                    Text("Close")
+                }
+            } else {
+                Button(
+                    onClick = onSubmit,
+                    enabled = state.canSubmit,
+                ) {
+                    Text(if (state.submitting) "Registering…" else "Register")
+                }
+            }
+        },
+        dismissButton = {
+            if (state.registeredUsername == null) {
+                TextButton(onClick = onDismiss, enabled = !state.submitting) {
+                    Text("Cancel")
+                }
+            }
+        },
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RegisterDialogEmptyPreview() {
+    ClientTheme {
+        RegisterDialog(
+            state = RegisterDialogState(),
+            onUsernameChange = {},
+            onPasswordChange = {},
+            onSubmit = {},
+            onDismiss = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RegisterDialogErrorPreview() {
+    ClientTheme {
+        RegisterDialog(
+            state = RegisterDialogState(
+                username = "alice",
+                password = "hunter2",
+                errorMessage = "Username 'alice' is already taken",
+            ),
+            onUsernameChange = {},
+            onPasswordChange = {},
+            onSubmit = {},
+            onDismiss = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RegisterDialogSuccessPreview() {
+    ClientTheme {
+        RegisterDialog(
+            state = RegisterDialogState(registeredUsername = "alice"),
+            onUsernameChange = {},
+            onPasswordChange = {},
+            onSubmit = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/app/src/main/java/com/machikoro/client/ui/start/RegisterDialogViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/RegisterDialogViewModel.kt
@@ -1,0 +1,85 @@
+package com.machikoro.client.ui.start
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.machikoro.client.domain.model.state.RegisterDialogState
+import com.machikoro.client.network.auth.AuthApi
+import com.machikoro.client.network.auth.RegisterRequest
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import java.io.IOException
+
+class RegisterDialogViewModel(
+    private val authApi: AuthApi,
+) : ViewModel() {
+    val state: StateFlow<RegisterDialogState>
+        get() = mutableState.asStateFlow()
+
+    private val mutableState = MutableStateFlow(RegisterDialogState())
+
+    fun usernameChanged(value: String) {
+        mutableState.update { it.copy(username = value, errorMessage = null) }
+    }
+
+    fun passwordChanged(value: String) {
+        mutableState.update { it.copy(password = value, errorMessage = null) }
+    }
+
+    fun submit() {
+        val current = mutableState.value
+        if (!current.canSubmit) return
+
+        mutableState.update { it.copy(submitting = true, errorMessage = null) }
+
+        viewModelScope.launch {
+            val result = runCatching {
+                authApi.register(RegisterRequest(current.username, current.password))
+            }
+            mutableState.update { previous ->
+                result.fold(
+                    onSuccess = { response ->
+                        previous.copy(
+                            submitting = false,
+                            registeredUsername = response.username,
+                            errorMessage = null,
+                        )
+                    },
+                    onFailure = { throwable ->
+                        previous.copy(
+                            submitting = false,
+                            errorMessage = throwable.toUserMessage(),
+                        )
+                    },
+                )
+            }
+        }
+    }
+
+    fun reset() {
+        mutableState.value = RegisterDialogState()
+    }
+
+    private fun Throwable.toUserMessage(): String = when (this) {
+        is HttpException -> response()?.errorBody()?.string()?.takeIf { it.isNotBlank() }
+            ?: "Registration failed (HTTP ${code()})"
+        is IOException -> "Network error: ${message ?: "could not reach server"}"
+        else -> message ?: "Registration failed"
+    }
+
+    class Factory(
+        private val authApi: AuthApi,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            require(modelClass.isAssignableFrom(RegisterDialogViewModel::class.java)) {
+                "Unknown ViewModel class: ${modelClass.name}"
+            }
+            return RegisterDialogViewModel(authApi) as T
+        }
+    }
+}

--- a/app/src/main/java/com/machikoro/client/ui/start/StartScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/StartScreen.kt
@@ -12,8 +12,10 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -23,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.LobbyStatus
+import com.machikoro.client.domain.model.state.RegisterDialogState
 import com.machikoro.client.domain.model.state.StartScreenState
 import com.machikoro.client.domain.model.state.toDisplayText
 import com.machikoro.client.ui.theme.ClientTheme
@@ -31,10 +34,16 @@ import com.machikoro.client.R
 @Composable
 fun StartScreen(
     state: StartScreenState,
+    registerDialogState: RegisterDialogState,
+    onRegisterUsernameChange: (String) -> Unit,
+    onRegisterPasswordChange: (String) -> Unit,
+    onRegisterSubmit: () -> Unit,
+    onRegisterDialogReset: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
     val showPdfViewer = remember { mutableStateOf(false) }
+    var showRegisterDialog by remember { mutableStateOf(false) }
 
     if (showPdfViewer.value) {
         PdfViewerScreen(
@@ -104,6 +113,32 @@ fun StartScreen(
                     style = MaterialTheme.typography.bodyMedium, // test
                     color = MaterialTheme.colorScheme.primary // test
                 )
+                Button(
+                    onClick = { showRegisterDialog = true },
+                    shape = RoundedCornerShape(8.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color(0xFF64B5F6)
+                    )
+                ) {
+                    Text(
+                        text = "Register",
+                        color = Color.Black,
+                        style = MaterialTheme.typography.labelLarge
+                    )
+                }
+            }
+
+            if (showRegisterDialog) {
+                RegisterDialog(
+                    state = registerDialogState,
+                    onUsernameChange = onRegisterUsernameChange,
+                    onPasswordChange = onRegisterPasswordChange,
+                    onSubmit = onRegisterSubmit,
+                    onDismiss = {
+                        showRegisterDialog = false
+                        onRegisterDialogReset()
+                    },
+                )
             }
         }
     }
@@ -125,7 +160,12 @@ private fun StartScreenPreview() {
         StartScreen(
             state = StartScreenState.placeholder().copy(
                 connectionStatus = ConnectionStatus.CONNECTED
-            )
+            ),
+            registerDialogState = RegisterDialogState(),
+            onRegisterUsernameChange = {},
+            onRegisterPasswordChange = {},
+            onRegisterSubmit = {},
+            onRegisterDialogReset = {},
         )
     }
 }

--- a/app/src/test/java/com/machikoro/client/ui/start/RegisterDialogViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/start/RegisterDialogViewModelTest.kt
@@ -1,0 +1,129 @@
+package com.machikoro.client.ui.start
+
+import com.machikoro.client.network.auth.AuthApi
+import com.machikoro.client.network.auth.RegisterRequest
+import com.machikoro.client.network.auth.RegisterResponse
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RegisterDialogViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun submitSuccessSetsRegisteredUsernameAndClearsSubmitting() = runTest {
+        val api = FakeAuthApi(
+            response = { request -> RegisterResponse(id = 7, username = request.username) },
+        )
+        val viewModel = RegisterDialogViewModel(api)
+        viewModel.usernameChanged("alice")
+        viewModel.passwordChanged("hunter2")
+
+        viewModel.submit()
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals("alice", state.registeredUsername)
+        assertFalse(state.submitting)
+        assertNull(state.errorMessage)
+    }
+
+    @Test
+    fun submitHttpExceptionSurfacesServerErrorBody() = runTest {
+        val errorBody = "Username 'alice' is already taken".toResponseBody("text/plain".toMediaType())
+        val api = FakeAuthApi(
+            response = { throw HttpException(Response.error<RegisterResponse>(400, errorBody)) },
+        )
+        val viewModel = RegisterDialogViewModel(api)
+        viewModel.usernameChanged("alice")
+        viewModel.passwordChanged("hunter2")
+
+        viewModel.submit()
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals("Username 'alice' is already taken", state.errorMessage)
+        assertNull(state.registeredUsername)
+        assertFalse(state.submitting)
+    }
+
+    @Test
+    fun submitIoExceptionSurfacesNetworkErrorMessage() = runTest {
+        val api = FakeAuthApi(
+            response = { throw IOException("connect timed out") },
+        )
+        val viewModel = RegisterDialogViewModel(api)
+        viewModel.usernameChanged("alice")
+        viewModel.passwordChanged("hunter2")
+
+        viewModel.submit()
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals("Network error: connect timed out", state.errorMessage)
+        assertFalse(state.submitting)
+    }
+
+    @Test
+    fun usernameAndPasswordChangedUpdateState() = runTest {
+        val viewModel = RegisterDialogViewModel(FakeAuthApi())
+
+        viewModel.usernameChanged("alice")
+        viewModel.passwordChanged("hunter2")
+
+        assertEquals("alice", viewModel.state.value.username)
+        assertEquals("hunter2", viewModel.state.value.password)
+    }
+
+    @Test
+    fun resetClearsTheForm() = runTest {
+        val viewModel = RegisterDialogViewModel(FakeAuthApi())
+        viewModel.usernameChanged("alice")
+        viewModel.passwordChanged("hunter2")
+
+        viewModel.reset()
+
+        val state = viewModel.state.value
+        assertEquals("", state.username)
+        assertEquals("", state.password)
+        assertNull(state.registeredUsername)
+        assertNull(state.errorMessage)
+    }
+
+    @Test
+    fun canSubmitIsFalseWhenFieldsBlankOrAlreadyRegisteredOrSubmitting() = runTest {
+        val viewModel = RegisterDialogViewModel(FakeAuthApi())
+
+        // blank fields
+        assertFalse(viewModel.state.value.canSubmit)
+
+        // username only
+        viewModel.usernameChanged("alice")
+        assertFalse(viewModel.state.value.canSubmit)
+
+        // both filled
+        viewModel.passwordChanged("hunter2")
+        assertTrue(viewModel.state.value.canSubmit)
+    }
+
+    private class FakeAuthApi(
+        private val response: (RegisterRequest) -> RegisterResponse = { _ ->
+            RegisterResponse(id = 1, username = "stub")
+        },
+    ) : AuthApi {
+        override suspend fun register(body: RegisterRequest): RegisterResponse = response(body)
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.kotlin.compose) apply false
+    alias(libs.plugins.kotlin.serialization) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,8 @@ coroutinesTest = "1.8.1"
 json = "20231013"
 material3 = "1.4.0"
 composeMaterial3 = "1.6.0"
+retrofit = "2.11.0"
+kotlinxSerialization = "1.8.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -31,10 +33,15 @@ androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "u
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 json = { group = "org.json", name = "json", version.ref = "json" }
+retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
+retrofit-kotlinx-serialization-converter = { group = "com.squareup.retrofit2", name = "converter-kotlinx-serialization", version.ref = "retrofit" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
Closes #88. Pairs with Server PR SE2-Machi-Koro/Server#164.

## Summary
- New "Register" button on `StartScreen` opens an `AlertDialog` with username + password inputs, password show/hide eye toggle, server error message in red, and a single-state success view ("Registered as <user>" with a Close button).
- Typed network layer in `network/auth/`: Retrofit `AuthApi`, `@Serializable` `RegisterRequest` / `RegisterResponse`, and `AuthApiFactory.create(baseUrl)`. Uses `BuildConfig.BACKEND_BASE_URL` (already wired, defaults to `http://10.0.2.2:8080` for the emulator).
- `RegisterDialogViewModel` with `@Transactional`-style atomic state updates: distinguishes `HttpException` (surfaces the server's plain-text error body verbatim — "Username 'alice' is already taken" etc.) from `IOException` (friendly "Network error" message).
- `MainActivity` lazy-initializes `authApi` and the new ViewModel. State + four callbacks plumb through `AppRoot` → `StartScreen` matching the existing pattern.

## What's intentional
- **Validation lives on the server.** Client only blocks blank submits via the `canSubmit` flag. Server's length/charset/duplicate rules are surfaced through the dialog's error text, so client and server can't drift.
- **No password trimming.** Username is normalized server-side (trim + lowercase); password keeps surrounding whitespace by design.
- **Dialog over screen.** `AlertDialog` over `StartScreen` rather than introducing `androidx.navigation.compose` for a single new flow. File a separate refactor issue if the team wants proper navigation before #158.
- **No Hilt.** Kept the manual `ViewModel.Factory(...)` pattern from the existing `StartScreenViewModel` / `GameScreenViewModel`.

## Out of scope
- Login / token storage / authenticated calls — separate Client issue once Server #158 lands.
- Password strength meter, autofill, biometric.
- Replacing the `if`-switch in `AppRoot` with a `NavController` / `NavHost`.
- Snackbar / toast outside the dialog — success state lives inside the dialog itself.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin :app:compileDebugUnitTestKotlin` — clean.
- [x] `./gradlew :app:testDebugUnitTest` — full unit suite green, including 6 new `RegisterDialogViewModelTest` cases (success / HTTP 400 / IOException / field updates / reset / `canSubmit`).
- [x] `./gradlew :app:jacocoTestCoverageVerification` — 80% coverage gate still satisfied.
- [x] **Manual end-to-end** against Server branch `162-registration-endpoint` running locally:
  - Register button visible on Start screen.
  - Dialog opens, fields update, eye toggle reveals/hides password.
  - Submit a fresh username → "Registered as <user>" success view + INFO log on the server.
  - Submit a duplicate → "Username '<x>' is already taken" rendered in red.
  - Empty fields → submit disabled, no request fires.
  - Row visible in pgAdmin with populated `password_hash`.
- [ ] Reviewer to run `:app:connectedDebugAndroidTest` against an emulator for the 4 new `RegisterDialogTest` cases plus the updated `AppRootTest`.

## Heads-up for reviewers
- New deps land in commit 1: Retrofit 2.11.0, kotlinx-serialization 1.8.0, material-icons-extended (BOM-managed). No version bumps to existing deps.
- "Connection status: connection error" on the start screen is the existing WebSocket layer, unrelated to the new HTTP/Retrofit path. Not introduced by this PR — already present on `main`.

## Commit split (4)
1. `build: #88 add Retrofit, kotlinx.serialization, and material-icons-extended` — pure deps, app behaves identically.
2. `feat: #88 add AuthApi, DTOs, and AuthApiFactory` — typed network layer.
3. `feat: #88 add RegisterDialogViewModel and state` — VM + 6 unit tests.
4. `feat: #88 add RegisterDialog and Register button on StartScreen` — composable + plumbing through `AppRoot` / `MainActivity` / `AppRootTest` + 4 UI tests.