### PR TITLE
Gate lobby/game UI on authenticated state

### DIFF
--- a/app/src/androidTest/java/com/machikoro/client/ui/AppRootTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/AppRootTest.kt
@@ -19,6 +19,12 @@ import org.junit.Rule
 import org.junit.Test
 
 private const val START_SCREEN_TITLE = "MACHI KORO"
+// HomeScreen-specific labels — distinguish HomeScreen from StartScreen, which
+// shares the "MACHI KORO" title.
+private const val HOME_SCREEN_LOBBY_CARD = "Lobby beitreten"
+private const val HOME_SCREEN_LOGOUT = "Abmelden"
+private const val START_SCREEN_LOGIN = "Login"
+private const val START_SCREEN_REGISTER = "Register"
 
 class AppRootTest {
     @get:Rule
@@ -90,6 +96,56 @@ class AppRootTest {
 
         composeTestRule.onNodeWithText(GamePhase.ROLL_DICE.toDisplayText()).assertIsDisplayed()
         composeTestRule.onNodeWithText(START_SCREEN_TITLE).assertDoesNotExist()
+    }
+
+    @Test
+    fun showsStartScreenWhenUnauthenticated() {
+        setAppRoot(loggedInAs = null)
+
+        composeTestRule.onNodeWithText(START_SCREEN_REGISTER).assertIsDisplayed()
+        composeTestRule.onNodeWithText(START_SCREEN_LOGIN).assertIsDisplayed()
+        composeTestRule.onNodeWithText(HOME_SCREEN_LOGOUT).assertDoesNotExist()
+        composeTestRule.onNodeWithText(HOME_SCREEN_LOBBY_CARD).assertDoesNotExist()
+    }
+
+    @Test
+    fun showsHomeScreenWhenAuthenticated() {
+        setAppRoot(loggedInAs = "alice")
+
+        composeTestRule.onNodeWithText(HOME_SCREEN_LOBBY_CARD).assertIsDisplayed()
+        composeTestRule.onNodeWithText(HOME_SCREEN_LOGOUT).assertIsDisplayed()
+        composeTestRule.onNodeWithText(START_SCREEN_REGISTER).assertDoesNotExist()
+        composeTestRule.onNodeWithText(START_SCREEN_LOGIN).assertDoesNotExist()
+    }
+
+    private fun setAppRoot(loggedInAs: String?) {
+        composeTestRule.setContent {
+            ClientTheme {
+                AppRoot(
+                    gameScreenState = GameScreenState.initial(),
+                    startScreenState = StartScreenState.placeholder().copy(loggedInAs = loggedInAs),
+                    registerDialogState = RegisterDialogState(),
+                    loginDialogState = LoginDialogState(),
+                    logoutState = LogoutState(),
+                    onRegisterUsernameChange = {},
+                    onRegisterPasswordChange = {},
+                    onRegisterSubmit = {},
+                    onRegisterDialogReset = {},
+                    onLoginUsernameChange = {},
+                    onLoginPasswordChange = {},
+                    onLoginSubmit = {},
+                    onLoginDialogReset = {},
+                    onLogoutSubmit = {},
+                    lobbyScreenState = LobbyScreenState.placeholder(),
+                    lobbyCode = null,
+                    loggedInAs = loggedInAs,
+                    onCreateLobbyClick = {},
+                    onReadyToggle = {},
+                    onStartGame = {},
+                    onLeaveLobby = {},
+                )
+            }
+        }
     }
 
     @Test

--- a/app/src/androidTest/java/com/machikoro/client/ui/home/HomeScreenLogoutTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/home/HomeScreenLogoutTest.kt
@@ -1,0 +1,40 @@
+package com.machikoro.client.ui.home
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.machikoro.client.ui.theme.ClientTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class HomeScreenLogoutTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun showsLogoutButton() {
+        composeTestRule.setContent {
+            ClientTheme {
+                HomeScreen()
+            }
+        }
+
+        composeTestRule.onNodeWithText("Abmelden").assertIsDisplayed()
+    }
+
+    @Test
+    fun clickingLogoutInvokesCallback() {
+        var clicks = 0
+        composeTestRule.setContent {
+            ClientTheme {
+                HomeScreen(onLogoutClick = { clicks += 1 })
+            }
+        }
+
+        composeTestRule.onNodeWithText("Abmelden").performClick()
+
+        assertEquals(1, clicks)
+    }
+}

--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -95,13 +95,14 @@ class MainActivity : ComponentActivity() {
             }
 
             // Server #159 contract: STOMP CONNECT with a missing/expired token
