### PR TITLE
142 fix lobby navigation after lobby code confirmation

### DIFF
--- a/app/src/androidTest/java/com/machikoro/client/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ExampleInstrumentedTest.kt
@@ -42,7 +42,7 @@ class ExampleInstrumentedTest {
         }
 
         composeTestRule.onNodeWithText("MACHI KORO").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Connection status: connected").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Lobby/start: placeholder").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Login").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Register").assertIsDisplayed()
     }
 }

--- a/app/src/androidTest/java/com/machikoro/client/ui/AppRootTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/AppRootTest.kt
@@ -21,14 +21,14 @@ import org.junit.Test
 private const val START_SCREEN_TITLE = "MACHI KORO"
 // HomeScreen-specific labels — distinguish HomeScreen from StartScreen, which
 // shares the "MACHI KORO" title.
-private const val HOME_SCREEN_LOBBY_CARD = "Lobby beitreten"
-private const val HOME_SCREEN_LOGOUT = "Abmelden"
+private const val HOME_SCREEN_LOBBY_CARD = "Join Lobby"
+private const val HOME_SCREEN_LOGOUT = "Logout"
 private const val START_SCREEN_LOGIN = "Login"
 private const val START_SCREEN_REGISTER = "Register"
 // LobbyScreen-specific label — only rendered on LobbyScreen (it's the
 // "Spielerliste" heading above the player list), so it cleanly distinguishes
 // LobbyScreen from HomeScreen for routing assertions.
