### PR TITLE
feat: #90 add login dialog, logout button, and in-memory session state

### DIFF
--- a/app/src/androidTest/java/com/machikoro/client/ui/AppRootTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/AppRootTest.kt
@@ -8,6 +8,8 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.GameScreenState
+import com.machikoro.client.domain.model.state.LoginDialogState
+import com.machikoro.client.domain.model.state.LogoutState
 import com.machikoro.client.domain.model.state.RegisterDialogState
 import com.machikoro.client.domain.model.state.StartScreenState
 import com.machikoro.client.domain.model.state.toDisplayText
@@ -29,10 +31,17 @@ class AppRootTest {
                     gameScreenState = GameScreenState.initial(),
                     startScreenState = StartScreenState.placeholder(),
                     registerDialogState = RegisterDialogState(),
+                    loginDialogState = LoginDialogState(),
+                    logoutState = LogoutState(),
                     onRegisterUsernameChange = {},
                     onRegisterPasswordChange = {},
                     onRegisterSubmit = {},
                     onRegisterDialogReset = {},
+                    onLoginUsernameChange = {},
+                    onLoginPasswordChange = {},
+                    onLoginSubmit = {},
+                    onLoginDialogReset = {},
+                    onLogoutSubmit = {},
                 )
             }
         }
@@ -49,10 +58,17 @@ class AppRootTest {
                     gameScreenState = GameScreenState.initial().copy(gamePhase = GamePhase.ROLL_DICE),
                     startScreenState = StartScreenState.placeholder(),
                     registerDialogState = RegisterDialogState(),
+                    loginDialogState = LoginDialogState(),
+                    logoutState = LogoutState(),
                     onRegisterUsernameChange = {},
                     onRegisterPasswordChange = {},
                     onRegisterSubmit = {},
                     onRegisterDialogReset = {},
+                    onLoginUsernameChange = {},
+                    onLoginPasswordChange = {},
+                    onLoginSubmit = {},
+                    onLoginDialogReset = {},
+                    onLogoutSubmit = {},
                 )
             }
         }
@@ -70,10 +86,17 @@ class AppRootTest {
                     gameScreenState = GameScreenState.initial().copy(gamePhase = phase),
                     startScreenState = StartScreenState.placeholder(),
                     registerDialogState = RegisterDialogState(),
+                    loginDialogState = LoginDialogState(),
+                    logoutState = LogoutState(),
                     onRegisterUsernameChange = {},
                     onRegisterPasswordChange = {},
                     onRegisterSubmit = {},
                     onRegisterDialogReset = {},
+                    onLoginUsernameChange = {},
+                    onLoginPasswordChange = {},
+                    onLoginSubmit = {},
+                    onLoginDialogReset = {},
+                    onLogoutSubmit = {},
                 )
             }
         }