-            // produces a STOMP ERROR frame. The transport layer surfaces that
-            // as `authRejections`; clearing the local session here keeps the
-            // policy decision in the UI layer rather than baking signOut into
-            // the network client.
+            // produces a STOMP ERROR frame, which OkHttpWebSocketClient handles
+            // by calling SessionManager.signOut() directly (durable side-effect
+            // that survives activity recreation). The snackbar below is the
+            // UI-only counterpart and is miss-tolerant: if the activity isn't
+            // attached when the event fires, the user is still signed out — we
+            // just skip the toast for that emission.
             LaunchedEffect(Unit) {
                 webSocketClient.authRejections.collect {
-                    SessionManager.signOut()
                     snackbarHostState.showSnackbar(
                         "Sitzung abgelaufen, bitte erneut anmelden"
                     )

--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -8,9 +8,12 @@ import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.lifecycleScope
 import com.machikoro.client.config.AppConfig
@@ -75,6 +78,8 @@ class MainActivity : ComponentActivity() {
             val loginDialogState by loginDialogViewModel.state.collectAsState()
             val logoutState by logoutViewModel.state.collectAsState()
 
+            val snackbarHostState = remember { SnackbarHostState() }
+
             // Drive WebSocket lifecycle from session changes during the foreground.
             // onStart/onStop handle the activity-lifecycle case; this handles the
             // user-logs-in-or-out-while-app-is-open case. connect() and disconnect()
@@ -89,8 +94,25 @@ class MainActivity : ComponentActivity() {
                 }
             }
 
+            // Server #159 contract: STOMP CONNECT with a missing/expired token
+            // produces a STOMP ERROR frame. The transport layer surfaces that
+            // as `authRejections`; clearing the local session here keeps the
+            // policy decision in the UI layer rather than baking signOut into
+            // the network client.
+            LaunchedEffect(Unit) {
+                webSocketClient.authRejections.collect {
+                    SessionManager.signOut()
+                    snackbarHostState.showSnackbar(
+                        "Sitzung abgelaufen, bitte erneut anmelden"
+                    )
+                }
+            }
+
             ClientTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
+                Scaffold(
+                    modifier = Modifier.fillMaxSize(),
+                    snackbarHost = { SnackbarHost(snackbarHostState) },
+                ) { innerPadding ->
                     AppRoot(
                         gameScreenState = gameScreenState,
                         startScreenState = startScreenState,

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -6,8 +6,12 @@ import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.PlayerCoinState
 import com.machikoro.client.domain.session.SessionStateHolder
 import java.net.URI
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import okhttp3.Request
 import okhttp3.Response
@@ -33,10 +37,20 @@ class OkHttpWebSocketClient(
     override val lobbyCode: StateFlow<String?> // Internal state for the latest lobby code returned by the backend
         get() = mutableLobbyCode.asStateFlow()
 
+    override val authRejections: SharedFlow<Unit>
+        get() = mutableAuthRejections.asSharedFlow()
+
     private val mutableConnectionStatus = MutableStateFlow(ConnectionStatus.IDLE)
     private val mutableGamePhase = MutableStateFlow(GamePhase.NONE)
     private val mutablePlayers = MutableStateFlow<List<PlayerCoinState>>(emptyList())
     private val mutableLobbyCode = MutableStateFlow<String?>(null) // Exposes lobby code as read-only StateFlow to UI/ViewModels
+    // Buffer 1 + DROP_OLDEST so tryEmit never fails on the OkHttp listener
+    // thread when nobody is collecting yet (e.g. emission during startup
+    // before MainActivity wires its collector).
+    private val mutableAuthRejections = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
     private val frameBuffer = StringBuilder()
 
     @Volatile
@@ -215,7 +229,20 @@ class OkHttpWebSocketClient(
 
             "ERROR" -> {
                 Log.e(TAG, "STOMP error frame received: ${frame.body}")
-                mutableConnectionStatus.value = ConnectionStatus.ERROR
+                if (isAuthRejection(frame.body)) {
+                    // Server rejected the CONNECT for auth reasons (#159 path):
+                    // missing/malformed/unrecognised token. The connection will
+                    // be closed by the server; flip to DISCONNECTED rather than
+                    // ERROR because this is a recoverable, user-actionable
+                    // state, not a transport failure.
+                    mutableConnectionStatus.value = ConnectionStatus.DISCONNECTED
+                    resetGameState()
+                    // Invariant: extraBufferCapacity=1 + DROP_OLDEST means
+                    // tryEmit is non-suspending and never returns false.
+                    mutableAuthRejections.tryEmit(Unit)
+                } else {
+                    mutableConnectionStatus.value = ConnectionStatus.ERROR
+                }
             }
         }
     }
@@ -297,6 +324,13 @@ class OkHttpWebSocketClient(
         }
     }
 
+    // Mirrors the literal body produced by Server #159's StompAuthChannelInterceptor
+    // (GENERIC_AUTH_FAILURE = "Authentication failed"). Strict equality — if the
+    // server message ever changes, fail closed (fall through to generic ERROR
+    // status) rather than match overly loosely.
+    private fun isAuthRejection(body: String): Boolean =
+        body == AUTH_REJECTION_BODY
+
     private fun resetGameState() {
         mutableGamePhase.value = GamePhase.NONE
         // Keep #37 coin display clean after game end/disconnect until #45 reset flow owns this state.
@@ -327,6 +361,10 @@ class OkHttpWebSocketClient(
         private const val AUTH_HEADER = "Authorization"
         private const val BEARER_PREFIX = "Bearer "
         private const val LOBBY_CREATED_TYPE = "LOBBY_CREATED"
+        // Frozen contract: matches GENERIC_AUTH_FAILURE on the server's
+        // StompAuthChannelInterceptor. If the server message changes, this
+        // client will silently fall through to the generic ERROR handling.
+        private const val AUTH_REJECTION_BODY = "Authentication failed"
         private const val GAME_START_BODY =
             """{"type":"START","sender":"${WebSocketContract.defaultSender}"}"""
     }

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -237,6 +237,14 @@ class OkHttpWebSocketClient(
                     // state, not a transport failure.
                     mutableConnectionStatus.value = ConnectionStatus.DISCONNECTED
                     resetGameState()
+                    // Sign out here rather than relying on a Compose collector
+                    // in the UI. The activity can be destroyed (rotation, process
+                    // death) between the emission and the collector attaching,
+                    // and `authRejections` uses replay = 0 so a missed event
+                    // would leave the user signed in against a token the server
+                    // no longer accepts. The snackbar in MainActivity is purely
+                    // a UI side-effect and remains miss-tolerant.
+                    sessionStateHolder.signOut()
                     // Invariant: extraBufferCapacity=1 + DROP_OLDEST means
                     // tryEmit is non-suspending and never returns false.
                     mutableAuthRejections.tryEmit(Unit)
@@ -335,6 +343,9 @@ class OkHttpWebSocketClient(
         mutableGamePhase.value = GamePhase.NONE
         // Keep #37 coin display clean after game end/disconnect until #45 reset flow owns this state.
         mutablePlayers.value = emptyList()
+        // Clear the latest lobby code so a stale code can't reappear on the
+        // next sign-in within the same app session.
+        mutableLobbyCode.value = null
     }
 
     private fun websocketHostHeader(): String {

--- a/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
@@ -3,6 +3,7 @@ package com.machikoro.client.network.websocket
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.PlayerCoinState
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
 interface WebSocketClient {
@@ -16,6 +17,13 @@ interface WebSocketClient {
     // Holds the latest created lobby code received from the server.
     // Null if no lobby has been created yet.
     val lobbyCode: StateFlow<String?>
+
+    // Fires when the server rejects the STOMP CONNECT for auth reasons (token
+    // missing / invalid / server-side cleared). The UI layer is responsible for
+    // calling SessionManager.signOut() and surfacing a "session expired"
+    // message — kept out of the network client so transport and policy stay
+    // separated.
+    val authRejections: SharedFlow<Unit>
 
     fun connect()
 

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -55,6 +55,7 @@ fun AppRoot(
         HomeScreen(
             lobbyCode = lobbyCode,
             onCreateLobbyClick = onCreateLobbyClick,
+            onLogoutClick = onLogoutSubmit,
             modifier = modifier
         )
     } else {

--- a/app/src/main/java/com/machikoro/client/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/home/HomeScreen.kt
@@ -54,6 +54,7 @@ fun HomeScreen(
     onRulesClick: () -> Unit = {},
     onRankingClick: () -> Unit = {},
     onSettingsClick: () -> Unit = {},
+    onLogoutClick: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     // Root container. Box allows placing elements freely with align().
@@ -111,6 +112,17 @@ fun HomeScreen(
                 .padding(top = 25.dp, end = 30.dp)
         )
 
+        // Logout affordance in the top-left corner. Issue #106 places the
+        // logout action on the authenticated screen; the start screen never
+        // shows it because the routing in AppRoot collapses HomeScreen back to
+        // StartScreen the moment the session clears.
+        LogoutButton(
+            onClick = onLogoutClick,
+            modifier = Modifier
+                .align(Alignment.TopStart)
+                .padding(top = 25.dp, start = 30.dp)
+        )
+
         // === MAIN ACTION BUTTONS ===
         // Three main lobby actions in the center of the screen.
         Row(
@@ -162,6 +174,31 @@ fun HomeScreen(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .padding(bottom = 0.dp)
+        )
+    }
+}
+
+@Composable
+private fun LogoutButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier.height(40.dp),
+        shape = RoundedCornerShape(10.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = ButtonBlueDark,
+            contentColor = TextWhite,
+        ),
+        elevation = ButtonDefaults.buttonElevation(defaultElevation = 6.dp),
+        contentPadding = PaddingValues(horizontal = 16.dp),
+    ) {
+        Text(
+            text = "Abmelden",
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Bold,
+            color = TextWhite,
         )
     }
 }

--- a/app/src/test/java/com/machikoro/client/network/websocket/FakeWebSocketClient.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/FakeWebSocketClient.kt
@@ -3,7 +3,10 @@ package com.machikoro.client.network.websocket
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.PlayerCoinState
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
 class FakeWebSocketClient : WebSocketClient {
@@ -19,10 +22,17 @@ class FakeWebSocketClient : WebSocketClient {
     override val lobbyCode: StateFlow<String?>
         get() = mutableLobbyCode
 
+    override val authRejections: SharedFlow<Unit>
+        get() = mutableAuthRejections
+
     private val mutableConnectionStatus = MutableStateFlow(ConnectionStatus.IDLE)
     private val mutableGamePhase = MutableStateFlow(GamePhase.NONE)
     private val mutablePlayers = MutableStateFlow<List<PlayerCoinState>>(emptyList())
     private val mutableLobbyCode = MutableStateFlow<String?>(null)
+    private val mutableAuthRejections = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
 
     var gameStartSent = false
         private set

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -624,7 +624,8 @@ class OkHttpWebSocketClientTest {
         // StompAuthChannelInterceptor. If the server message changes, this
         // test (and the client logic) must be updated together.
         val factory = FakeWebSocketFactory()
-        val client = newClient(factory)
+        val sessionHolder = FakeSessionStateHolder(initial = DEFAULT_SESSION)
+        val client = newClient(factory, sessionStateHolder = sessionHolder)
         val rejections = mutableListOf<Unit>()
         client.authRejections.onEach { rejections += it }.launchIn(backgroundScope)
         runCurrent()
@@ -636,6 +637,10 @@ class OkHttpWebSocketClientTest {
 
         assertEquals(1, rejections.size)
         assertEquals(ConnectionStatus.DISCONNECTED, client.connectionStatus.value)
+        // Sign-out is performed by the WS client itself so the policy survives
+        // activity destruction (rotation / process death) — it must not depend
+        // on a Compose collector being attached.
+        assertEquals(null, sessionHolder.session.value)
     }
 
     @Test
@@ -670,4 +675,56 @@ class OkHttpWebSocketClientTest {
 
         assertEquals(null, client.lobbyCode.value)
     }
+
+    @Test
+    fun disconnectClearsLobbyCode() {
+        // Regression: a stale lobby code must not persist across a sign-out/
+        // sign-in cycle within the same app session. Same contract applies to
+        // the auth-rejection path which also funnels through resetGameState().
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        factory.simulateText(
+            gameActionFrame(
+                """{"type":"LOBBY_CREATED","sender":"SERVER","payload":{"lobbyCode":"AJ25Z39"}}"""
+            )
+        )
+        assertEquals("AJ25Z39", client.lobbyCode.value)
+
+        client.disconnect()
+
+        assertEquals(null, client.lobbyCode.value)
+    }
+
+    @Test
+    fun authRejectionClearsLobbyCode() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.authRejections.onEach { }.launchIn(backgroundScope)
+        runCurrent()
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        factory.simulateText(
+            gameActionFrame(
+                """{"type":"LOBBY_CREATED","sender":"SERVER","payload":{"lobbyCode":"AJ25Z39"}}"""
+            )
+        )
+        assertEquals("AJ25Z39", client.lobbyCode.value)
+
+        factory.simulateText(authRejectionErrorFrame())
+        runCurrent()
+
+        assertEquals(null, client.lobbyCode.value)
+    }
+
+    private fun connectedFrame(): String =
+        "CONNECTED\nversion:1.2\n\n "
+
+    private fun authRejectionErrorFrame(): String =
+        "ERROR\nmessage:Authentication failed\n\nAuthentication failed "
 }

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -6,9 +6,14 @@ import com.machikoro.client.domain.model.state.PlayerCoinState
 import com.machikoro.client.domain.session.Session
 import com.machikoro.client.domain.session.SessionStateHolder
 import java.io.IOException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
 import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
@@ -20,6 +25,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class OkHttpWebSocketClientTest {
     @Test
     fun connectMovesStatusToConnecting() {
@@ -610,6 +616,43 @@ class OkHttpWebSocketClientTest {
         factory.simulateText(gameActionFrame("not json"))
 
         assertEquals(null, client.lobbyCode.value)
+    }
+
+    @Test
+    fun stompErrorFrameWithAuthFailureBodyEmitsAuthRejectionAndDisconnects() = runTest {
+        // Frozen contract: matches GENERIC_AUTH_FAILURE on Server #159's
+        // StompAuthChannelInterceptor. If the server message changes, this
+        // test (and the client logic) must be updated together.
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        val rejections = mutableListOf<Unit>()
+        client.authRejections.onEach { rejections += it }.launchIn(backgroundScope)
+        runCurrent()
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("ERROR\nmessage:Authentication failed\n\nAuthentication failed ")
+        runCurrent()
+
+        assertEquals(1, rejections.size)
+        assertEquals(ConnectionStatus.DISCONNECTED, client.connectionStatus.value)
+    }
+
+    @Test
+    fun stompErrorFrameWithNonAuthBodyDoesNotEmitAuthRejectionAndSetsErrorStatus() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        val rejections = mutableListOf<Unit>()
+        client.authRejections.onEach { rejections += it }.launchIn(backgroundScope)
+        runCurrent()
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("ERROR\n\nSome other error ")
+        runCurrent()
+
+        assertTrue(rejections.isEmpty())
+        assertEquals(ConnectionStatus.ERROR, client.connectionStatus.value)
     }
 
     @Test

--- a/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
@@ -4,7 +4,10 @@ import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.PlayerCoinState
 import com.machikoro.client.network.websocket.WebSocketClient
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -61,6 +64,11 @@ class HomeScreenViewModelTest {
 
         val mutableLobbyCode = MutableStateFlow<String?>(null)
         override val lobbyCode: StateFlow<String?> = mutableLobbyCode
+
+        override val authRejections: SharedFlow<Unit> = MutableSharedFlow(
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
 
         var connectCalled = false
         var disconnectCalled = false


### PR DESCRIPTION
Closes #106. Server-side dependency #160 already merged.

## Summary

- **HomeScreen** gets an `Abmelden` (Logout) button in the top-left. Wired through `AppRoot` to the existing `LogoutViewModel` + `SessionManager.signOut()`. The unauthenticated start screen already routes via `AppRoot` (`StartScreen` for null session, `HomeScreen` for non-null), so no defensive gating on `StartScreen` itself is needed.
- **STOMP auth-rejection handling**: `OkHttpWebSocketClient` now distinguishes the auth-rejection `ERROR` frame (literal body `"Authentication failed"`, per Server #159's `StompAuthChannelInterceptor`) from generic transport errors. On match it emits a new `authRejections: SharedFlow<Unit>`, flips status to `DISCONNECTED`, and resets game state.
- **MainActivity** collects `authRejections`, calls `SessionManager.signOut()`, and shows a snackbar (`"Sitzung abgelaufen, bitte erneut anmelden"`) via a new `SnackbarHost` on the existing `Scaffold`. Routing then collapses the user back to `StartScreen`.

Strict body equality on the auth-rejection match keeps the failure mode loud if the server contract drifts — better a regressed flow caught by a failing test than a silent fall-through.

## Test plan

Unit + lint:
- [x] `./gradlew :app:testDebugUnitTest` — green
- [x] `./gradlew :app:lintDebug` — no new issues
- [x] `./gradlew :app:assembleDebug :app:assembleDebugAndroidTest` — green

Compose UI tests (compile only — need a device/emulator to run):
- [x] `AppRootTest.showsStartScreenWhenUnauthenticated`
- [x] `AppRootTest.showsHomeScreenWhenAuthenticated`
- [x] `HomeScreenLogoutTest.showsLogoutButton`
- [x] `HomeScreenLogoutTest.clickingLogoutInvokesCallback`

Manual:
- [ ] Cold start → StartScreen (Register/Login/Rules, no Logout, no lobby cards).
- [ ] Login → routes to HomeScreen with Logout + lobby cards.
- [ ] Tap Logout → returns to StartScreen.
- [ ] Auth-rejection: login, background app, wipe DB (`docker compose -f compose-dev.yaml down -v && up -d`), foreground → snackbar appears, UI returns to StartScreen.

## Out of scope (per #106)

- Refresh tokens / silent re-auth.
- Per-action authorization (`NOT_YOUR_TURN` etc.) — server's concern.
- Anonymous-game support.