-private const val LOBBY_SCREEN_PLAYER_LIST = "Spielerliste"
+private const val LOBBY_SCREEN_PLAYER_LIST = "Players"
 
 class AppRootTest {
     @get:Rule
@@ -55,7 +55,6 @@ class AppRootTest {
                     onLogoutSubmit = {},
                     lobbyScreenState = LobbyScreenState.placeholder(),
                     lobbyCode = null,
-                    isLobbyHost = false,
                     loggedInAs = null,
                     onCreateLobbyClick = {},
                     onGoToLobbyClick = {},
@@ -76,7 +75,8 @@ class AppRootTest {
         composeTestRule.setContent {
             ClientTheme {
                 AppRoot(
-                    gameScreenState = GameScreenState.initial().copy(gamePhase = GamePhase.ROLL_DICE),
+                    gameScreenState = GameScreenState.initial()
+                        .copy(gamePhase = GamePhase.ROLL_DICE),
                     startScreenState = StartScreenState.placeholder(),
                     registerDialogState = RegisterDialogState(),
                     loginDialogState = LoginDialogState(),
@@ -92,7 +92,6 @@ class AppRootTest {
                     onLogoutSubmit = {},
                     lobbyScreenState = LobbyScreenState.placeholder(),
                     lobbyCode = null,
-                    isLobbyHost = false,
                     loggedInAs = null,
                     onCreateLobbyClick = {},
                     onGoToLobbyClick = {},
@@ -155,7 +154,6 @@ class AppRootTest {
                     onLogoutSubmit = {},
                     lobbyScreenState = LobbyScreenState.placeholder(),
                     lobbyCode = "ABC1234",
-                    isLobbyHost = false,
                     loggedInAs = "alice",
                     onCreateLobbyClick = {},
                     onGoToLobbyClick = {},
@@ -199,7 +197,6 @@ class AppRootTest {
                     onLogoutSubmit = {},
                     lobbyScreenState = LobbyScreenState.placeholder(),
                     lobbyCode = null,
-                    isLobbyHost = false,
                     loggedInAs = loggedInAs,
                     onCreateLobbyClick = {},
                     onGoToLobbyClick = {},
@@ -234,7 +231,6 @@ class AppRootTest {
                     onLogoutSubmit = {},
                     lobbyScreenState = LobbyScreenState.placeholder(),
                     lobbyCode = null,
-                    isLobbyHost = false,
                     loggedInAs = null,
                     onCreateLobbyClick = {},
                     onGoToLobbyClick = {},
@@ -258,15 +254,12 @@ class AppRootTest {
     }
 
     @Test
-    fun showsHomeScreenWithStartGameWhenLoggedInHostHasActiveGame() {
+    fun showsHomeScreenWhenLoggedInUserHasLobbyActions() {
         composeTestRule.setContent {
             ClientTheme {
                 AppRoot(
                     gameScreenState = GameScreenState.initial(),
-                    startScreenState = StartScreenState.placeholder().copy(
-                        loggedInAs = "alice",
-                        connectionStatus = com.machikoro.client.domain.model.state.ConnectionStatus.CONNECTED,
-                    ),
+                    startScreenState = StartScreenState.placeholder().copy(loggedInAs = "alice"),
                     registerDialogState = RegisterDialogState(),
                     loginDialogState = LoginDialogState(),
                     logoutState = LogoutState(),
@@ -281,15 +274,18 @@ class AppRootTest {
                     onLogoutSubmit = {},
                     lobbyScreenState = LobbyScreenState.placeholder(),
                     lobbyCode = null,
-                    isLobbyHost = true,
                     loggedInAs = "alice",
                     onCreateLobbyClick = {},
+                    onGoToLobbyClick = {},
+                    showLobbyScreen = false,
+                    onReadyToggle = {},
                     onStartGame = {},
+                    onLeaveLobby = {},
                 )
             }
         }
 
-        composeTestRule.onNodeWithText("Lobby erstellen").assertIsDisplayed()
-        composeTestRule.onNodeWithText("Spiel starten").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Create Lobby").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Join Lobby").assertIsDisplayed()
     }
 }

--- a/app/src/androidTest/java/com/machikoro/client/ui/home/HomeScreenLogoutTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/home/HomeScreenLogoutTest.kt
@@ -21,7 +21,7 @@ class HomeScreenLogoutTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Abmelden").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Logout").assertIsDisplayed()
     }
 
     @Test
@@ -36,7 +36,7 @@ class HomeScreenLogoutTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Abmelden").performClick()
+        composeTestRule.onNodeWithText("Logout").performClick()
 
         assertEquals(1, clicks)
     }

--- a/app/src/androidTest/java/com/machikoro/client/ui/start/LoginDialogTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/start/LoginDialogTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onAllNodesWithText
 import com.machikoro.client.domain.model.state.LoginDialogState
 import com.machikoro.client.ui.theme.ClientTheme
 import org.junit.Rule
@@ -28,8 +29,7 @@ class LoginDialogTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Login").assertIsDisplayed().assertIsNotEnabled()
-    }
+        composeTestRule.onAllNodesWithText("Login")[1].assertIsDisplayed().assertIsNotEnabled()    }
 
     @Test
     fun submitButtonIsEnabledWhenBothFieldsFilled() {
@@ -45,8 +45,7 @@ class LoginDialogTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Login").assertIsDisplayed().assertIsEnabled()
-    }
+        composeTestRule.onAllNodesWithText("Login")[1].assertIsDisplayed().assertIsEnabled()    }
 
     @Test
     fun errorMessageIsRenderedWhenPresent() {

--- a/app/src/androidTest/java/com/machikoro/client/ui/start/RegisterDialogTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/start/RegisterDialogTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onAllNodesWithText
 import com.machikoro.client.domain.model.state.RegisterDialogState
 import com.machikoro.client.ui.theme.ClientTheme
 import org.junit.Rule
@@ -28,8 +29,7 @@ class RegisterDialogTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Register").assertIsDisplayed().assertIsNotEnabled()
-    }
+        composeTestRule.onAllNodesWithText("Register")[1].assertIsDisplayed().assertIsNotEnabled()    }
 
     @Test
     fun submitButtonIsEnabledWhenBothFieldsFilled() {
@@ -45,8 +45,7 @@ class RegisterDialogTest {
             }
         }
 
-        composeTestRule.onNodeWithText("Register").assertIsDisplayed().assertIsEnabled()
-    }
+        composeTestRule.onAllNodesWithText("Register")[1].assertIsDisplayed().assertIsEnabled()    }
 
     @Test
     fun errorMessageIsRenderedWhenPresent() {

--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -132,7 +132,6 @@ class MainActivity : ComponentActivity() {
                         onRollDice = gameScreenViewModel::rollDice,
                         modifier = Modifier.padding(innerPadding),
                         lobbyCode = lobbyCode,
-                        isLobbyHost = isLobbyHost,
                         loggedInAs = startScreenState.loggedInAs,
                         showLobbyScreen = showLobbyScreen,
                         onGoToLobbyClick = {

--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -126,7 +126,7 @@ class MainActivity : ComponentActivity() {
                         onReadyToggle = lobbyScreenViewModel::onReadyToggle,
                         onStartGame = homeViewModel::startGame,
                         onLeaveLobby = {
-                            lobbyScreenViewModel.onLeaveLobby()
+                            showLobbyScreen = false
                             homeViewModel.clearLobbyCode()
                         },
                         onRollDice = gameScreenViewModel::rollDice,

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -52,7 +52,7 @@ fun AppRoot(
             onRollDice = onRollDice,
             modifier = modifier
         )
-    } else if (lobbyCode != null) {
+    } else if (showLobbyScreen) {
         LobbyScreen(
             state = lobbyScreenState,
             onReadyToggle = onReadyToggle,
@@ -68,7 +68,6 @@ fun AppRoot(
                     startScreenState.connectionStatus == ConnectionStatus.CONNECTED,
             onCreateLobbyClick = onCreateLobbyClick,
             onStartGame = onStartGame,
-            showLobbyScreen = showLobbyScreen,
             onGoToLobbyClick = onGoToLobbyClick,
             onLogoutClick = onLogoutSubmit,
             modifier = modifier

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -26,7 +26,6 @@ fun AppRoot(
     loginDialogState: LoginDialogState,
     logoutState: LogoutState,
     lobbyCode: String?,
-    isLobbyHost: Boolean,
     loggedInAs: String?,
     onRegisterUsernameChange: (String) -> Unit,
     onRegisterPasswordChange: (String) -> Unit,
@@ -63,11 +62,7 @@ fun AppRoot(
     } else if (loggedInAs != null) {
         HomeScreen(
             lobbyCode = lobbyCode,
-            isLobbyHost = isLobbyHost,
-            canStartGame = isLobbyHost &&
-                    startScreenState.connectionStatus == ConnectionStatus.CONNECTED,
             onCreateLobbyClick = onCreateLobbyClick,
-            onStartGame = onStartGame,
             onGoToLobbyClick = onGoToLobbyClick,
             onLogoutClick = onLogoutSubmit,
             modifier = modifier
@@ -113,7 +108,6 @@ private fun AppRootStartScreenPreview() {
             onLoginDialogReset = {},
             onLogoutSubmit = {},
             lobbyCode = null,
-            isLobbyHost = false,
             loggedInAs = null,
             onCreateLobbyClick = {},
         )
@@ -141,7 +135,6 @@ private fun AppRootGameScreenPreview() {
             onLoginDialogReset = {},
             onLogoutSubmit = {},
             lobbyCode = null,
-            isLobbyHost = false,
             loggedInAs = null,
             onCreateLobbyClick = {},
         )

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -54,6 +54,7 @@ fun AppRoot(
     } else if (showLobbyScreen) {
         LobbyScreen(
             state = lobbyScreenState,
+            lobbyCode = lobbyCode,
             onReadyToggle = onReadyToggle,
             onStartGame = onStartGame,
             onLeaveLobby = onLeaveLobby,

--- a/app/src/main/java/com/machikoro/client/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/home/HomeScreen.kt
@@ -45,11 +45,8 @@ import com.machikoro.client.ui.theme.White
 fun HomeScreen(
     // Latest lobby code received from the server after creating a lobby.
     lobbyCode: String? = null,
-    isLobbyHost: Boolean = false,
-    canStartGame: Boolean = false,
     onJoinLobbyClick: () -> Unit = {},
     onCreateLobbyClick: () -> Unit = {},
-    onStartGame: () -> Unit = {},
     onPublicLobbiesClick: () -> Unit = {},
     onRulesClick: () -> Unit = {},
     onRankingClick: () -> Unit = {},
@@ -173,33 +170,8 @@ fun HomeScreen(
                     onClick = onPublicLobbiesClick
                 )
             }
-
-            // Start Game button visible only to the lobby host and enabled when ready.
-            if (isLobbyHost) {
-                Spacer(modifier = Modifier.height(20.dp))
-
-                Button(
-                    onClick = onStartGame,
-                    enabled = canStartGame,
-                    shape = RoundedCornerShape(10.dp),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = ButtonBlueDark,
-                        contentColor = TextWhite,
-                    ),
-                    elevation = ButtonDefaults.buttonElevation(defaultElevation = 8.dp),
-                    contentPadding = PaddingValues(horizontal = 20.dp),
-                    modifier = Modifier
-                        .height(44.dp)
-                ) {
-                    Text(
-                        text = "Spiel starten",
-                        style = MaterialTheme.typography.bodyLarge,
-                        fontWeight = FontWeight.Bold,
-                        color = TextWhite
-                    )
-                }
-            }
         }
+
         // === BOTTOM MENU ===
         // Clickable menu items for rules, ranking and settings.
         BottomMenuBar(

--- a/app/src/main/java/com/machikoro/client/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/home/HomeScreen.kt
@@ -1,5 +1,9 @@
 package com.machikoro.client.ui.home
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -28,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -265,6 +270,18 @@ private fun LobbyCodeRow(
     code: String,
     onGoToLobbyClick: () -> Unit
 ) {
+    val context = LocalContext.current
+
+    fun copyLobbyCodeToClipboard() {
+        val clipboard =
+            context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+
+        val clip = ClipData.newPlainText("Lobby Code", code)
+        clipboard.setPrimaryClip(clip)
+
+        Toast.makeText(context, "Lobby code copied", Toast.LENGTH_SHORT).show()
+    }
+
     Row(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp)
@@ -295,7 +312,11 @@ private fun LobbyCodeRow(
                 Image(
                     painter = painterResource(id = R.drawable.home_copy_icon),
                     contentDescription = "Copy lobby code",
-                    modifier = Modifier.size(20.dp)
+                    modifier = Modifier
+                        .size(20.dp)
+                        .clickable {
+                            copyLobbyCodeToClipboard()
+                        }
                 )
             }
         }

--- a/app/src/main/java/com/machikoro/client/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/home/HomeScreen.kt
@@ -141,7 +141,7 @@ fun HomeScreen(
             ) {
                 HomeCard(
                     iconRes = R.drawable.home_lobby_join_icon,
-                    text = "Lobby beitreten",
+                    text = "Join Lobby",
                     isPrimary = false,
                     onClick = onJoinLobbyClick
                 )
@@ -153,7 +153,7 @@ fun HomeScreen(
                 ) {
                     HomeCard(
                         iconRes = R.drawable.home_lobby_create_icon,
-                        text = "Lobby erstellen",
+                        text = "Create Lobby",
                         isPrimary = true,
                         onClick = onCreateLobbyClick
                     )
@@ -170,7 +170,7 @@ fun HomeScreen(
 
                 HomeCard(
                     iconRes = R.drawable.home_lobby_public_icon,
-                    text = "Öffentliche Lobbys",
+                    text = "Public Lobbys",
                     isPrimary = false,
                     onClick = onPublicLobbiesClick
                 )
@@ -207,7 +207,7 @@ private fun LogoutButton(
         contentPadding = PaddingValues(horizontal = 16.dp),
     ) {
         Text(
-            text = "Abmelden",
+            text = "Logout",
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Bold,
             color = TextWhite,
@@ -413,21 +413,21 @@ private fun BottomMenuBar(
             // Opens the rules screen / PDF viewer.
             BottomMenuItem(
                 iconRes = R.drawable.home_rules_icon,
-                text = "Regeln",
+                text = "Rules",
                 onClick = onRulesClick
             )
 
             // Opens the ranking / leaderboard screen.
             BottomMenuItem(
                 iconRes = R.drawable.home_rang_icon,
-                text = "Rangliste",
+                text = "Leaderboard",
                 onClick = onRankingClick
             )
 
             // Opens the settings screen.
             BottomMenuItem(
                 iconRes = R.drawable.home_settings_icon,
-                text = "Einstellungen",
+                text = "Settings",
                 onClick = onSettingsClick
             )
         }

--- a/app/src/main/java/com/machikoro/client/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/home/HomeScreen.kt
@@ -54,8 +54,6 @@ fun HomeScreen(
     onRulesClick: () -> Unit = {},
     onRankingClick: () -> Unit = {},
     onSettingsClick: () -> Unit = {},
-    // Allows immediate navigation to the lobby UI after lobby creation confirmation.
-    showLobbyScreen: Boolean = false,
     onGoToLobbyClick: () -> Unit = {},
     onLogoutClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -162,7 +160,7 @@ fun HomeScreen(
                         Spacer(modifier = Modifier.height(8.dp))
 
                         LobbyCodeRow(
-                            code = lobbyCode,
+                            code = code,
                             onGoToLobbyClick = onGoToLobbyClick
                         )
                     }

--- a/app/src/main/java/com/machikoro/client/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/home/HomeViewModel.kt
@@ -2,6 +2,10 @@ package com.machikoro.client.ui.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.network.websocket.WebSocketClient
 
@@ -9,17 +13,33 @@ class HomeViewModel(
     private val webSocketClient: WebSocketClient,
 ) : ViewModel() {
 
+    private var createLobbyJob: Job? = null
+
     val lobbyCode = webSocketClient.lobbyCode
     val activeGameId = webSocketClient.activeGameId
     val isLobbyHost = webSocketClient.isLobbyHost
 
     fun createLobby() {
-        if (webSocketClient.connectionStatus.value != ConnectionStatus.CONNECTED) {
-            webSocketClient.connect()
+        if (webSocketClient.connectionStatus.value == ConnectionStatus.CONNECTED) {
+            webSocketClient.sendCreateLobby()
             return
         }
 
-        webSocketClient.sendCreateLobby()
+        if (createLobbyJob?.isActive == true) return
+
+        webSocketClient.connect()
+
+        createLobbyJob = viewModelScope.launch {
+            val status = webSocketClient.connectionStatus.first { status ->
+                status == ConnectionStatus.CONNECTED ||
+                        status == ConnectionStatus.ERROR ||
+                        status == ConnectionStatus.DISCONNECTED
+            }
+
+            if (status == ConnectionStatus.CONNECTED) {
+                webSocketClient.sendCreateLobby()
+            }
+        }
     }
 
     fun startGame() {

--- a/app/src/main/java/com/machikoro/client/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/home/HomeViewModel.kt
@@ -2,6 +2,7 @@ package com.machikoro.client.ui.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.network.websocket.WebSocketClient
 
 class HomeViewModel(
@@ -13,7 +14,11 @@ class HomeViewModel(
     val isLobbyHost = webSocketClient.isLobbyHost
 
     fun createLobby() {
-        webSocketClient.connect()
+        if (webSocketClient.connectionStatus.value != ConnectionStatus.CONNECTED) {
+            webSocketClient.connect()
+            return
+        }
+
         webSocketClient.sendCreateLobby()
     }
 

--- a/app/src/main/java/com/machikoro/client/ui/lobby/LobbyScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/lobby/LobbyScreen.kt
@@ -1,5 +1,9 @@
 package com.machikoro.client.ui.lobby
 
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.widget.Toast
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -28,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -46,6 +51,7 @@ import com.machikoro.client.ui.theme.White
 @Composable
 fun LobbyScreen(
     state: LobbyScreenState,
+    lobbyCode: String?,
     onReadyToggle: () -> Unit = {},
     onStartGame: () -> Unit = {},
     onLeaveLobby: () -> Unit = {},
@@ -59,6 +65,7 @@ fun LobbyScreen(
         hostUsername = state.playerList.firstOrNull(),
         isHost = state.isHost,
         isReady = state.isReady,
+        lobbyCode = lobbyCode,
         onReadyToggle = onReadyToggle,
         onStartGame = onStartGame,
         onLeaveLobby = onLeaveLobby,
@@ -74,6 +81,7 @@ fun LobbyScreen(
     hostUsername: String? = null,
     isHost: Boolean = false,
     isReady: Boolean = false,
+    lobbyCode: String? = null,
     onReadyToggle: () -> Unit = {},
     onStartGame: () -> Unit = {},
     onLeaveLobby: () -> Unit = {},
@@ -205,11 +213,20 @@ fun LobbyScreen(
                 .padding(end = 140.dp, top = 40.dp)
         )
 
+        lobbyCode?.let { code ->
+            LobbyCodeCopyRow(
+                code = code,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(top = 180.dp, start = 95.dp)
+            )
+        }
+
         LeaveLobbyButton(
             onClick = onLeaveLobby,
             modifier = Modifier
-                .align(Alignment.BottomStart)
-                .padding(start = 65.dp, bottom = 38.dp)
+                .align(Alignment.TopStart)
+                .padding(top = 25.dp, start = 30.dp)
         )
     }
 }
@@ -280,7 +297,7 @@ fun ReadyToggle(
     ) {
         Text(
             text = "bereit",
-            color = TextWhite,
+            color = White,
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Bold
         )
@@ -320,7 +337,7 @@ fun ReadyToggle(
 
         Text(
             text = "nicht\nbereit",
-            color = TextWhite,
+            color = White,
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Bold
         )
@@ -328,39 +345,97 @@ fun ReadyToggle(
 }
 
 @Composable
+private fun LobbyCodeCopyRow(
+    code: String,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+
+    fun copyLobbyCodeToClipboard() {
+        val clipboard =
+            context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+
+        val clip = ClipData.newPlainText("Lobby Code", code)
+        clipboard.setPrimaryClip(clip)
+
+        Toast.makeText(context, "Lobby code copied", Toast.LENGTH_SHORT).show()
+    }
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+
+        Spacer(modifier = Modifier.height(6.dp))
+
+        Card(
+            modifier = Modifier
+                .width(140.dp)
+                .height(40.dp)
+                .clickable { copyLobbyCodeToClipboard() },
+            shape = RoundedCornerShape(10.dp),
+            colors = CardDefaults.cardColors(containerColor = White),
+            elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = code,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color(0x4D004E7E),
+                    maxLines = 1
+                )
+
+                Spacer(modifier = Modifier.weight(1f))
+
+                Image(
+                    painter = painterResource(id = R.drawable.home_copy_icon),
+                    contentDescription = "Copy lobby code",
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
+    }
+}
+@Composable
 private fun LeaveLobbyButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(
+    Card(
         modifier = modifier
-            .width(95.dp)
-            .height(95.dp)
-            .background(
-                color = ButtonBlueGrey,
-                shape = RoundedCornerShape(14.dp)
-            )
-            .clickable { onClick() }
-            .padding(10.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+            .width(120.dp)
+            .height(42.dp)
+            .clickable { onClick() },
+        shape = RoundedCornerShape(10.dp),
+        colors = CardDefaults.cardColors(containerColor = ButtonBlueDark),
+        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
     ) {
-        Image(
-            painter = painterResource(id = R.drawable.lobby_leave),
-            contentDescription = "Lobby verlassen",
-            modifier = Modifier.size(32.dp)
-        )
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.lobby_leave),
+                contentDescription = "Lobby verlassen",
+                modifier = Modifier.size(22.dp)
+            )
 
-        Spacer(modifier = Modifier.height(6.dp))
+            Spacer(modifier = Modifier.width(10.dp))
 
-        Text(
-            text = "Lobby\nverlassen",
-            modifier = Modifier.fillMaxWidth(),
-            color = TextBlueDark,
-            style = MaterialTheme.typography.bodySmall,
-            fontWeight = FontWeight.Bold,
-            textAlign = TextAlign.Center
-        )
+            Text(
+                text = "Lobby verlassen",
+                color = TextWhite,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Bold
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/machikoro/client/ui/lobby/LobbyScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/lobby/LobbyScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -35,7 +34,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.machikoro.client.R
@@ -143,7 +141,7 @@ fun LobbyScreen(
         ) {
             Row(horizontalArrangement = Arrangement.spacedBy(0.dp)) {
                 Text(
-                    text = "Spielerliste",
+                    text = "Players",
                     modifier = Modifier.width(220.dp),
                     color = TextBlueDark,
                     style = MaterialTheme.typography.bodyMedium
@@ -170,7 +168,7 @@ fun LobbyScreen(
                     PlayerSlot(
                         name = when {
                             name == null -> ""
-                            isCurrentUser -> "$name (ich)"
+                            isCurrentUser -> "$name (you)"
                             else -> name
                         },
                         isHost = isHostPlayer
@@ -179,8 +177,8 @@ fun LobbyScreen(
                     // TODO: Replace placeholder ready state once backend exposes readiness per player.
                     val statusText = when {
                         name == null -> ""
-                        isCurrentUser && !isReady -> "nicht bereit"
-                        else -> "bereit"
+                        isCurrentUser && !isReady -> "not ready"
+                        else -> "ready"
                     }
 
                     StatusSlot(text = statusText)
@@ -201,7 +199,7 @@ fun LobbyScreen(
                     disabledContainerColor = ButtonBlueDark.copy(alpha = 0.65f)
                 )
             ) {
-                Text("Spiel starten", color = TextWhite, style =  MaterialTheme.typography.labelLarge)
+                Text("Start Game", color = TextWhite, style =  MaterialTheme.typography.labelLarge)
             }
         }
 
@@ -296,7 +294,7 @@ fun ReadyToggle(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(
-            text = "bereit",
+            text = "ready",
             color = White,
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Bold
@@ -336,7 +334,7 @@ fun ReadyToggle(
         Spacer(modifier = Modifier.height(12.dp))
 
         Text(
-            text = "nicht\nbereit",
+            text = "not\nready",
             color = White,
             style = MaterialTheme.typography.bodyMedium,
             fontWeight = FontWeight.Bold
@@ -408,7 +406,7 @@ private fun LeaveLobbyButton(
 ) {
     Card(
         modifier = modifier
-            .width(120.dp)
+            .width(105.dp)
             .height(42.dp)
             .clickable { onClick() },
         shape = RoundedCornerShape(10.dp),
@@ -430,7 +428,7 @@ private fun LeaveLobbyButton(
             Spacer(modifier = Modifier.width(10.dp))
 
             Text(
-                text = "Lobby verlassen",
+                text = "Leave Lobby",
                 color = TextWhite,
                 style = MaterialTheme.typography.bodyMedium,
                 fontWeight = FontWeight.Bold
@@ -444,9 +442,9 @@ private fun LeaveLobbyButton(
 private fun LobbyScreenPreview() {
     ClientTheme {
         LobbyScreen(
-            playerNames = listOf("Spieler1"),
-            currentUsername = "Spieler1",
-            hostUsername = "Spieler1",
+            playerNames = listOf("Player1"),
+            currentUsername = "Player1",
+            hostUsername = "Player",
             isHost = true,
             isReady = false
         )
@@ -458,9 +456,9 @@ private fun LobbyScreenPreview() {
 private fun LobbyScreenFullPreview() {
     ClientTheme {
         LobbyScreen(
-            playerNames = listOf("Spieler1", "Spieler2", "Spieler3", "Spieler4"),
-            currentUsername = "Spieler1",
-            hostUsername = "Spieler1",
+            playerNames = listOf("Player1", "Player2", "Player3", "Player4"),
+            currentUsername = "Player1",
+            hostUsername = "Player1",
             isHost = true,
             isReady = true
         )

--- a/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
@@ -4,21 +4,33 @@ import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.PlayerCoinState
 import com.machikoro.client.network.websocket.WebSocketClient
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class HomeScreenViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
 
     @Test
     fun exposesLobbyCodeFromWebSocketClient() {
@@ -43,13 +55,34 @@ class HomeScreenViewModelTest {
     }
 
     @Test
-    fun createLobbyConnectsWhenWebSocketIsNotConnected() {
+    fun createLobbyConnectsAndSendsCreateLobbyRequestAfterWebSocketConnects() = runTest {
         val fakeClient = FakeWebSocketClient()
         val viewModel = HomeViewModel(fakeClient)
 
         viewModel.createLobby()
 
         assertTrue(fakeClient.connectCalled)
+        assertFalse(fakeClient.sendCreateLobbyCalled)
+
+        fakeClient.mutableConnectionStatus.value = ConnectionStatus.CONNECTED
+        advanceUntilIdle()
+
+        assertTrue(fakeClient.sendCreateLobbyCalled)
+    }
+
+    @Test
+    fun createLobbyDoesNotSendCreateLobbyRequestWhenWebSocketFails() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = HomeViewModel(fakeClient)
+
+        viewModel.createLobby()
+
+        assertTrue(fakeClient.connectCalled)
+        assertFalse(fakeClient.sendCreateLobbyCalled)
+
+        fakeClient.mutableConnectionStatus.value = ConnectionStatus.ERROR
+        advanceUntilIdle()
+
         assertFalse(fakeClient.sendCreateLobbyCalled)
     }
 
@@ -126,5 +159,18 @@ class HomeScreenViewModelTest {
         override fun sendGameStart() { sendGameStartCalled = true }
         override fun sendCreateLobby() { sendCreateLobbyCalled = true }
         override fun clearLobbyCode() { mutableLobbyCode.value = null }
+    }
+}
+
+class MainDispatcherRule(
+    private val testDispatcher: TestDispatcher = StandardTestDispatcher(),
+) : TestWatcher() {
+
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
     }
 }

--- a/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -42,13 +43,26 @@ class HomeScreenViewModelTest {
     }
 
     @Test
-    fun createLobbyConnectsAndSendsCreateLobbyRequest() {
+    fun createLobbyConnectsWhenWebSocketIsNotConnected() {
         val fakeClient = FakeWebSocketClient()
         val viewModel = HomeViewModel(fakeClient)
 
         viewModel.createLobby()
 
         assertTrue(fakeClient.connectCalled)
+        assertFalse(fakeClient.sendCreateLobbyCalled)
+    }
+
+    @Test
+    fun createLobbySendsCreateLobbyRequestWhenWebSocketIsConnected() {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = HomeViewModel(fakeClient)
+
+        fakeClient.mutableConnectionStatus.value = ConnectionStatus.CONNECTED
+
+        viewModel.createLobby()
+
+        assertFalse(fakeClient.connectCalled)
         assertTrue(fakeClient.sendCreateLobbyCalled)
     }
 
@@ -77,8 +91,10 @@ class HomeScreenViewModelTest {
     }
 
     private class FakeWebSocketClient : WebSocketClient {
-        override val connectionStatus: StateFlow<ConnectionStatus> =
+        val mutableConnectionStatus =
             MutableStateFlow(ConnectionStatus.IDLE)
+        override val connectionStatus: StateFlow<ConnectionStatus> =
+            mutableConnectionStatus
         override val gamePhase: StateFlow<GamePhase> =
             MutableStateFlow(GamePhase.NONE)
         override val diceResult: StateFlow<List<Int>?> =


### PR DESCRIPTION
This PR fixes the lobby navigation flow after lobby creation and confirmation #142 

**Implemented:**
-  The host remains on HomeScreen after creating a lobby.
-  The generated lobby code is displayed on HomeScreen.
- The lobby code can be copied to the clipboard.
- The host navigates to LobbyScreen only after confirming via the check action.
- LobbyScreen also displays the lobby code with copy functionality.
- AppRoot navigation logic and related tests were updated.
- UI was changed from German to English.
- Android and unit tests are passing again.

**Note:** The "_Other players join a lobby_" flow is intentionally not part of this PR and will be handled separately in: #53 and #55 