### PR TITLE
Restore Register and Login buttons on StartScreen

### DIFF
--- a/app/src/androidTest/java/com/machikoro/client/ui/AppRootTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/AppRootTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.GameScreenState
+import com.machikoro.client.domain.model.state.LobbyScreenState
 import com.machikoro.client.domain.model.state.LoginDialogState
 import com.machikoro.client.domain.model.state.LogoutState
 import com.machikoro.client.domain.model.state.RegisterDialogState
@@ -42,6 +43,13 @@ class AppRootTest {
                     onLoginSubmit = {},
                     onLoginDialogReset = {},
                     onLogoutSubmit = {},
+                    lobbyScreenState = LobbyScreenState.placeholder(),
+                    lobbyCode = null,
+                    loggedInAs = null,
+                    onCreateLobbyClick = {},
+                    onReadyToggle = {},
+                    onStartGame = {},
+                    onLeaveLobby = {},
                 )
             }
         }
@@ -69,6 +77,13 @@ class AppRootTest {
                     onLoginSubmit = {},
                     onLoginDialogReset = {},
                     onLogoutSubmit = {},
+                    lobbyScreenState = LobbyScreenState.placeholder(),
+                    lobbyCode = null,
+                    loggedInAs = null,
+                    onCreateLobbyClick = {},
+                    onReadyToggle = {},
+                    onStartGame = {},
+                    onLeaveLobby = {},
                 )
             }
         }
@@ -97,6 +112,13 @@ class AppRootTest {
                     onLoginSubmit = {},
                     onLoginDialogReset = {},
                     onLogoutSubmit = {},
+                    lobbyScreenState = LobbyScreenState.placeholder(),
+                    lobbyCode = null,
+                    loggedInAs = null,
+                    onCreateLobbyClick = {},
+                    onReadyToggle = {},
+                    onStartGame = {},
+                    onLeaveLobby = {},
                 )
             }
         }

--- a/app/src/androidTest/java/com/machikoro/client/ui/start/StartScreenAuthStateTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/start/StartScreenAuthStateTest.kt
@@ -1,17 +1,13 @@
 package com.machikoro.client.ui.start
 
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsEnabled
-import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
-import androidx.compose.ui.test.performClick
 import com.machikoro.client.domain.model.state.LoginDialogState
 import com.machikoro.client.domain.model.state.LogoutState
 import com.machikoro.client.domain.model.state.RegisterDialogState
 import com.machikoro.client.domain.model.state.StartScreenState
 import com.machikoro.client.ui.theme.ClientTheme
-import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -45,151 +41,5 @@ class StartScreenAuthStateTest {
         composeTestRule.onNodeWithText("Login").assertIsDisplayed()
         composeTestRule.onNodeWithText("Logout").assertDoesNotExist()
         composeTestRule.onNodeWithText("Logged in as alice").assertDoesNotExist()
-    }
-
-    @Test
-    fun authenticatedShowsLoggedInBannerAndLogoutAndHidesRegisterAndLogin() {
-        composeTestRule.setContent {
-            ClientTheme {
-                StartScreen(
-                    state = StartScreenState.placeholder().copy(loggedInAs = "alice"),
-                    registerDialogState = RegisterDialogState(),
-                    loginDialogState = LoginDialogState(),
-                    logoutState = LogoutState(),
-                    onRegisterUsernameChange = {},
-                    onRegisterPasswordChange = {},
-                    onRegisterSubmit = {},
-                    onRegisterDialogReset = {},
-                    onLoginUsernameChange = {},
-                    onLoginPasswordChange = {},
-                    onLoginSubmit = {},
-                    onLoginDialogReset = {},
-                    onLogoutSubmit = {},
-                )
-            }
-        }
-
-        composeTestRule.onNodeWithText("Logged in as alice").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Logout").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Register").assertDoesNotExist()
-        composeTestRule.onNodeWithText("Login").assertDoesNotExist()
-    }
-
-    @Test
-    fun hostButtonIsShownAndEnabledWithTwoOrMorePlayers() {
-        composeTestRule.setContent {
-            ClientTheme {
-                StartScreen(
-                    state = StartScreenState.placeholder().copy(
-                        isHost = true,
-                        playerList = listOf("alice", "bob"),
-                    ),
-                    registerDialogState = RegisterDialogState(),
-                    loginDialogState = LoginDialogState(),
-                    logoutState = LogoutState(),
-                    onRegisterUsernameChange = {},
-                    onRegisterPasswordChange = {},
-                    onRegisterSubmit = {},
-                    onRegisterDialogReset = {},
-                    onLoginUsernameChange = {},
-                    onLoginPasswordChange = {},
-                    onLoginSubmit = {},
-                    onLoginDialogReset = {},
-                    onLogoutSubmit = {},
-                )
-            }
-        }
-
-        composeTestRule.onNodeWithText("Start Game").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Start Game").assertIsEnabled()
-    }
-
-    @Test
-    fun hostButtonIsShownButDisabledWithOnlyOnePlayer() {
-        composeTestRule.setContent {
-            ClientTheme {
-                StartScreen(
-                    state = StartScreenState.placeholder().copy(
-                        isHost = true,
-                        playerList = listOf("alice"),
-                    ),
-                    registerDialogState = RegisterDialogState(),
-                    loginDialogState = LoginDialogState(),
-                    logoutState = LogoutState(),
-                    onRegisterUsernameChange = {},
-                    onRegisterPasswordChange = {},
-                    onRegisterSubmit = {},
-                    onRegisterDialogReset = {},
-                    onLoginUsernameChange = {},
-                    onLoginPasswordChange = {},
-                    onLoginSubmit = {},
-                    onLoginDialogReset = {},
-                    onLogoutSubmit = {},
-                )
-            }
-        }
-
-        composeTestRule.onNodeWithText("Start Game").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Start Game").assertIsNotEnabled()
-    }
-
-    @Test
-    fun hostButtonIsHiddenWhenNotHost() {
-        composeTestRule.setContent {
-            ClientTheme {
-                StartScreen(
-                    state = StartScreenState.placeholder().copy(
-                        isHost = false,
-                        playerList = listOf("alice", "bob"),
-                    ),
-                    registerDialogState = RegisterDialogState(),
-                    loginDialogState = LoginDialogState(),
-                    logoutState = LogoutState(),
-                    onRegisterUsernameChange = {},
-                    onRegisterPasswordChange = {},
-                    onRegisterSubmit = {},
-                    onRegisterDialogReset = {},
-                    onLoginUsernameChange = {},
-                    onLoginPasswordChange = {},
-                    onLoginSubmit = {},
-                    onLoginDialogReset = {},
-                    onLogoutSubmit = {},
-                )
-            }
-        }
-
-        composeTestRule.onNodeWithText("Start Game").assertDoesNotExist()
-    }
-
-    @Test
-    fun clickingEnabledHostButtonInvokesOnStartGame() {
-        var startGameCalled = false
-        composeTestRule.setContent {
-            ClientTheme {
-                StartScreen(
-                    state = StartScreenState.placeholder().copy(
-                        isHost = true,
-                        playerList = listOf("alice", "bob"),
-                    ),
-                    registerDialogState = RegisterDialogState(),
-                    loginDialogState = LoginDialogState(),
-                    logoutState = LogoutState(),
-                    onRegisterUsernameChange = {},
-                    onRegisterPasswordChange = {},
-                    onRegisterSubmit = {},
-                    onRegisterDialogReset = {},
-                    onLoginUsernameChange = {},
-                    onLoginPasswordChange = {},
-                    onLoginSubmit = {},
-                    onLoginDialogReset = {},
-                    onLogoutSubmit = {},
-                    onStartGame = { startGameCalled = true },
-                )
-            }
-        }
-
-        composeTestRule.onNodeWithText("Start Game").performClick()
-
-        assertTrue(startGameCalled)
     }
 }