--- a/app/src/androidTest/java/com/machikoro/client/ui/start/LoginDialogTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/start/LoginDialogTest.kt
@@ -1,0 +1,89 @@
+package com.machikoro.client.ui.start
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.machikoro.client.domain.model.state.LoginDialogState
+import com.machikoro.client.ui.theme.ClientTheme
+import org.junit.Rule
+import org.junit.Test
+
+class LoginDialogTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun submitButtonIsDisabledWhenFieldsAreBlank() {
+        composeTestRule.setContent {
+            ClientTheme {
+                LoginDialog(
+                    state = LoginDialogState(),
+                    onUsernameChange = {},
+                    onPasswordChange = {},
+                    onSubmit = {},
+                    onDismiss = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Login").assertIsDisplayed().assertIsNotEnabled()
+    }
+
+    @Test
+    fun submitButtonIsEnabledWhenBothFieldsFilled() {
+        composeTestRule.setContent {
+            ClientTheme {
+                LoginDialog(
+                    state = LoginDialogState(username = "alice", password = "hunter2"),
+                    onUsernameChange = {},
+                    onPasswordChange = {},
+                    onSubmit = {},
+                    onDismiss = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Login").assertIsDisplayed().assertIsEnabled()
+    }
+
+    @Test
+    fun errorMessageIsRenderedWhenPresent() {
+        composeTestRule.setContent {
+            ClientTheme {
+                LoginDialog(
+                    state = LoginDialogState(
+                        username = "alice",
+                        password = "wrong",
+                        errorMessage = "Invalid username or password",
+                    ),
+                    onUsernameChange = {},
+                    onPasswordChange = {},
+                    onSubmit = {},
+                    onDismiss = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Invalid username or password").assertIsDisplayed()
+    }
+
+    @Test
+    fun successStateShowsLoggedInMessageAndCloseButton() {
+        composeTestRule.setContent {
+            ClientTheme {
+                LoginDialog(
+                    state = LoginDialogState(loggedInAs = "alice"),
+                    onUsernameChange = {},
+                    onPasswordChange = {},
+                    onSubmit = {},
+                    onDismiss = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Logged in as alice").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Close").assertIsDisplayed().assertIsEnabled()
+    }
+}

--- a/app/src/androidTest/java/com/machikoro/client/ui/start/StartScreenAuthStateTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/start/StartScreenAuthStateTest.kt
@@ -1,0 +1,73 @@
+package com.machikoro.client.ui.start
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.machikoro.client.domain.model.state.LoginDialogState
+import com.machikoro.client.domain.model.state.LogoutState
+import com.machikoro.client.domain.model.state.RegisterDialogState
+import com.machikoro.client.domain.model.state.StartScreenState
+import com.machikoro.client.ui.theme.ClientTheme
+import org.junit.Rule
+import org.junit.Test
+
+class StartScreenAuthStateTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun unauthenticatedShowsRegisterAndLoginAndHidesLoggedInBanner() {
+        composeTestRule.setContent {
+            ClientTheme {
+                StartScreen(
+                    state = StartScreenState.placeholder(),
+                    registerDialogState = RegisterDialogState(),
+                    loginDialogState = LoginDialogState(),
+                    logoutState = LogoutState(),
+                    onRegisterUsernameChange = {},
+                    onRegisterPasswordChange = {},
+                    onRegisterSubmit = {},
+                    onRegisterDialogReset = {},
+                    onLoginUsernameChange = {},
+                    onLoginPasswordChange = {},
+                    onLoginSubmit = {},
+                    onLoginDialogReset = {},
+                    onLogoutSubmit = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Register").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Login").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Logout").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Logged in as alice").assertDoesNotExist()
+    }
+
+    @Test
+    fun authenticatedShowsLoggedInBannerAndLogoutAndHidesRegisterAndLogin() {
+        composeTestRule.setContent {
+            ClientTheme {
+                StartScreen(
+                    state = StartScreenState.placeholder().copy(loggedInAs = "alice"),
+                    registerDialogState = RegisterDialogState(),
+                    loginDialogState = LoginDialogState(),
+                    logoutState = LogoutState(),
+                    onRegisterUsernameChange = {},
+                    onRegisterPasswordChange = {},
+                    onRegisterSubmit = {},
+                    onRegisterDialogReset = {},
+                    onLoginUsernameChange = {},
+                    onLoginPasswordChange = {},
+                    onLoginSubmit = {},
+                    onLoginDialogReset = {},
+                    onLogoutSubmit = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Logged in as alice").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Logout").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Register").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Login").assertDoesNotExist()
+    }
+}

--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -12,10 +12,13 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import com.machikoro.client.config.AppConfig
+import com.machikoro.client.domain.session.SessionManager
 import com.machikoro.client.network.auth.AuthApiFactory
 import com.machikoro.client.network.websocket.OkHttpWebSocketClient
 import com.machikoro.client.ui.AppRoot
 import com.machikoro.client.ui.game.GameScreenViewModel
+import com.machikoro.client.ui.start.LoginDialogViewModel
+import com.machikoro.client.ui.start.LogoutViewModel
 import com.machikoro.client.ui.start.RegisterDialogViewModel
 import com.machikoro.client.ui.start.StartScreenViewModel
 import com.machikoro.client.ui.theme.ClientTheme
@@ -28,13 +31,19 @@ class MainActivity : ComponentActivity() {
         AuthApiFactory.create(AppConfig.backendBaseUrl)
     }
     private val startScreenViewModel by viewModels<StartScreenViewModel> {
-        StartScreenViewModel.Factory(webSocketClient)
+        StartScreenViewModel.Factory(webSocketClient, SessionManager)
     }
     private val gameScreenViewModel by viewModels<GameScreenViewModel> {
         GameScreenViewModel.Factory(webSocketClient)
     }
     private val registerDialogViewModel by viewModels<RegisterDialogViewModel> {
         RegisterDialogViewModel.Factory(authApi)
+    }
+    private val loginDialogViewModel by viewModels<LoginDialogViewModel> {
+        LoginDialogViewModel.Factory(authApi, SessionManager)
+    }
+    private val logoutViewModel by viewModels<LogoutViewModel> {
+        LogoutViewModel.Factory(authApi, SessionManager)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -44,16 +53,25 @@ class MainActivity : ComponentActivity() {
             val startScreenState by startScreenViewModel.state.collectAsState()
             val gameScreenState by gameScreenViewModel.state.collectAsState()
             val registerDialogState by registerDialogViewModel.state.collectAsState()
+            val loginDialogState by loginDialogViewModel.state.collectAsState()
+            val logoutState by logoutViewModel.state.collectAsState()
             ClientTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     AppRoot(
                         gameScreenState = gameScreenState,
                         startScreenState = startScreenState,
                         registerDialogState = registerDialogState,
+                        loginDialogState = loginDialogState,
+                        logoutState = logoutState,
                         onRegisterUsernameChange = registerDialogViewModel::usernameChanged,
                         onRegisterPasswordChange = registerDialogViewModel::passwordChanged,
                         onRegisterSubmit = registerDialogViewModel::submit,
                         onRegisterDialogReset = registerDialogViewModel::reset,
+                        onLoginUsernameChange = loginDialogViewModel::usernameChanged,
+                        onLoginPasswordChange = loginDialogViewModel::passwordChanged,
+                        onLoginSubmit = loginDialogViewModel::submit,
+                        onLoginDialogReset = loginDialogViewModel::reset,
+                        onLogoutSubmit = logoutViewModel::submit,
                         modifier = Modifier.padding(innerPadding)
                     )
                 }

--- a/app/src/main/java/com/machikoro/client/domain/model/state/LoginDialogState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/LoginDialogState.kt
@@ -1,0 +1,15 @@
+package com.machikoro.client.domain.model.state
+
+data class LoginDialogState(
+    val username: String = "",
+    val password: String = "",
+    val submitting: Boolean = false,
+    val errorMessage: String? = null,
+    val loggedInAs: String? = null,
+) {
+    val canSubmit: Boolean
+        get() = !submitting &&
+            loggedInAs == null &&
+            username.isNotBlank() &&
+            password.isNotBlank()
+}

--- a/app/src/main/java/com/machikoro/client/domain/model/state/LogoutState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/LogoutState.kt
@@ -1,0 +1,5 @@
+package com.machikoro.client.domain.model.state
+
+data class LogoutState(
+    val submitting: Boolean = false,
+)

--- a/app/src/main/java/com/machikoro/client/domain/model/state/StartScreenState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/StartScreenState.kt
@@ -3,13 +3,15 @@ package com.machikoro.client.domain.model.state
 data class StartScreenState(
     val title: String,
     val connectionStatus: ConnectionStatus,
-    val lobbyStatus: LobbyStatus
+    val lobbyStatus: LobbyStatus,
+    val loggedInAs: String? = null,
 ) {
     companion object {
         fun placeholder() = StartScreenState(
             title = "Machi Koro Client",
             connectionStatus = ConnectionStatus.IDLE,
-            lobbyStatus = LobbyStatus.PLACEHOLDER
+            lobbyStatus = LobbyStatus.PLACEHOLDER,
+            loggedInAs = null,
         )
     }
 }

--- a/app/src/main/java/com/machikoro/client/domain/session/Session.kt
+++ b/app/src/main/java/com/machikoro/client/domain/session/Session.kt
@@ -1,0 +1,6 @@
+package com.machikoro.client.domain.session
+
+data class Session(
+    val sessionToken: String,
+    val username: String,
+)

--- a/app/src/main/java/com/machikoro/client/domain/session/SessionManager.kt
+++ b/app/src/main/java/com/machikoro/client/domain/session/SessionManager.kt
@@ -1,0 +1,18 @@
+package com.machikoro.client.domain.session
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+object SessionManager : SessionStateHolder {
+    private val mutableSession = MutableStateFlow<Session?>(null)
+    override val session: StateFlow<Session?> = mutableSession.asStateFlow()
+
+    override fun signIn(token: String, username: String) {
+        mutableSession.value = Session(sessionToken = token, username = username)
+    }
+
+    override fun signOut() {
+        mutableSession.value = null
+    }
+}

--- a/app/src/main/java/com/machikoro/client/domain/session/SessionStateHolder.kt
+++ b/app/src/main/java/com/machikoro/client/domain/session/SessionStateHolder.kt
@@ -1,0 +1,14 @@
+package com.machikoro.client.domain.session
+
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Owns the in-memory authenticated-session state. Survives screen rotation
+ * but not an app cold-start. Persisting the token across cold-starts is a
+ * separate follow-up issue.
+ */
+interface SessionStateHolder {
+    val session: StateFlow<Session?>
+    fun signIn(token: String, username: String)
+    fun signOut()
+}

--- a/app/src/main/java/com/machikoro/client/network/auth/AuthApi.kt
+++ b/app/src/main/java/com/machikoro/client/network/auth/AuthApi.kt
@@ -1,9 +1,20 @@
 package com.machikoro.client.network.auth
 
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
 
 interface AuthApi {
     @POST("/auth/register")
     suspend fun register(@Body body: RegisterRequest): RegisterResponse
+
+    @POST("/auth/login")
+    suspend fun login(@Body body: LoginRequest): LoginResponse
+
+    /**
+     * Server returns 200 with empty body on success (and on unknown-token no-op).
+     * Wrapped in Response<Unit> so we don't ask the JSON converter to parse "".
+     */
+    @POST("/auth/logout")
+    suspend fun logout(@Body body: LogoutRequest): Response<Unit>
 }

--- a/app/src/main/java/com/machikoro/client/network/auth/AuthDtos.kt
+++ b/app/src/main/java/com/machikoro/client/network/auth/AuthDtos.kt
@@ -13,3 +13,20 @@ data class RegisterResponse(
     val id: Int,
     val username: String,
 )
+
+@Serializable
+data class LoginRequest(
+    val username: String,
+    val password: String,
+)
+
+@Serializable
+data class LoginResponse(
+    val sessionToken: String,
+    val username: String,
+)
+
+@Serializable
+data class LogoutRequest(
+    val sessionToken: String,
+)

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -5,6 +5,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.GameScreenState
+import com.machikoro.client.domain.model.state.LoginDialogState
+import com.machikoro.client.domain.model.state.LogoutState
 import com.machikoro.client.domain.model.state.RegisterDialogState
 import com.machikoro.client.domain.model.state.StartScreenState
 import com.machikoro.client.ui.game.GameScreen
@@ -16,10 +18,17 @@ fun AppRoot(
     gameScreenState: GameScreenState,
     startScreenState: StartScreenState,
     registerDialogState: RegisterDialogState,
+    loginDialogState: LoginDialogState,
+    logoutState: LogoutState,
     onRegisterUsernameChange: (String) -> Unit,
     onRegisterPasswordChange: (String) -> Unit,
     onRegisterSubmit: () -> Unit,
     onRegisterDialogReset: () -> Unit,
+    onLoginUsernameChange: (String) -> Unit,
+    onLoginPasswordChange: (String) -> Unit,
+    onLoginSubmit: () -> Unit,
+    onLoginDialogReset: () -> Unit,
+    onLogoutSubmit: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     if (gameScreenState.gamePhase != GamePhase.NONE) {
@@ -28,10 +37,17 @@ fun AppRoot(
         StartScreen(
             state = startScreenState,
             registerDialogState = registerDialogState,
+            loginDialogState = loginDialogState,
+            logoutState = logoutState,
             onRegisterUsernameChange = onRegisterUsernameChange,
             onRegisterPasswordChange = onRegisterPasswordChange,
             onRegisterSubmit = onRegisterSubmit,
             onRegisterDialogReset = onRegisterDialogReset,
+            onLoginUsernameChange = onLoginUsernameChange,
+            onLoginPasswordChange = onLoginPasswordChange,
+            onLoginSubmit = onLoginSubmit,
+            onLoginDialogReset = onLoginDialogReset,
+            onLogoutSubmit = onLogoutSubmit,
             modifier = modifier
         )
     }
@@ -45,10 +61,17 @@ private fun AppRootStartScreenPreview() {
             gameScreenState = GameScreenState.initial(),
             startScreenState = StartScreenState.placeholder(),
             registerDialogState = RegisterDialogState(),
+            loginDialogState = LoginDialogState(),
+            logoutState = LogoutState(),
             onRegisterUsernameChange = {},
             onRegisterPasswordChange = {},
             onRegisterSubmit = {},
             onRegisterDialogReset = {},
+            onLoginUsernameChange = {},
+            onLoginPasswordChange = {},
+            onLoginSubmit = {},
+            onLoginDialogReset = {},
+            onLogoutSubmit = {},
         )
     }
 }
@@ -61,10 +84,17 @@ private fun AppRootGameScreenPreview() {
             gameScreenState = GameScreenState.initial().copy(gamePhase = GamePhase.ROLL_DICE),
             startScreenState = StartScreenState.placeholder(),
             registerDialogState = RegisterDialogState(),
+            loginDialogState = LoginDialogState(),
+            logoutState = LogoutState(),
             onRegisterUsernameChange = {},
             onRegisterPasswordChange = {},
             onRegisterSubmit = {},
             onRegisterDialogReset = {},
+            onLoginUsernameChange = {},
+            onLoginPasswordChange = {},
+            onLoginSubmit = {},
+            onLoginDialogReset = {},
+            onLogoutSubmit = {},
         )
     }
 }

--- a/app/src/main/java/com/machikoro/client/ui/start/LoginDialog.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/LoginDialog.kt
@@ -1,0 +1,171 @@
+package com.machikoro.client.ui.start
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.machikoro.client.domain.model.state.LoginDialogState
+import com.machikoro.client.ui.theme.ClientTheme
+
+@Composable
+fun LoginDialog(
+    state: LoginDialogState,
+    onUsernameChange: (String) -> Unit,
+    onPasswordChange: (String) -> Unit,
+    onSubmit: () -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var passwordVisible by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        modifier = modifier,
+        onDismissRequest = onDismiss,
+        title = { Text("Login") },
+        text = {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedTextField(
+                    value = state.username,
+                    onValueChange = onUsernameChange,
+                    label = { Text("Username") },
+                    singleLine = true,
+                    enabled = !state.submitting && state.loggedInAs == null,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                OutlinedTextField(
+                    value = state.password,
+                    onValueChange = onPasswordChange,
+                    label = { Text("Password") },
+                    singleLine = true,
+                    enabled = !state.submitting && state.loggedInAs == null,
+                    visualTransformation = if (passwordVisible) {
+                        VisualTransformation.None
+                    } else {
+                        PasswordVisualTransformation()
+                    },
+                    trailingIcon = {
+                        IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                            Icon(
+                                imageVector = if (passwordVisible) {
+                                    Icons.Filled.VisibilityOff
+                                } else {
+                                    Icons.Filled.Visibility
+                                },
+                                contentDescription = if (passwordVisible) {
+                                    "Hide password"
+                                } else {
+                                    "Show password"
+                                },
+                            )
+                        }
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                if (state.errorMessage != null) {
+                    Text(
+                        text = state.errorMessage,
+                        color = MaterialTheme.colorScheme.error,
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+                if (state.loggedInAs != null) {
+                    Text(
+                        text = "Logged in as ${state.loggedInAs}",
+                        color = MaterialTheme.colorScheme.primary,
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            if (state.loggedInAs != null) {
+                Button(onClick = onDismiss) {
+                    Text("Close")
+                }
+            } else {
+                Button(
+                    onClick = onSubmit,
+                    enabled = state.canSubmit,
+                ) {
+                    Text(if (state.submitting) "Logging in…" else "Login")
+                }
+            }
+        },
+        dismissButton = {
+            if (state.loggedInAs == null) {
+                TextButton(onClick = onDismiss, enabled = !state.submitting) {
+                    Text("Cancel")
+                }
+            }
+        },
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LoginDialogEmptyPreview() {
+    ClientTheme {
+        LoginDialog(
+            state = LoginDialogState(),
+            onUsernameChange = {},
+            onPasswordChange = {},
+            onSubmit = {},
+            onDismiss = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LoginDialogErrorPreview() {
+    ClientTheme {
+        LoginDialog(
+            state = LoginDialogState(
+                username = "alice",
+                password = "wrong",
+                errorMessage = "Invalid username or password",
+            ),
+            onUsernameChange = {},
+            onPasswordChange = {},
+            onSubmit = {},
+            onDismiss = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LoginDialogSuccessPreview() {
+    ClientTheme {
+        LoginDialog(
+            state = LoginDialogState(loggedInAs = "alice"),
+            onUsernameChange = {},
+            onPasswordChange = {},
+            onSubmit = {},
+            onDismiss = {},
+        )
+    }
+}

--- a/app/src/main/java/com/machikoro/client/ui/start/LoginDialogViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/LoginDialogViewModel.kt
@@ -1,0 +1,89 @@
+package com.machikoro.client.ui.start
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.machikoro.client.domain.model.state.LoginDialogState
+import com.machikoro.client.domain.session.SessionStateHolder
+import com.machikoro.client.network.auth.AuthApi
+import com.machikoro.client.network.auth.LoginRequest
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import java.io.IOException
+
+class LoginDialogViewModel(
+    private val authApi: AuthApi,
+    private val sessionStateHolder: SessionStateHolder,
+) : ViewModel() {
+    val state: StateFlow<LoginDialogState>
+        get() = mutableState.asStateFlow()
+
+    private val mutableState = MutableStateFlow(LoginDialogState())
+
+    fun usernameChanged(value: String) {
+        mutableState.update { it.copy(username = value, errorMessage = null) }
+    }
+
+    fun passwordChanged(value: String) {
+        mutableState.update { it.copy(password = value, errorMessage = null) }
+    }
+
+    fun submit() {
+        val current = mutableState.value
+        if (!current.canSubmit) return
+
+        mutableState.update { it.copy(submitting = true, errorMessage = null) }
+
+        viewModelScope.launch {
+            val result = runCatching {
+                authApi.login(LoginRequest(current.username, current.password))
+            }
+            mutableState.update { previous ->
+                result.fold(
+                    onSuccess = { response ->
+                        sessionStateHolder.signIn(response.sessionToken, response.username)
+                        previous.copy(
+                            submitting = false,
+                            loggedInAs = response.username,
+                            errorMessage = null,
+                        )
+                    },
+                    onFailure = { throwable ->
+                        previous.copy(
+                            submitting = false,
+                            errorMessage = throwable.toUserMessage(),
+                        )
+                    },
+                )
+            }
+        }
+    }
+
+    fun reset() {
+        mutableState.value = LoginDialogState()
+    }
+
+    private fun Throwable.toUserMessage(): String = when (this) {
+        is HttpException -> response()?.errorBody()?.string()?.takeIf { it.isNotBlank() }
+            ?: "Login failed (HTTP ${code()})"
+        is IOException -> "Network error: ${message ?: "could not reach server"}"
+        else -> message ?: "Login failed"
+    }
+
+    class Factory(
+        private val authApi: AuthApi,
+        private val sessionStateHolder: SessionStateHolder,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            require(modelClass.isAssignableFrom(LoginDialogViewModel::class.java)) {
+                "Unknown ViewModel class: ${modelClass.name}"
+            }
+            return LoginDialogViewModel(authApi, sessionStateHolder) as T
+        }
+    }
+}

--- a/app/src/main/java/com/machikoro/client/ui/start/LogoutViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/LogoutViewModel.kt
@@ -1,0 +1,63 @@
+package com.machikoro.client.ui.start
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.machikoro.client.domain.model.state.LogoutState
+import com.machikoro.client.domain.session.SessionStateHolder
+import com.machikoro.client.network.auth.AuthApi
+import com.machikoro.client.network.auth.LogoutRequest
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class LogoutViewModel(
+    private val authApi: AuthApi,
+    private val sessionStateHolder: SessionStateHolder,
+) : ViewModel() {
+    val state: StateFlow<LogoutState>
+        get() = mutableState.asStateFlow()
+
+    private val mutableState = MutableStateFlow(LogoutState())
+
+    fun submit() {
+        val current = sessionStateHolder.session.value ?: return
+        if (mutableState.value.submitting) return
+
+        mutableState.update { it.copy(submitting = true) }
+
+        viewModelScope.launch {
+            // Tolerate network failure: clear the local session regardless so the user
+            // isn't stranded on a bad connection. The server's stale-token endpoint
+            // already silently no-ops if the token is later replayed. Log only —
+            // by the time we'd surface a UI error the start screen has already
+            // flipped to the unauthenticated layout, so there is no visible host
+            // for an error banner.
+            runCatching { authApi.logout(LogoutRequest(current.sessionToken)) }
+                .onFailure { Log.w(TAG, "Logout API call failed; clearing local session anyway", it) }
+
+            sessionStateHolder.signOut()
+            mutableState.update { it.copy(submitting = false) }
+        }
+    }
+
+    class Factory(
+        private val authApi: AuthApi,
+        private val sessionStateHolder: SessionStateHolder,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            require(modelClass.isAssignableFrom(LogoutViewModel::class.java)) {
+                "Unknown ViewModel class: ${modelClass.name}"
+            }
+            return LogoutViewModel(authApi, sessionStateHolder) as T
+        }
+    }
+
+    companion object {
+        private const val TAG = "LogoutViewModel"
+    }
+}

--- a/app/src/main/java/com/machikoro/client/ui/start/StartScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/StartScreen.kt
@@ -25,6 +25,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.LobbyStatus
+import com.machikoro.client.domain.model.state.LoginDialogState
+import com.machikoro.client.domain.model.state.LogoutState
 import com.machikoro.client.domain.model.state.RegisterDialogState
 import com.machikoro.client.domain.model.state.StartScreenState
 import com.machikoro.client.domain.model.state.toDisplayText
@@ -35,15 +37,23 @@ import com.machikoro.client.R
 fun StartScreen(
     state: StartScreenState,
     registerDialogState: RegisterDialogState,
+    loginDialogState: LoginDialogState,
+    logoutState: LogoutState,
     onRegisterUsernameChange: (String) -> Unit,
     onRegisterPasswordChange: (String) -> Unit,
     onRegisterSubmit: () -> Unit,
     onRegisterDialogReset: () -> Unit,
+    onLoginUsernameChange: (String) -> Unit,
+    onLoginPasswordChange: (String) -> Unit,
+    onLoginSubmit: () -> Unit,
+    onLoginDialogReset: () -> Unit,
+    onLogoutSubmit: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
     val showPdfViewer = remember { mutableStateOf(false) }
     var showRegisterDialog by remember { mutableStateOf(false) }
+    var showLoginDialog by remember { mutableStateOf(false) }
 
     if (showPdfViewer.value) {
         PdfViewerScreen(
@@ -113,18 +123,54 @@ fun StartScreen(
                     style = MaterialTheme.typography.bodyMedium, // test
                     color = MaterialTheme.colorScheme.primary // test
                 )
-                Button(
-                    onClick = { showRegisterDialog = true },
-                    shape = RoundedCornerShape(8.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = Color(0xFF64B5F6)
-                    )
-                ) {
+
+                if (state.loggedInAs == null) {
+                    Button(
+                        onClick = { showRegisterDialog = true },
+                        shape = RoundedCornerShape(8.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color(0xFF64B5F6)
+                        )
+                    ) {
+                        Text(
+                            text = "Register",
+                            color = Color.Black,
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                    }
+                    Button(
+                        onClick = { showLoginDialog = true },
+                        shape = RoundedCornerShape(8.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color(0xFF64B5F6)
+                        )
+                    ) {
+                        Text(
+                            text = "Login",
+                            color = Color.Black,
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                    }
+                } else {
                     Text(
-                        text = "Register",
-                        color = Color.Black,
-                        style = MaterialTheme.typography.labelLarge
+                        text = "Logged in as ${state.loggedInAs}",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.primary
                     )
+                    Button(
+                        onClick = onLogoutSubmit,
+                        enabled = !logoutState.submitting,
+                        shape = RoundedCornerShape(8.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color(0xFF64B5F6)
+                        )
+                    ) {
+                        Text(
+                            text = if (logoutState.submitting) "Logging out…" else "Logout",
+                            color = Color.Black,
+                            style = MaterialTheme.typography.labelLarge
+                        )
+                    }
                 }
             }
 
@@ -137,6 +183,19 @@ fun StartScreen(
                     onDismiss = {
                         showRegisterDialog = false
                         onRegisterDialogReset()
+                    },
+                )
+            }
+
+            if (showLoginDialog) {
+                LoginDialog(
+                    state = loginDialogState,
+                    onUsernameChange = onLoginUsernameChange,
+                    onPasswordChange = onLoginPasswordChange,
+                    onSubmit = onLoginSubmit,
+                    onDismiss = {
+                        showLoginDialog = false
+                        onLoginDialogReset()
                     },
                 )
             }
@@ -162,10 +221,46 @@ private fun StartScreenPreview() {
                 connectionStatus = ConnectionStatus.CONNECTED
             ),
             registerDialogState = RegisterDialogState(),
+            loginDialogState = LoginDialogState(),
+            logoutState = LogoutState(),
             onRegisterUsernameChange = {},
             onRegisterPasswordChange = {},
             onRegisterSubmit = {},
             onRegisterDialogReset = {},
+            onLoginUsernameChange = {},
+            onLoginPasswordChange = {},
+            onLoginSubmit = {},
+            onLoginDialogReset = {},
+            onLogoutSubmit = {},
+        )
+    }
+}
+
+@Preview(
+    showBackground = true,
+    widthDp = 917,
+    heightDp = 412
+)
+@Composable
+private fun StartScreenAuthenticatedPreview() {
+    ClientTheme {
+        StartScreen(
+            state = StartScreenState.placeholder().copy(
+                connectionStatus = ConnectionStatus.CONNECTED,
+                loggedInAs = "alice",
+            ),
+            registerDialogState = RegisterDialogState(),
+            loginDialogState = LoginDialogState(),
+            logoutState = LogoutState(),
+            onRegisterUsernameChange = {},
+            onRegisterPasswordChange = {},
+            onRegisterSubmit = {},
+            onRegisterDialogReset = {},
+            onLoginUsernameChange = {},
+            onLoginPasswordChange = {},
+            onLoginSubmit = {},
+            onLoginDialogReset = {},
+            onLogoutSubmit = {},
         )
     }
 }

--- a/app/src/main/java/com/machikoro/client/ui/start/StartScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/StartScreenViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.machikoro.client.domain.model.state.StartScreenState
+import com.machikoro.client.domain.session.SessionStateHolder
 import com.machikoro.client.network.websocket.WebSocketClient
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -12,7 +13,8 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class StartScreenViewModel(
-    private val webSocketClient: WebSocketClient
+    private val webSocketClient: WebSocketClient,
+    private val sessionStateHolder: SessionStateHolder,
 ) : ViewModel() {
     val state: StateFlow<StartScreenState>
         get() = mutableState.asStateFlow()
@@ -27,17 +29,25 @@ class StartScreenViewModel(
                 }
             }
         }
+        viewModelScope.launch {
+            sessionStateHolder.session.collect { session ->
+                mutableState.update { current ->
+                    current.copy(loggedInAs = session?.username)
+                }
+            }
+        }
     }
 
     class Factory(
-        private val webSocketClient: WebSocketClient
+        private val webSocketClient: WebSocketClient,
+        private val sessionStateHolder: SessionStateHolder,
     ) : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             require(modelClass.isAssignableFrom(StartScreenViewModel::class.java)) {
                 "Unknown ViewModel class: ${modelClass.name}"
             }
-            return StartScreenViewModel(webSocketClient) as T
+            return StartScreenViewModel(webSocketClient, sessionStateHolder) as T
         }
     }
 }

--- a/app/src/test/java/com/machikoro/client/domain/session/SessionManagerTest.kt
+++ b/app/src/test/java/com/machikoro/client/domain/session/SessionManagerTest.kt
@@ -1,0 +1,39 @@
+package com.machikoro.client.domain.session
+
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class SessionManagerTest {
+
+    @Before
+    fun ensureCleanStartingState() {
+        // Defensive — if a prior test class left state in the singleton (or a
+        // prior test in this class threw before its @After), don't read it.
+        SessionManager.signOut()
+    }
+
+    @After
+    fun resetSingleton() {
+        // Tests share the global singleton; clear after each so order doesn't matter.
+        SessionManager.signOut()
+    }
+
+    @Test
+    fun `signIn populates session`() {
+        SessionManager.signIn(token = "uuid-123", username = "alice")
+
+        assertEquals(Session("uuid-123", "alice"), SessionManager.session.value)
+    }
+
+    @Test
+    fun `signOut clears session`() {
+        SessionManager.signIn(token = "uuid-123", username = "alice")
+
+        SessionManager.signOut()
+
+        assertNull(SessionManager.session.value)
+    }
+}

--- a/app/src/test/java/com/machikoro/client/ui/start/LoginDialogViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/start/LoginDialogViewModelTest.kt
@@ -1,0 +1,155 @@
+package com.machikoro.client.ui.start
+
+import com.machikoro.client.domain.session.Session
+import com.machikoro.client.domain.session.SessionStateHolder
+import com.machikoro.client.network.auth.AuthApi
+import com.machikoro.client.network.auth.LoginRequest
+import com.machikoro.client.network.auth.LoginResponse
+import com.machikoro.client.network.auth.LogoutRequest
+import com.machikoro.client.network.auth.RegisterRequest
+import com.machikoro.client.network.auth.RegisterResponse
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LoginDialogViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun submitSuccessSetsLoggedInAsAndPopulatesSessionStateHolder() = runTest {
+        val sessionHolder = FakeSessionStateHolder()
+        val api = FakeAuthApi(loginHandler = { request ->
+            LoginResponse(sessionToken = "uuid-123", username = request.username)
+        })
+        val viewModel = LoginDialogViewModel(api, sessionHolder)
+        viewModel.usernameChanged("alice")
+        viewModel.passwordChanged("hunter2")
+
+        viewModel.submit()
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals("alice", state.loggedInAs)
+        assertFalse(state.submitting)
+        assertNull(state.errorMessage)
+        assertEquals(Session("uuid-123", "alice"), sessionHolder.session.value)
+    }
+
+    @Test
+    fun submitHttpExceptionSurfacesServerErrorBodyVerbatim() = runTest {
+        val sessionHolder = FakeSessionStateHolder()
+        val errorBody = "Invalid username or password".toResponseBody("text/plain".toMediaType())
+        val api = FakeAuthApi(loginHandler = {
+            throw HttpException(Response.error<LoginResponse>(401, errorBody))
+        })
+        val viewModel = LoginDialogViewModel(api, sessionHolder)
+        viewModel.usernameChanged("alice")
+        viewModel.passwordChanged("wrong")
+
+        viewModel.submit()
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals("Invalid username or password", state.errorMessage)
+        assertNull(state.loggedInAs)
+        assertNull(sessionHolder.session.value)
+    }
+
+    @Test
+    fun submitIoExceptionSurfacesNetworkErrorMessage() = runTest {
+        val sessionHolder = FakeSessionStateHolder()
+        val api = FakeAuthApi(loginHandler = {
+            throw IOException("connect timed out")
+        })
+        val viewModel = LoginDialogViewModel(api, sessionHolder)
+        viewModel.usernameChanged("alice")
+        viewModel.passwordChanged("hunter2")
+
+        viewModel.submit()
+        advanceUntilIdle()
+
+        val state = viewModel.state.value
+        assertEquals("Network error: connect timed out", state.errorMessage)
+        assertNull(sessionHolder.session.value)
+    }
+
+    @Test
+    fun usernameAndPasswordChangedUpdateState() = runTest {
+        val viewModel = LoginDialogViewModel(FakeAuthApi(), FakeSessionStateHolder())
+
+        viewModel.usernameChanged("alice")
+        viewModel.passwordChanged("hunter2")
+
+        assertEquals("alice", viewModel.state.value.username)
+        assertEquals("hunter2", viewModel.state.value.password)
+    }
+
+    @Test
+    fun resetClearsTheForm() = runTest {
+        val viewModel = LoginDialogViewModel(FakeAuthApi(), FakeSessionStateHolder())
+        viewModel.usernameChanged("alice")
+        viewModel.passwordChanged("hunter2")
+
+        viewModel.reset()
+
+        val state = viewModel.state.value
+        assertEquals("", state.username)
+        assertEquals("", state.password)
+        assertNull(state.loggedInAs)
+        assertNull(state.errorMessage)
+    }
+
+    @Test
+    fun canSubmitGateBlocksWhenBlankOrAlreadyLoggedInOrSubmitting() = runTest {
+        val viewModel = LoginDialogViewModel(FakeAuthApi(), FakeSessionStateHolder())
+
+        assertFalse(viewModel.state.value.canSubmit)
+
+        viewModel.usernameChanged("alice")
+        assertFalse(viewModel.state.value.canSubmit)
+
+        viewModel.passwordChanged("hunter2")
+        assertTrue(viewModel.state.value.canSubmit)
+    }
+
+    private class FakeSessionStateHolder : SessionStateHolder {
+        private val mutableSession = MutableStateFlow<Session?>(null)
+        override val session: StateFlow<Session?> = mutableSession.asStateFlow()
+        override fun signIn(token: String, username: String) {
+            mutableSession.value = Session(token, username)
+        }
+        override fun signOut() {
+            mutableSession.value = null
+        }
+    }
+
+    private class FakeAuthApi(
+        private val loginHandler: (LoginRequest) -> LoginResponse = { _ ->
+            LoginResponse("stub-token", "stub")
+        },
+    ) : AuthApi {
+        override suspend fun register(body: RegisterRequest): RegisterResponse =
+            RegisterResponse(id = 0, username = body.username)
+
+        override suspend fun login(body: LoginRequest): LoginResponse = loginHandler(body)
+
+        override suspend fun logout(body: LogoutRequest): Response<Unit> =
+            Response.success(Unit)
+    }
+}

--- a/app/src/test/java/com/machikoro/client/ui/start/LogoutViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/start/LogoutViewModelTest.kt
@@ -1,0 +1,121 @@
+package com.machikoro.client.ui.start
+
+import com.machikoro.client.domain.session.Session
+import com.machikoro.client.domain.session.SessionStateHolder
+import com.machikoro.client.network.auth.AuthApi
+import com.machikoro.client.network.auth.LoginRequest
+import com.machikoro.client.network.auth.LoginResponse
+import com.machikoro.client.network.auth.LogoutRequest
+import com.machikoro.client.network.auth.RegisterRequest
+import com.machikoro.client.network.auth.RegisterResponse
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LogoutViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun submitCallsApiAndClearsSession() = runTest {
+        val sessionHolder = FakeSessionStateHolder().apply {
+            signIn(token = "uuid-123", username = "alice")
+        }
+        val api = FakeAuthApi()
+        val viewModel = LogoutViewModel(api, sessionHolder)
+
+        viewModel.submit()
+        advanceUntilIdle()
+
+        assertEquals(listOf(LogoutRequest("uuid-123")), api.logoutCalls)
+        assertNull(sessionHolder.session.value)
+        assertFalse(viewModel.state.value.submitting)
+    }
+
+    @Test
+    fun submitIsNoOpWhenNoSession() = runTest {
+        val sessionHolder = FakeSessionStateHolder()
+        val api = FakeAuthApi()
+        val viewModel = LogoutViewModel(api, sessionHolder)
+
+        viewModel.submit()
+        advanceUntilIdle()
+
+        assertTrue(api.logoutCalls.isEmpty())
+        assertFalse(viewModel.state.value.submitting)
+    }
+
+    @Test
+    fun submitClearsLocalSessionEvenWhenNetworkCallFails() = runTest {
+        val sessionHolder = FakeSessionStateHolder().apply {
+            signIn(token = "uuid-123", username = "alice")
+        }
+        val api = FakeAuthApi(logoutHandler = { throw IOException("connection refused") })
+        val viewModel = LogoutViewModel(api, sessionHolder)
+
+        viewModel.submit()
+        advanceUntilIdle()
+
+        // The API attempt is recorded — proves we tried — but the failure must
+        // not strand the user. Local session is cleared regardless.
+        assertEquals(listOf(LogoutRequest("uuid-123")), api.logoutCalls)
+        assertNull(sessionHolder.session.value)
+        assertFalse(viewModel.state.value.submitting)
+    }
+
+    @Test
+    fun secondSubmitWhileInFlightIsIgnored() = runTest {
+        val sessionHolder = FakeSessionStateHolder().apply {
+            signIn(token = "uuid-123", username = "alice")
+        }
+        val api = FakeAuthApi()
+        val viewModel = LogoutViewModel(api, sessionHolder)
+
+        viewModel.submit()
+        // Don't advance — the first submit hasn't completed.
+        viewModel.submit()
+        advanceUntilIdle()
+
+        assertEquals(1, api.logoutCalls.size)
+    }
+
+    private class FakeSessionStateHolder : SessionStateHolder {
+        private val mutableSession = MutableStateFlow<Session?>(null)
+        override val session: StateFlow<Session?> = mutableSession.asStateFlow()
+        override fun signIn(token: String, username: String) {
+            mutableSession.value = Session(token, username)
+        }
+        override fun signOut() {
+            mutableSession.value = null
+        }
+    }
+
+    private class FakeAuthApi(
+        private val logoutHandler: (LogoutRequest) -> Response<Unit> = { Response.success(Unit) },
+    ) : AuthApi {
+        val logoutCalls = mutableListOf<LogoutRequest>()
+
+        override suspend fun register(body: RegisterRequest): RegisterResponse =
+            RegisterResponse(id = 0, username = body.username)
+
+        override suspend fun login(body: LoginRequest): LoginResponse =
+            LoginResponse(sessionToken = "stub-token", username = body.username)
+
+        override suspend fun logout(body: LogoutRequest): Response<Unit> {
+            logoutCalls.add(body)
+            return logoutHandler(body)
+        }
+    }
+}

--- a/app/src/test/java/com/machikoro/client/ui/start/RegisterDialogViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/start/RegisterDialogViewModelTest.kt
@@ -1,6 +1,9 @@
 package com.machikoro.client.ui.start
 
 import com.machikoro.client.network.auth.AuthApi
+import com.machikoro.client.network.auth.LoginRequest
+import com.machikoro.client.network.auth.LoginResponse
+import com.machikoro.client.network.auth.LogoutRequest
 import com.machikoro.client.network.auth.RegisterRequest
 import com.machikoro.client.network.auth.RegisterResponse
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -17,6 +20,7 @@ import org.junit.Test
 import retrofit2.HttpException
 import retrofit2.Response
 import java.io.IOException
+
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class RegisterDialogViewModelTest {
@@ -125,5 +129,9 @@ class RegisterDialogViewModelTest {
         },
     ) : AuthApi {
         override suspend fun register(body: RegisterRequest): RegisterResponse = response(body)
+        override suspend fun login(body: LoginRequest): LoginResponse =
+            LoginResponse(sessionToken = "stub-token", username = body.username)
+        override suspend fun logout(body: LogoutRequest): Response<Unit> =
+            Response.success(Unit)
     }
 }

--- a/app/src/test/java/com/machikoro/client/ui/start/StartScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/start/StartScreenViewModelTest.kt
@@ -2,13 +2,17 @@ package com.machikoro.client.ui.start
 
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
+import com.machikoro.client.domain.session.Session
+import com.machikoro.client.domain.session.SessionStateHolder
 import com.machikoro.client.network.websocket.WebSocketClient
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 
@@ -19,18 +23,19 @@ class StartScreenViewModelTest {
 
     @Test
     fun initialStateUsesPlaceholderValues() = runTest {
-        val viewModel = StartScreenViewModel(FakeWebSocketClient())
+        val viewModel = StartScreenViewModel(FakeWebSocketClient(), FakeSessionStateHolder())
 
         advanceUntilIdle()
 
         assertEquals("Machi Koro Client", viewModel.state.value.title)
         assertEquals(ConnectionStatus.IDLE, viewModel.state.value.connectionStatus)
+        assertNull(viewModel.state.value.loggedInAs)
     }
 
     @Test
     fun clientStatusUpdatesAreReflectedInScreenState() = runTest {
         val fakeClient = FakeWebSocketClient()
-        val viewModel = StartScreenViewModel(fakeClient)
+        val viewModel = StartScreenViewModel(fakeClient, FakeSessionStateHolder())
 
         fakeClient.emit(ConnectionStatus.CONNECTING)
         advanceUntilIdle()
@@ -43,6 +48,20 @@ class StartScreenViewModelTest {
         fakeClient.emit(ConnectionStatus.ERROR)
         advanceUntilIdle()
         assertEquals(ConnectionStatus.ERROR, viewModel.state.value.connectionStatus)
+    }
+
+    @Test
+    fun sessionUpdatesAreReflectedInLoggedInAs() = runTest {
+        val sessionHolder = FakeSessionStateHolder()
+        val viewModel = StartScreenViewModel(FakeWebSocketClient(), sessionHolder)
+
+        sessionHolder.signIn(token = "uuid-123", username = "alice")
+        advanceUntilIdle()
+        assertEquals("alice", viewModel.state.value.loggedInAs)
+
+        sessionHolder.signOut()
+        advanceUntilIdle()
+        assertNull(viewModel.state.value.loggedInAs)
     }
 
     private class FakeWebSocketClient : WebSocketClient {
@@ -61,6 +80,17 @@ class StartScreenViewModelTest {
 
         fun emit(status: ConnectionStatus) {
             mutableConnectionStatus.value = status
+        }
+    }
+
+    private class FakeSessionStateHolder : SessionStateHolder {
+        private val mutableSession = MutableStateFlow<Session?>(null)
+        override val session: StateFlow<Session?> = mutableSession.asStateFlow()
+        override fun signIn(token: String, username: String) {
+            mutableSession.value = Session(token, username)
+        }
+        override fun signOut() {
+            mutableSession.value = null
         }
     }
 }


### PR DESCRIPTION
Closes #90. Pairs with Server PR SE2-Machi-Koro/Server#167.

⚠️ **Do not merge before Server #167 is on main** — the UI calls `/auth/login` and `/auth/logout` which only exist on the server's `158-login-endpoint` branch today. The two PRs were developed in parallel against the locked endpoint contract.

## Summary
- **Login flow**: new `LoginDialog` (mirrors `RegisterDialog`'s `AlertDialog` shape with show-password eye toggle + single-state success view) opened by a new "Login" button on `StartScreen`. `LoginDialogViewModel` calls `AuthApi.login`, surfaces the server's plain-text error body verbatim on 401, and on success populates `SessionManager`.
- **Logout flow**: new "Logout" button replaces Register + Login when the user is authenticated. `LogoutViewModel.submit()` always clears the local session — network failure is logged via `Log.w` but not surfaced to the UI (the start screen has already flipped to the unauthenticated layout by then, so there'd be no host for an error banner).
- **Session state**: new `SessionManager` (Kotlin `object` singleton) implements `SessionStateHolder`. The interface lets ViewModel unit tests use a `FakeSessionStateHolder` rather than mutating the global. `StartScreenViewModel` collects `session.username` into `StartScreenState.loggedInAs`, and `StartScreen` renders conditionally on that.
- **Network**: `AuthApi` extended with `login()` and `logout()`. Logout returns `Response<Unit>` so the kotlinx-serialization converter isn't asked to parse the server's intentionally empty 200 body.

## Validation contract
- Client only blocks blank-field submission. Server is authoritative for username normalization (trim + lowercase), length limits, and credential validation. The server's "Invalid username or password" body is rendered verbatim in the dialog's red error text — same response for unknown user and wrong password (no enumeration leaks through to the UI).
- Logout is idempotent on the server side and tolerant of network failure on the client side. Local session always clears.

## What's intentional
- **Manual-Close success view on the dialog** — when login succeeds the dialog still shows "Logged in as <x>" + Close until the user dismisses. Same pattern as `RegisterDialog`. Auto-dismiss is a separate cross-cutting UX issue if the team wants it.
- **`Log.w` instead of an error UI for logout failures** — by the time we'd surface an error the user has already returned to the unauthenticated layout, so there's no host for an error banner. Trade-off explained inline in `LogoutViewModel.submit()`.
- **`object` singleton `SessionManager`** — survives rotation but not cold-start. Tests use a `FakeSessionStateHolder` to avoid mutating the global; `SessionManagerTest` itself uses `@Before` + `@After` to reset.
- **No DI** — kept the manual `ViewModel.Factory(...)` pattern from existing VMs.

## Out of scope
- **Token persistence across cold-starts** (DataStore / EncryptedSharedPreferences) — separate follow-up issue.
- **"Remember me" / auto-login**.
- **Authenticated WebSocket** — needs Server #159.
- **Game-screen auth gating** — separate. The `gamePhase != NONE` switch in `AppRoot` doesn't yet care about login state.
- **Replacing the `if`-switch in `AppRoot` with `androidx.navigation.compose`** — separate refactor issue.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin :app:compileDebugUnitTestKotlin --warning-mode all` — clean, **no warnings, no deprecations**.
- [x] `./gradlew :app:testDebugUnitTest` — all unit tests pass: 6 new `LoginDialogViewModelTest`, 4 new `LogoutViewModelTest`, 2 new `SessionManagerTest`, 1 new `StartScreenViewModelTest` (loggedInAs reflection), plus existing tests with updated fakes.
- [x] `./gradlew :app:jacocoTestCoverageVerification` — 80% line-coverage gate satisfied.
- [x] `./gradlew :app:lintDebug` — Android Lint passes.
- [ ] **Manual end-to-end** against Server branch `158-login-endpoint` — recommended by reviewer:
  1. Run server on Server branch `158-login-endpoint`, Postgres via `compose-dev.yaml`.
  2. Register `bob` / `hunter2` from the existing dialog. Verify in pgAdmin.
  3. Tap **Login** → enter `bob` / `hunter2` → success view shows "Logged in as bob". Click Close.
  4. Start screen now shows "Logged in as bob" + Logout button; Register + Login hidden.
  5. Verify `users.session_token` is populated for `bob` in pgAdmin.
  6. Wrong password → server's `Invalid username or password` rendered verbatim in red.
  7. Tap **Logout** → start screen returns to Register + Login. `users.session_token` is now `NULL`.
  8. Rotate device while logged in → session survives. Cold-start app → session is lost (deferred behaviour, called out in scope).
- [ ] `./gradlew :app:connectedDebugAndroidTest --tests "com.machikoro.client.ui.start.LoginDialogTest"` and `"...StartScreenAuthStateTest"` (needs an emulator).

## Heads-up for reviewers
- New deps: **none**. Retrofit, kotlinx.serialization, and material-icons-extended are already on main from Client #89.
- `RegisterDialogViewModelTest`'s `FakeAuthApi` was updated with stubs for `login` / `logout` to satisfy the now-three-method `AuthApi` interface — this is the only delta to existing tests.
- The `if (showRegisterDialog) RegisterDialog(...)` block in `StartScreen` is unchanged from #89; only the new login + logout pieces are additive.

## Commit split (4)
1. `feat: #90 add login + logout DTOs and AuthApi methods` — pure scaffolding.
2. `feat: #90 add SessionManager and SessionStateHolder` — singleton state holder + interface + 2 unit tests.
3. `feat: #90 add LoginDialog and LoginDialogViewModel` — login form, VM, 6 unit tests, 4 UI tests. Wiring deferred to commit 4.
4. `feat: #90 add LogoutViewModel, auth-state UI, and start-screen plumbing` — logout VM + 4 tests, conditional render on `loggedInAs`, full plumbing through StartScreen / AppRoot / MainActivity, AppRootTest signature update, new StartScreenAuthStateTest UI test.