### PR TITLE
feat: keep user on home screen after lobby creation

### DIFF
--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -43,20 +43,14 @@ fun AppRoot(
 ) {
     if (gameScreenState.gamePhase != GamePhase.NONE) {
         GameScreen(state = gameScreenState, modifier = modifier)
-    } else if (lobbyCode != null) {
-        LobbyScreen(
-            state = lobbyScreenState,
-            onReadyToggle = onReadyToggle,
-            onStartGame = onStartGame,
-            onLeaveLobby = onLeaveLobby,
-            modifier = modifier
-        )
+
     } else if (loggedInAs != null) {
         HomeScreen(
             lobbyCode = lobbyCode,
             onCreateLobbyClick = onCreateLobbyClick,
             modifier = modifier
         )
+
     } else {
         StartScreen(
             state = startScreenState,


### PR DESCRIPTION
Updated the lobby creation flow on the client side.

Previously, the app navigated directly to the LobbyScreen immediately after a lobby was created. This prevented the generated lobby code from being displayed on the HomeScreen.

Changes:

* Kept the user on the HomeScreen after successful lobby creation
* Displayed the generated lobby code directly below the "Lobby erstellen" button
* Prepared the flow for future navigation via the confirmation/check button instead of automatic screen switching