--- a/app/src/main/java/com/machikoro/client/ui/start/StartScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/StartScreen.kt
@@ -1,8 +1,10 @@
 package com.machikoro.client.ui.start
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -72,6 +74,23 @@ fun StartScreen(
                     .align(Alignment.TopEnd)
                     .padding(top = 16.dp, end = 16.dp),
             )
+
+            Column(
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(16.dp),
+            ) {
+                SecondaryActionButton(
+                    text = "Register",
+                    onClick = { showRegisterDialog = true },
+                )
+                SecondaryActionButton(
+                    text = "Login",
+                    onClick = { showLoginDialog = true },
+                )
+            }
 
             if (showRegisterDialog) {
                 RegisterDialog(


### PR DESCRIPTION
## Summary
The Register and Login buttons disappeared from `StartScreen` after #125 merged. An unauthenticated user only sees the title and the Rules button — the dialog state vars (`showRegisterDialog`, `showLoginDialog`) are still on the screen but nothing flips them to `true` anymore, so the dialogs are unreachable.

This restores both buttons as a centered Column using the existing `SecondaryActionButton` style, wired to the dialog state that's already in place.

## Root cause
PR #125's `cleanup: remove commented-out code` commit deleted the button blocks (which had been commented out earlier in the lobby refactor) but left the orphaned dialog scaffolding behind.

## Also fixed in this PR
`androidTest` compilation has been broken on `main` since #125 merged. Two files needed updates:

- **`AppRootTest`** — pass the new required parameters that #125 added to `AppRoot` (`lobbyScreenState`, `lobbyCode`, `loggedInAs`, `onCreateLobbyClick`, `onReadyToggle`, `onStartGame`, `onLeaveLobby`). All three test cases were missing them.
- **`StartScreenAuthStateTest`** — drop the stale cases that referenced removed `StartScreenState.isHost`/`.playerList` and the removed `onStartGame` parameter on `StartScreen`. That host-gating moved to `LobbyScreen` with #125 and is covered there. The authenticated-state cases at the `StartScreen` level are also obsolete now that auth-based routing is `AppRoot`'s responsibility.

The kept test (`unauthenticatedShowsRegisterAndLoginAndHidesLoggedInBanner`) now compiles and asserts against the restored buttons — closing the loop on what would have caught this regression.

## Test plan
- [x] `./gradlew :app:assembleDebug` — APK builds
- [x] `./gradlew :app:testDebugUnitTest` — green
- [x] `./gradlew :app:lintDebug` — 0 errors
- [x] `./gradlew :app:compileDebugAndroidTestKotlin` — green (was broken on `main`)
- [ ] Manual: launch on emulator, confirm Register and Login buttons are visible and tapping them opens the respective dialogs