### PR TITLE
feat: #104 send session token in WebSocket STOMP CONNECT headers

### DIFF
--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -25,7 +25,10 @@ import com.machikoro.client.ui.theme.ClientTheme
 
 class MainActivity : ComponentActivity() {
     private val webSocketClient by lazy {
-        OkHttpWebSocketClient(websocketUrl = AppConfig.websocketUrl)
+        OkHttpWebSocketClient(
+            websocketUrl = AppConfig.websocketUrl,
+            sessionStateHolder = SessionManager,
+        )
     }
     private val authApi by lazy {
         AuthApiFactory.create(AppConfig.backendBaseUrl)

--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -58,6 +59,21 @@ class MainActivity : ComponentActivity() {
             val registerDialogState by registerDialogViewModel.state.collectAsState()
             val loginDialogState by loginDialogViewModel.state.collectAsState()
             val logoutState by logoutViewModel.state.collectAsState()
+
+            // Drive WebSocket lifecycle from session changes during the foreground.
+            // onStart/onStop handle the activity-lifecycle case; this handles the
+            // user-logs-in-or-out-while-app-is-open case. connect() and disconnect()
+            // are both idempotent so it's safe to call them on every emission.
+            LaunchedEffect(Unit) {
+                SessionManager.session.collect { session ->
+                    if (session != null) {
+                        webSocketClient.connect()
+                    } else {
+                        webSocketClient.disconnect()
+                    }
+                }
+            }
+
             ClientTheme {
                 Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
                     AppRoot(

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.PlayerCoinState
+import com.machikoro.client.domain.session.SessionStateHolder
 import java.net.URI
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,7 +18,8 @@ import org.json.JSONObject
 
 class OkHttpWebSocketClient(
     private val websocketUrl: String,
-    private val webSocketFactory: WebSocketFactory = OkHttpWebSocketFactory()
+    private val sessionStateHolder: SessionStateHolder,
+    private val webSocketFactory: WebSocketFactory = OkHttpWebSocketFactory(),
 ) : WebSocketClient {
     override val connectionStatus: StateFlow<ConnectionStatus>
         get() = mutableConnectionStatus.asStateFlow()
@@ -39,6 +41,15 @@ class OkHttpWebSocketClient(
     override fun connect() {
         synchronized(this) {
             if (webSocket != null) {
+                return
+            }
+            // Strict-reject server (#159): no session means we have nothing to
+            // present at STOMP CONNECT. Don't open a socket only to be kicked.
+            // Status stays at whatever it was — IDLE on first launch, DISCONNECTED
+            // after a logout — so the user doesn't see a misleading "connection
+            // error" when they simply aren't logged in yet.
+            if (sessionStateHolder.session.value == null) {
+                Log.d(TAG, "Skipping WS connect — no session token")
                 return
             }
 
@@ -65,9 +76,15 @@ class OkHttpWebSocketClient(
             webSocket = null
             socket
         }
+        // True no-op when there was nothing to disconnect. Without this, every
+        // session-driven LaunchedEffect emission of `null` (including the initial
+        // one on cold start) would flip the status from IDLE to DISCONNECTED,
+        // which the start screen renders as "Connection status: disconnected"
+        // before the user has tried to connect.
+        if (currentSocket == null) return
 
-        currentSocket?.send(StompFrame(command = "DISCONNECT").serialize())
-        currentSocket?.close(NORMAL_CLOSURE_STATUS, "Client disconnect")
+        currentSocket.send(StompFrame(command = "DISCONNECT").serialize())
+        currentSocket.close(NORMAL_CLOSURE_STATUS, "Client disconnect")
         Log.d(TAG, "Disconnect requested by client")
         mutableConnectionStatus.value = ConnectionStatus.DISCONNECTED
         resetGameState()
@@ -76,13 +93,24 @@ class OkHttpWebSocketClient(
     private val listener = object : WebSocketListener() {
         override fun onOpen(webSocket: WebSocket, response: Response) {
             Log.d(TAG, "WebSocket opened: ${response.code} ${response.message}")
+            // Read the token at handshake time, not at connect-time. Closes the
+            // race where the user logged out between connect() and the WS being
+            // ready — without this we'd send a CONNECT frame with a stale token
+            // that the server would reject anyway.
+            val token = sessionStateHolder.session.value?.sessionToken
+            if (token == null) {
+                Log.w(TAG, "WS opened but session vanished — closing without sending CONNECT")
+                webSocket.close(NORMAL_CLOSURE_STATUS, "No session at CONNECT time")
+                return
+            }
             webSocket.send(
                 StompFrame(
                     command = "CONNECT",
                     headers = mapOf(
                         "accept-version" to WebSocketContract.stompVersion,
                         "host" to websocketHostHeader(),
-                        "heart-beat" to "0,0"
+                        "heart-beat" to "0,0",
+                        AUTH_HEADER to "$BEARER_PREFIX$token",
                     )
                 ).serialize()
             )
@@ -214,5 +242,9 @@ class OkHttpWebSocketClient(
         private const val NORMAL_CLOSURE_STATUS = 1000
         private const val TAG = "OkHttpWebSocketClient"
         private const val GAME_ACTION_TYPE = "GAME_ACTION"
+        // Match Server #159's StompAuthChannelInterceptor expectation:
+        // accessor.getFirstNativeHeader("Authorization") + BEARER_PREFIX = "Bearer ".
+        private const val AUTH_HEADER = "Authorization"
+        private const val BEARER_PREFIX = "Bearer "
     }
 }

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -3,7 +3,12 @@ package com.machikoro.client.network.websocket
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.PlayerCoinState
+import com.machikoro.client.domain.session.Session
+import com.machikoro.client.domain.session.SessionStateHolder
 import java.io.IOException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
@@ -19,10 +24,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun connectMovesStatusToConnecting() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
 
@@ -32,10 +34,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun openSendsStompConnectFrame() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateOpen()
@@ -48,10 +47,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun connectedFrameMovesStatusToConnectedAndTriggersSubscribeAndJoin() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateOpen()
@@ -66,10 +62,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun disconnectClosesSocketAndMovesStatusToDisconnected() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateOpen()
@@ -83,10 +76,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun failureMovesStatusToError() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateFailure(IOException("boom"))
@@ -97,10 +87,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun closingMovesStatusToDisconnected() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateClosing()
@@ -112,10 +99,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun closedMovesStatusToDisconnected() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateClosed()
@@ -126,10 +110,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun secondConnectDoesNotCreateAnotherSocket() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         client.connect()
@@ -138,22 +119,11 @@ class OkHttpWebSocketClientTest {
     }
 
     @Test
-    fun disconnectWithoutActiveSocketStillUpdatesStatus() {
-        val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
-
-        client.disconnect()
-
-        assertEquals(ConnectionStatus.DISCONNECTED, client.connectionStatus.value)
-        assertFalse(factory.socket.closed)
-    }
-
-    @Test
     fun invalidUrlMovesStatusToError() {
-        val client = OkHttpWebSocketClient(websocketUrl = "not-a-url")
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "not-a-url",
+            sessionStateHolder = FakeSessionStateHolder(DEFAULT_SESSION),
+        )
 
         client.connect()
 
@@ -162,20 +132,14 @@ class OkHttpWebSocketClientTest {
 
     @Test
     fun gamePhaseStartsAsNone() {
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = FakeWebSocketFactory()
-        )
+        val client = newClient(FakeWebSocketFactory())
 
         assertEquals(GamePhase.NONE, client.gamePhase.value)
     }
 
     @Test
     fun playersStartEmpty() {
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = FakeWebSocketFactory()
-        )
+        val client = newClient(FakeWebSocketFactory())
 
         assertEquals(emptyList<PlayerCoinState>(), client.players.value)
     }
@@ -183,10 +147,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun gameActionMessageUpdatesGamePhase() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateOpen()
@@ -201,10 +162,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun gameActionMessagesAdvanceThroughAllPhases() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateOpen()
@@ -226,10 +184,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun nonGameActionMessageDoesNotChangeGamePhase() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateOpen()
@@ -244,10 +199,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun messageWithoutCoinPayloadLeavesPlayersUnchanged() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateOpen()
@@ -262,10 +214,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun malformedJsonMessageDoesNotCrashAndLeavesGamePhaseUnchanged() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateOpen()
@@ -278,10 +227,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun gameActionWithoutPayloadLeavesGamePhaseUnchanged() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateOpen()
@@ -296,10 +242,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun gameActionWithUnknownTurnPhaseLeavesGamePhaseUnchanged() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateOpen()
@@ -314,10 +257,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun gameActionWithMissingTurnPhaseLeavesGamePhaseUnchanged() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateOpen()
@@ -332,10 +272,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun disconnectResetsGamePhaseToNone() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateOpen()
@@ -353,10 +290,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun closingResetsGamePhaseToNone() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateOpen()
@@ -374,10 +308,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun closedResetsGamePhaseToNone() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateOpen()
@@ -395,10 +326,7 @@ class OkHttpWebSocketClientTest {
     @Test
     fun failureResetsGamePhaseToNone() {
         val factory = FakeWebSocketFactory()
-        val client = OkHttpWebSocketClient(
-            websocketUrl = "ws://10.0.2.2:8080/ws",
-            webSocketFactory = factory
-        )
+        val client = newClient(factory)
 
         client.connect()
         factory.simulateOpen()
@@ -482,5 +410,108 @@ class OkHttpWebSocketClientTest {
         override fun cancel() {
             closed = true
         }
+    }
+
+    private class FakeSessionStateHolder(initial: Session? = null) : SessionStateHolder {
+        private val mutableSession = MutableStateFlow(initial)
+        override val session: StateFlow<Session?> = mutableSession.asStateFlow()
+        override fun signIn(token: String, username: String) {
+            mutableSession.value = Session(token, username)
+        }
+        override fun signOut() {
+            mutableSession.value = null
+        }
+    }
+
+    private companion object {
+        const val DEFAULT_TOKEN = "test-token"
+        const val DEFAULT_USERNAME = "test-user"
+        val DEFAULT_SESSION = Session(DEFAULT_TOKEN, DEFAULT_USERNAME)
+    }
+
+    /**
+     * Construct a client with a stub session by default so existing test
+     * assertions that don't care about auth keep working.
+     */
+    private fun newClient(
+        factory: FakeWebSocketFactory,
+        sessionStateHolder: SessionStateHolder = FakeSessionStateHolder(DEFAULT_SESSION),
+    ) = OkHttpWebSocketClient(
+        websocketUrl = "ws://10.0.2.2:8080/ws",
+        sessionStateHolder = sessionStateHolder,
+        webSocketFactory = factory,
+    )
+
+    @Test
+    fun connectWithNoSessionDoesNotOpenSocketAndDoesNotTransitionStatus() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory, sessionStateHolder = FakeSessionStateHolder(initial = null))
+
+        client.connect()
+
+        assertEquals(ConnectionStatus.IDLE, client.connectionStatus.value)
+        assertEquals(0, factory.createCount)
+    }
+
+    @Test
+    fun disconnectWhenNeverConnectedIsNoOpAndDoesNotTransitionStatus() {
+        // Important for the LaunchedEffect in MainActivity: on cold start with no
+        // session, the initial collect emission is null and triggers disconnect().
+        // If disconnect() flipped status from IDLE to DISCONNECTED, the start
+        // screen would render "Connection status: disconnected" before the user
+        // has tried to connect.
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+
+        client.disconnect()
+
+        assertEquals(ConnectionStatus.IDLE, client.connectionStatus.value)
+        assertEquals(0, factory.createCount)
+    }
+
+    @Test
+    fun connectFrameIncludesAuthorizationBearerHeaderWhenSessionPresent() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+
+        client.connect()
+        factory.simulateOpen()
+
+        val connectFrame = factory.socket.sentMessages.first { it.startsWith("CONNECT\n") }
+        assertTrue(connectFrame.contains("Authorization:Bearer $DEFAULT_TOKEN"))
+    }
+
+    @Test
+    fun connectFrameUsesCurrentSessionTokenAtHandshakeTime() {
+        // Locks down "read token at onOpen, not at connect()" — if we ever capture
+        // the token at connect() time, mid-flight session changes would send the
+        // wrong header.
+        val factory = FakeWebSocketFactory()
+        val sessionHolder = FakeSessionStateHolder(initial = Session("stale-token", "alice"))
+        val client = newClient(factory, sessionStateHolder = sessionHolder)
+
+        client.connect()
+        sessionHolder.signIn(token = "fresh-token", username = "alice")
+        factory.simulateOpen()
+
+        val connectFrame = factory.socket.sentMessages.first { it.startsWith("CONNECT\n") }
+        assertTrue(connectFrame.contains("Authorization:Bearer fresh-token"))
+        assertFalse(connectFrame.contains("stale-token"))
+    }
+
+    @Test
+    fun handshakeClosesCleanlyIfSessionVanishedBetweenConnectAndOnOpen() {
+        val factory = FakeWebSocketFactory()
+        val sessionHolder = FakeSessionStateHolder(initial = DEFAULT_SESSION)
+        val client = newClient(factory, sessionStateHolder = sessionHolder)
+
+        client.connect()
+        sessionHolder.signOut()  // user logs out before WS handshake completes
+        factory.simulateOpen()
+
+        assertTrue(factory.socket.closed)
+        assertFalse(factory.socket.sentMessages.any { it.startsWith("CONNECT\n") })
+        // Belt-and-braces — there should be no Authorization header in any frame.
+        assertFalse(factory.socket.sentMessages.any { it.contains("Authorization") })
     }
 }


### PR DESCRIPTION
Closes #104. Pairs with Server PR SE2-Machi-Koro/Server#179.

⚠️ **Do not merge before Server #179 is on `main`** — the new client will send `Authorization: Bearer …` on every STOMP CONNECT, but the contract that requires it (and rejects connections that don't) is on the server side. If we merge this first, nothing breaks (the header just gets ignored), but the auth flow remains insecure. The natural deploy order is: Server #179 lands → Client #104 lands.

## Summary
- `OkHttpWebSocketClient` now takes a `SessionStateHolder` constructor argument and is auth-aware.
- The CONNECT frame includes `Authorization: Bearer <token>` as a STOMP native header — exactly matching Server #179's `accessor.getFirstNativeHeader("Authorization")` + `BEARER_PREFIX = "Bearer "` contract.
- The token is read inside `onOpen`, not at `connect()` time, so a logout during the WS handshake doesn't ship a stale token.
- `connect()` short-circuits when there's no session — no socket opened, no status transition. The strict-reject server would reject anonymous CONNECT anyway; this avoids the misleading "connection error" the user would otherwise see when they simply aren't logged in yet.
- `disconnect()` is now truly idempotent (no-op when there was no socket). Without this, the new `LaunchedEffect` (commit 2) would flip status from `IDLE` to `DISCONNECTED` on every cold-start with no session.
- `MainActivity` reacts to login/logout while foregrounded via a `LaunchedEffect` collecting `SessionManager.session` and calling `connect()` / `disconnect()` accordingly. Activity-lifecycle behaviour (`onStart` / `onStop`) is unchanged.

## Header contract
`Authorization: Bearer <session-token>` as a STOMP native header on the CONNECT frame. Spelled out as constants on both sides:
- Client: `OkHttpWebSocketClient.AUTH_HEADER` + `BEARER_PREFIX`.
- Server: `StompAuthChannelInterceptor.AUTH_HEADER` + `BEARER_PREFIX`.

## What's intentional
- **Strict-reject parity with Server #179.** No anonymous WS connections — if there's no session, we don't even open the socket. Aligns the client UX with the server's behaviour: no fake "connection error" before login, no doomed handshake attempt.
- **Token read at `onOpen`, not at `connect()`.** Tested explicitly (`connectFrameUsesCurrentSessionTokenAtHandshakeTime`).
- **Vanished-session-during-handshake closes cleanly.** Tested (`handshakeClosesCleanlyIfSessionVanishedBetweenConnectAndOnOpen`).
- **No changes to the `WebSocketClient` interface.** Auth concern stays impl-internal; ViewModels and tests that mock the interface are unaffected.

## Out of scope
- **Token persistence across cold-starts** — Client #105.
- **Auth-rejection UX** (force-logout when server rejects mid-session) — Client #106.
- **Refresh tokens / token rotation** — server doesn't expire tokens yet.
- **Narrow login/logout/login race during the WS-close window** — described in self-review; the obvious fix (clear socket synchronously after vanished-session close) creates a worse problem (late `onClosed` clobbering a fresh CONNECT's status). Properly handling this needs a closing-generation counter that ignores callbacks from abandoned sockets. File a follow-up if ever observed in production.

## Test plan
- [x] `./gradlew :app:compileDebugKotlin :app:compileDebugUnitTestKotlin --warning-mode all` — clean, no warnings, no deprecation notes.
- [x] `./gradlew :app:testDebugUnitTest` — all unit tests pass: 4 new auth-header tests, 1 new idempotent-disconnect test, all existing tests green via the `newClient(...)` helper.
- [x] `./gradlew :app:jacocoTestCoverageVerification` — 80% coverage gate satisfied.
- [x] `./gradlew :app:lintDebug` — Android Lint passes.
- [x] **Manual end-to-end** against Server PR #179's branch:
  - Run server on Server branch `159-websocket-auth-principal` (or `main` once #179 merges).
  - Run client on this branch from Android Studio.
  - **Cold launch, no login** → no WS connect, "Connection status: idle" stays.
  - **Login** → WS connects, server log: `WS CONNECT accepted for user '<x>'`. Status flips to `CONNECTED`.
  - **Logout** → WS disconnects, status flips to `DISCONNECTED`.
  - **Re-login** → WS reconnects with the new token (verify in pgAdmin: `users.session_token` is the new UUID).
  - **Background → foreground** while logged in: status briefly drops to `DISCONNECTED` then back to `CONNECTED`.

## Heads-up for reviewers
- The old test `disconnectWithoutActiveSocketStillUpdatesStatus` was deleted — it asserted the *opposite* of the new idempotent contract. Replaced by `disconnectWhenNeverConnectedIsNoOpAndDoesNotTransitionStatus` with an explanatory comment.
- The Client #104 issue body still says *"skip the auth header when the session is null"* — that's stale per Server #179's strict-reject design. I'll update the issue body after this PR opens (deferred so the URL in the description above stays valid).

## Commit split (2)
1. `feat: #104 add SessionStateHolder to OkHttpWebSocketClient and Authorization header` — pure client-layer change. Constructor + auth header + token-at-onOpen + idempotent disconnect + 5 new tests + `MainActivity` constructor wiring. Compiles + tests pass independently.
2. `feat: #104 drive WebSocket lifecycle from SessionManager session changes` — `MainActivity` `LaunchedEffect`. Adds the foreground reactive transitions on top of the existing activity-lifecycle path.