### PR TITLE
refactor start screen viewmodel

### DIFF
--- a/app/src/androidTest/java/com/machikoro/client/ui/start/StartScreenAuthStateTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/start/StartScreenAuthStateTest.kt
@@ -1,13 +1,17 @@
 package com.machikoro.client.ui.start
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import com.machikoro.client.domain.model.state.LoginDialogState
 import com.machikoro.client.domain.model.state.LogoutState
 import com.machikoro.client.domain.model.state.RegisterDialogState
 import com.machikoro.client.domain.model.state.StartScreenState
 import com.machikoro.client.ui.theme.ClientTheme
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -69,5 +73,123 @@ class StartScreenAuthStateTest {
         composeTestRule.onNodeWithText("Logout").assertIsDisplayed()
         composeTestRule.onNodeWithText("Register").assertDoesNotExist()
         composeTestRule.onNodeWithText("Login").assertDoesNotExist()
+    }
+
+    @Test
+    fun hostButtonIsShownAndEnabledWithTwoOrMorePlayers() {
+        composeTestRule.setContent {
+            ClientTheme {
+                StartScreen(
+                    state = StartScreenState.placeholder().copy(
+                        isHost = true,
+                        playerList = listOf("alice", "bob"),
+                    ),
+                    registerDialogState = RegisterDialogState(),
+                    loginDialogState = LoginDialogState(),
+                    logoutState = LogoutState(),
+                    onRegisterUsernameChange = {},
+                    onRegisterPasswordChange = {},
+                    onRegisterSubmit = {},
+                    onRegisterDialogReset = {},
+                    onLoginUsernameChange = {},
+                    onLoginPasswordChange = {},
+                    onLoginSubmit = {},
+                    onLoginDialogReset = {},
+                    onLogoutSubmit = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Start Game").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Start Game").assertIsEnabled()
+    }
+
+    @Test
+    fun hostButtonIsShownButDisabledWithOnlyOnePlayer() {
+        composeTestRule.setContent {
+            ClientTheme {
+                StartScreen(
+                    state = StartScreenState.placeholder().copy(
+                        isHost = true,
+                        playerList = listOf("alice"),
+                    ),
+                    registerDialogState = RegisterDialogState(),
+                    loginDialogState = LoginDialogState(),
+                    logoutState = LogoutState(),
+                    onRegisterUsernameChange = {},
+                    onRegisterPasswordChange = {},
+                    onRegisterSubmit = {},
+                    onRegisterDialogReset = {},
+                    onLoginUsernameChange = {},
+                    onLoginPasswordChange = {},
+                    onLoginSubmit = {},
+                    onLoginDialogReset = {},
+                    onLogoutSubmit = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Start Game").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Start Game").assertIsNotEnabled()
+    }
+
+    @Test
+    fun hostButtonIsHiddenWhenNotHost() {
+        composeTestRule.setContent {
+            ClientTheme {
+                StartScreen(
+                    state = StartScreenState.placeholder().copy(
+                        isHost = false,
+                        playerList = listOf("alice", "bob"),
+                    ),
+                    registerDialogState = RegisterDialogState(),
+                    loginDialogState = LoginDialogState(),
+                    logoutState = LogoutState(),
+                    onRegisterUsernameChange = {},
+                    onRegisterPasswordChange = {},
+                    onRegisterSubmit = {},
+                    onRegisterDialogReset = {},
+                    onLoginUsernameChange = {},
+                    onLoginPasswordChange = {},
+                    onLoginSubmit = {},
+                    onLoginDialogReset = {},
+                    onLogoutSubmit = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Start Game").assertDoesNotExist()
+    }
+
+    @Test
+    fun clickingEnabledHostButtonInvokesOnStartGame() {
+        var startGameCalled = false
+        composeTestRule.setContent {
+            ClientTheme {
+                StartScreen(
+                    state = StartScreenState.placeholder().copy(
+                        isHost = true,
+                        playerList = listOf("alice", "bob"),
+                    ),
+                    registerDialogState = RegisterDialogState(),
+                    loginDialogState = LoginDialogState(),
+                    logoutState = LogoutState(),
+                    onRegisterUsernameChange = {},
+                    onRegisterPasswordChange = {},
+                    onRegisterSubmit = {},
+                    onRegisterDialogReset = {},
+                    onLoginUsernameChange = {},
+                    onLoginPasswordChange = {},
+                    onLoginSubmit = {},
+                    onLoginDialogReset = {},
+                    onLogoutSubmit = {},
+                    onStartGame = { startGameCalled = true },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("Start Game").performClick()
+
+        assertTrue(startGameCalled)
     }
 }

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -73,6 +73,25 @@ class OkHttpWebSocketClient(
         resetGameState()
     }
 
+    override fun sendGameStart() {
+        val socket = synchronized(this) { webSocket }
+        if (socket == null) {
+            Log.w(TAG, "sendGameStart called but no active WebSocket connection")
+            return
+        }
+        socket.send(
+            StompFrame(
+                command = "SEND",
+                headers = mapOf(
+                    "destination" to WebSocketContract.gameStartDestination,
+                    "content-type" to "application/json"
+                ),
+                body = GAME_START_BODY
+            ).serialize()
+        )
+        Log.d(TAG, "Game start message sent")
+    }
+
     private val listener = object : WebSocketListener() {
         override fun onOpen(webSocket: WebSocket, response: Response) {
             Log.d(TAG, "WebSocket opened: ${response.code} ${response.message}")
@@ -214,5 +233,7 @@ class OkHttpWebSocketClient(
         private const val NORMAL_CLOSURE_STATUS = 1000
         private const val TAG = "OkHttpWebSocketClient"
         private const val GAME_ACTION_TYPE = "GAME_ACTION"
+        private const val GAME_START_BODY =
+            """{"type":"START","sender":"${WebSocketContract.defaultSender}"}"""
     }
 }

--- a/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
@@ -16,4 +16,6 @@ interface WebSocketClient {
     fun connect()
 
     fun disconnect()
+
+    fun sendGameStart()
 }

--- a/app/src/main/java/com/machikoro/client/network/websocket/WebSocketContract.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WebSocketContract.kt
@@ -10,5 +10,6 @@ object WebSocketContract {
     const val errorQueue: String = "/queue/errors"
     const val addUserDestination: String = "/app/chat.addUser"
     const val chatSendDestination: String = "/app/chat.send"
+    const val gameStartDestination: String = "/app/game.start"
     const val defaultSender: String = "android-client"
 }

--- a/app/src/main/java/com/machikoro/client/ui/start/StartScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/StartScreenViewModel.kt
@@ -36,10 +36,17 @@ class StartScreenViewModel(
                 }
             }
         }
+        viewModelScope.launch {
+            webSocketClient.players.collect { players ->
+                mutableState.update { current ->
+                    current.copy(playerList = players.map { it.displayName })
+                }
+            }
+        }
     }
 
     fun onStartGame() {
-        // TODO: Implement game start logic (e.g., send start message via webSocketClient)
+        webSocketClient.sendGameStart()
     }
 
     class Factory(

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -413,6 +413,40 @@ class OkHttpWebSocketClientTest {
         assertEquals(GamePhase.NONE, client.gamePhase.value)
     }
 
+    @Test
+    fun sendGameStartSendsStompFrameToGameStartDestination() {
+        val factory = FakeWebSocketFactory()
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "ws://10.0.2.2:8080/ws",
+            webSocketFactory = factory
+        )
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
+        client.sendGameStart()
+
+        assertTrue(
+            factory.socket.sentMessages.any {
+                it.startsWith("SEND\n") && it.contains("destination:/app/game.start")
+            }
+        )
+    }
+
+    @Test
+    fun sendGameStartWithoutConnectionIsIgnored() {
+        val factory = FakeWebSocketFactory()
+        val client = OkHttpWebSocketClient(
+            websocketUrl = "ws://10.0.2.2:8080/ws",
+            webSocketFactory = factory
+        )
+
+        // No connect() call — should not throw
+        client.sendGameStart()
+
+        assertTrue(factory.socket.sentMessages.isEmpty())
+    }
+
     private fun gameActionFrame(body: String): String =
         "MESSAGE\ndestination:/topic/public\ncontent-type:application/json\n\n$body\u0000"
 

--- a/app/src/test/java/com/machikoro/client/ui/start/StartScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/start/StartScreenViewModelTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -65,6 +66,41 @@ class StartScreenViewModelTest {
         assertNull(viewModel.state.value.loggedInAs)
     }
 
+    @Test
+    fun playersFlowUpdatesPlayerList() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = StartScreenViewModel(fakeClient, FakeSessionStateHolder())
+
+        fakeClient.emitPlayers(
+            listOf(
+                PlayerCoinState(id = "1", displayName = "alice", coins = 3),
+                PlayerCoinState(id = "2", displayName = "bob", coins = 5),
+            )
+        )
+        advanceUntilIdle()
+
+        assertEquals(listOf("alice", "bob"), viewModel.state.value.playerList)
+    }
+
+    @Test
+    fun playerListIsEmptyInitially() = runTest {
+        val viewModel = StartScreenViewModel(FakeWebSocketClient(), FakeSessionStateHolder())
+
+        advanceUntilIdle()
+
+        assertEquals(emptyList<String>(), viewModel.state.value.playerList)
+    }
+
+    @Test
+    fun onStartGameDelegatesToWebSocketClient() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = StartScreenViewModel(fakeClient, FakeSessionStateHolder())
+
+        viewModel.onStartGame()
+
+        assertTrue(fakeClient.gameStartSent)
+    }
+
     private class FakeWebSocketClient : WebSocketClient {
         override val connectionStatus: StateFlow<ConnectionStatus>
             get() = mutableConnectionStatus
@@ -79,12 +115,22 @@ class StartScreenViewModelTest {
         private val mutableGamePhase = MutableStateFlow(GamePhase.NONE)
         private val mutablePlayers = MutableStateFlow<List<PlayerCoinState>>(emptyList())
 
+        var gameStartSent = false
+
         override fun connect() = Unit
 
         override fun disconnect() = Unit
 
+        override fun sendGameStart() {
+            gameStartSent = true
+        }
+
         fun emit(status: ConnectionStatus) {
             mutableConnectionStatus.value = status
+        }
+
+        fun emitPlayers(players: List<PlayerCoinState>) {
+            mutablePlayers.value = players
         }
     }
 


### PR DESCRIPTION
This pull request adds support for starting a game from the lobby, including UI updates and backend integration, and refactors the start screen to better handle player and host state. It also introduces comprehensive UI tests for the new lobby controls and host functionality.

**Lobby Start Game Feature & UI Refactor:**

* Added `playerList`, `maxPlayers`, and `isHost` fields to `StartScreenState` to track lobby state and host status.
* Refactored `StartScreen` UI: introduced a `LobbyControls` composable to display players, connection status, and show a "Start Game" button for the host when appropriate. The button is enabled only if there are two or more players. [[1]](diffhunk://#diff-93feed1a8970c83e8f82a9a1a87d0e6736b62c0c5f9b1828d771349dd69ad84eL64-R141) [[2]](diffhunk://#diff-93feed1a8970c83e8f82a9a1a87d0e6736b62c0c5f9b1828d771349dd69ad84eL90-R182) [[3]](diffhunk://#diff-93feed1a8970c83e8f82a9a1a87d0e6736b62c0c5f9b1828d771349dd69ad84eL142-R195)
* Updated the main activity and root composable to pass the new props and handle the `onStartGame` event. [[1]](diffhunk://#diff-4dba311452be4a540f0c2b3f6aa33851a156b8ad2ceefcf6c7993c5092614936R75) [[2]](diffhunk://#diff-328ff481d738669b9bf3acb6e09ae20ea09ae0ef6a7c15d821464591888829d4R32) [[3]](diffhunk://#diff-328ff481d738669b9bf3acb6e09ae20ea09ae0ef6a7c15d821464591888829d4R52)
* Changed the app title in the test to match the new UI ("MACHI KORO").

**Backend Integration for Game Start:**

* Added a `sendGameStart` method to `WebSocketClient` and implemented it in `OkHttpWebSocketClient`, sending a STOMP message to the backend to start the game. [[1]](diffhunk://#diff-d6d8917d99ab3b9f11910f77673ec4a8b4bf3833e560455a827f81fbbaf8ca42R19-R20) [[2]](diffhunk://#diff-d3f8770213fd899d18bbeb364ee729e6cc8ab61b04669306bf7c16d0c25469ddR76-R94) [[3]](diffhunk://#diff-d3f8770213fd899d18bbeb364ee729e6cc8ab61b04669306bf7c16d0c25469ddR236-R237) [[4]](diffhunk://#diff-fff146b520730157b64b335c0b57699d3965d8bd9a510a414ca08acd651a08cfR13)

**Testing Improvements:**

* Added comprehensive UI tests for the lobby controls, including visibility and enabled state of the "Start Game" button depending on host status and player count, and verifying that clicking the button triggers the correct callback.

**Other Minor Updates:**

* Cleaned up imports and factored out background/title UI elements for improved code organization. [[1]](diffhunk://#diff-93feed1a8970c83e8f82a9a1a87d0e6736b62c0c5f9b1828d771349dd69ad84eR2-R6) [[2]](diffhunk://#diff-93feed1a8970c83e8f82a9a1a87d0e6736b62c0c5f9b1828d771349dd69ad84eL22-R27) [[3]](diffhunk://#diff-93feed1a8970c83e8f82a9a1a87d0e6736b62c0c5f9b1828d771349dd69ad84eL34) [[4]](diffhunk://#diff-93feed1a8970c83e8f82a9a1a87d0e6736b62c0c5f9b1828d771349dd69ad84eR52-L53)

These changes collectively enable the host to start a game from the lobby, improve the clarity and maintainability of the start screen, and ensure the new functionality is well-tested.