### PR TITLE
53 add lobby code input and join action

### DIFF
--- a/app/src/androidTest/java/com/machikoro/client/ui/game/GameScreenSnapshotTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/game/GameScreenSnapshotTest.kt
@@ -12,6 +12,7 @@ import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.GameScreenState
 import com.machikoro.client.domain.model.state.PlayerCoinState
 import com.machikoro.client.domain.model.state.PlayerLandmarkState
+import com.machikoro.client.domain.model.state.PurchaseState
 import com.machikoro.client.ui.theme.ClientTheme
 import org.junit.Rule
 import org.junit.Test
@@ -46,6 +47,8 @@ class GameScreenSnapshotTest {
             )
         ),
         marketplace = mapOf(CardType.WHEAT_FIELD to 6, CardType.BAKERY to 5),
+        gameId = 1,
+        purchaseState = PurchaseState.IDLE,
     )
 
     @Test

--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -75,13 +75,14 @@ class MainActivity : ComponentActivity() {
             val startScreenState by startScreenViewModel.state.collectAsState()
             val gameScreenState by gameScreenViewModel.state.collectAsState()
             val lobbyCode by homeViewModel.lobbyCode.collectAsState()
+            val joinLobbyCode by homeViewModel.joinLobbyCode.collectAsState()
             val isLobbyHost by homeViewModel.isLobbyHost.collectAsState()
             val lobbyScreenState by lobbyScreenViewModel.state.collectAsState()
             val registerDialogState by registerDialogViewModel.state.collectAsState()
             val loginDialogState by loginDialogViewModel.state.collectAsState()
             val logoutState by logoutViewModel.state.collectAsState()
             var showLobbyScreen by remember { mutableStateOf(false) }
-
+            var showJoinLobbyInput by remember { mutableStateOf(false) }
             val snackbarHostState = remember { SnackbarHostState() }
 
             LaunchedEffect(Unit) {
@@ -132,6 +133,8 @@ class MainActivity : ComponentActivity() {
                         onRollDice = gameScreenViewModel::rollDice,
                         modifier = Modifier.padding(innerPadding),
                         lobbyCode = lobbyCode,
+                        joinLobbyCode = joinLobbyCode,
+                        showJoinLobbyInput = showJoinLobbyInput,
                         loggedInAs = startScreenState.loggedInAs,
                         showLobbyScreen = showLobbyScreen,
                         onGoToLobbyClick = {
@@ -139,6 +142,11 @@ class MainActivity : ComponentActivity() {
                         },
                         onCreateLobbyClick = homeViewModel::createLobby,
                         onPurchaseClick = gameScreenViewModel::purchase,
+                        onJoinLobbyClick = {
+                            showJoinLobbyInput = !showJoinLobbyInput
+                        },
+                        onJoinLobbyCodeChange = homeViewModel::onJoinLobbyCodeChange,
+                        onJoinLobbySubmit = homeViewModel::joinLobby,
                     )
                 }
             }

--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -76,7 +76,6 @@ class MainActivity : ComponentActivity() {
             val gameScreenState by gameScreenViewModel.state.collectAsState()
             val lobbyCode by homeViewModel.lobbyCode.collectAsState()
             val joinLobbyCode by homeViewModel.joinLobbyCode.collectAsState()
-            val isLobbyHost by homeViewModel.isLobbyHost.collectAsState()
             val lobbyScreenState by lobbyScreenViewModel.state.collectAsState()
             val registerDialogState by registerDialogViewModel.state.collectAsState()
             val loginDialogState by loginDialogViewModel.state.collectAsState()

--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -139,10 +139,14 @@ class MainActivity : ComponentActivity() {
                         onGoToLobbyClick = {
                             showLobbyScreen = true
                         },
-                        onCreateLobbyClick = homeViewModel::createLobby,
+                        onCreateLobbyClick = {
+                            showJoinLobbyInput = false
+                            homeViewModel.createLobby()
+                        },
                         onPurchaseClick = gameScreenViewModel::purchase,
                         onJoinLobbyClick = {
-                            showJoinLobbyInput = !showJoinLobbyInput
+                            homeViewModel.clearLobbyCode()
+                            showJoinLobbyInput = true
                         },
                         onJoinLobbyCodeChange = homeViewModel::onJoinLobbyCodeChange,
                         onJoinLobbySubmit = homeViewModel::joinLobby,

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -170,6 +170,44 @@ class OkHttpWebSocketClient(
         }
     }
 
+    /**
+     * Sends a join-lobby request to the backend.
+     *
+     * The backend expects the lobby code inside the payload and resolves the
+     * authenticated user from the STOMP session, so the sender field is not used
+     * for identity.
+     */
+    override fun sendJoinLobby(lobbyCode: String) {
+        val socket = synchronized(this) { webSocket }
+        if (socket == null) {
+            Log.w(TAG, "sendJoinLobby called but no active WebSocket connection")
+            return
+        }
+
+        val frameStr = StompFrame(
+            command = "SEND",
+            headers = mapOf(
+                "destination" to WebSocketContract.joinLobbyDestination,
+                "content-type" to "application/json"
+            ),
+            body = """
+            {
+              "type":"JOIN",
+              "sender":"${WebSocketContract.defaultSender}",
+              "payload":{
+                "lobbyCode":"$lobbyCode"
+              }
+            }
+        """.trimIndent()
+        ).serialize()
+
+        if (socket.send(frameStr)) {
+            Log.d(TAG, "Join lobby message sent with code: $lobbyCode")
+        } else {
+            Log.w(TAG, "sendJoinLobby: failed to send join-lobby frame")
+        }
+    }
+
     override fun clearLobbyCode() {
         resetLobbyState()
     }

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -184,21 +184,22 @@ class OkHttpWebSocketClient(
             return
         }
 
+        val payload = JSONObject()
+            .put("lobbyCode", lobbyCode)
+
+        val enrichedBody = JSONObject()
+            .put("type", "JOIN")
+            .put("sender", WebSocketContract.defaultSender)
+            .put("payload", payload)
+            .toString()
+
         val frameStr = StompFrame(
             command = "SEND",
             headers = mapOf(
                 "destination" to WebSocketContract.joinLobbyDestination,
                 "content-type" to "application/json"
             ),
-            body = """
-            {
-              "type":"JOIN",
-              "sender":"${WebSocketContract.defaultSender}",
-              "payload":{
-                "lobbyCode":"$lobbyCode"
-              }
-            }
-        """.trimIndent()
+            body = enrichedBody
         ).serialize()
 
         if (socket.send(frameStr)) {

--- a/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
@@ -45,8 +45,8 @@ interface WebSocketClient {
 
     fun connect()
     fun disconnect()
-
     fun sendCreateLobby()
+    fun sendJoinLobby(lobbyCode: String)     // Sends a request to join an existing lobby by lobby code.
     fun clearLobbyCode()
     fun sendGameStart()
 

--- a/app/src/main/java/com/machikoro/client/network/websocket/WebSocketContract.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WebSocketContract.kt
@@ -13,6 +13,7 @@ object WebSocketContract {
     const val chatSendDestination: String = "/app/chat.send"
     const val rollDiceDestination: String = "/app/game.rollDice"
     const val createLobbyDestination: String = "/app/lobby.create"
+    const val joinLobbyDestination = "/app/lobby.join" // Destination used to send a lobby join request with an entered lobby code.
     const val gameStartDestination: String = "/app/game.start"
     // Server PR #216 exposes PurchaseRequest at @MessageMapping("/game.purchase").
     const val purchaseDestination: String = "/app/game.purchase"

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -28,6 +28,8 @@ fun AppRoot(
     loginDialogState: LoginDialogState,
     logoutState: LogoutState,
     lobbyCode: String?,
+    joinLobbyCode: String = "",
+    showJoinLobbyInput: Boolean = false,
     loggedInAs: String?,
     onRegisterUsernameChange: (String) -> Unit,
     onRegisterPasswordChange: (String) -> Unit,
@@ -37,6 +39,9 @@ fun AppRoot(
     onLoginPasswordChange: (String) -> Unit,
     onLoginSubmit: () -> Unit,
     onCreateLobbyClick: () -> Unit,
+    onJoinLobbyClick: () -> Unit = {},
+    onJoinLobbyCodeChange: (String) -> Unit = {},
+    onJoinLobbySubmit: () -> Unit = {},
     onLoginDialogReset: () -> Unit,
     onLogoutSubmit: () -> Unit,
     onReadyToggle: () -> Unit = {},
@@ -74,6 +79,11 @@ fun AppRoot(
     } else if (loggedInAs != null) {
         HomeScreen(
             lobbyCode = lobbyCode,
+            joinLobbyCode = joinLobbyCode,
+            showJoinLobbyInput = showJoinLobbyInput,
+            onJoinLobbyClick = onJoinLobbyClick,
+            onJoinLobbyCodeChange = onJoinLobbyCodeChange,
+            onJoinLobbySubmit = onJoinLobbySubmit,
             onCreateLobbyClick = onCreateLobbyClick,
             onGoToLobbyClick = onGoToLobbyClick,
             onLogoutClick = onLogoutSubmit,
@@ -140,6 +150,8 @@ private fun AppRootStartScreenPreview() {
             lobbyCode = null,
             loggedInAs = null,
             onCreateLobbyClick = {},
+            joinLobbyCode = "",
+            showJoinLobbyInput = false,
         )
     }
 }
@@ -167,6 +179,8 @@ private fun AppRootGameScreenPreview() {
             lobbyCode = null,
             loggedInAs = null,
             onCreateLobbyClick = {},
+            joinLobbyCode = "",
+            showJoinLobbyInput = false,
         )
     }
 }

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -60,6 +60,7 @@ fun AppRoot(
     showLobbyScreen: Boolean = false,
     onGoToLobbyClick: () -> Unit = {},
 ) {
+
     val navController = rememberNavController()
 
     // Keep the current state-based screen priority while hosting screens in one NavHost.

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -111,6 +111,11 @@ fun AppRoot(
         composable(AppRoute.Home.route) {
             HomeScreen(
                 lobbyCode = lobbyCode,
+                joinLobbyCode = joinLobbyCode,
+                showJoinLobbyInput = showJoinLobbyInput,
+                onJoinLobbyClick = onJoinLobbyClick,
+                onJoinLobbyCodeChange = onJoinLobbyCodeChange,
+                onJoinLobbySubmit = onJoinLobbySubmit,
                 onCreateLobbyClick = onCreateLobbyClick,
                 onGoToLobbyClick = onGoToLobbyClick,
                 onLogoutClick = onLogoutSubmit,

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -80,7 +80,7 @@ fun AppRoot(
         HomeScreen(
             lobbyCode = lobbyCode,
             joinLobbyCode = joinLobbyCode,
-            showJoinLobbyInput = showJoinLobbyInput,
+            showJoinLobbyInput = showJoinLobbyInput && lobbyCode == null,
             onJoinLobbyClick = onJoinLobbyClick,
             onJoinLobbyCodeChange = onJoinLobbyCodeChange,
             onJoinLobbySubmit = onJoinLobbySubmit,

--- a/app/src/main/java/com/machikoro/client/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/home/HomeScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
@@ -50,6 +52,9 @@ import com.machikoro.client.ui.theme.White
 fun HomeScreen(
     // Latest lobby code received from the server after creating a lobby.
     lobbyCode: String? = null,
+    joinLobbyCode: String = "",
+    showJoinLobbyInput: Boolean = false,
+    onJoinLobbyCodeChange: (String) -> Unit = {},
     onJoinLobbyClick: () -> Unit = {},
     onCreateLobbyClick: () -> Unit = {},
     onPublicLobbiesClick: () -> Unit = {},
@@ -57,6 +62,7 @@ fun HomeScreen(
     onRankingClick: () -> Unit = {},
     onSettingsClick: () -> Unit = {},
     onGoToLobbyClick: () -> Unit = {},
+    onJoinLobbySubmit: () -> Unit = {},
     onLogoutClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -139,12 +145,28 @@ fun HomeScreen(
                 verticalAlignment = Alignment.Top,
                 modifier = Modifier
             ) {
-                HomeCard(
-                    iconRes = R.drawable.home_lobby_join_icon,
-                    text = "Join Lobby",
-                    isPrimary = false,
-                    onClick = onJoinLobbyClick
-                )
+                // Join lobby card. The code input only appears after clicking the card.
+                Column(
+                    modifier = Modifier.width(150.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    HomeCard(
+                        iconRes = R.drawable.home_lobby_join_icon,
+                        text = "Join Lobby",
+                        isPrimary = false,
+                        onClick = onJoinLobbyClick
+                    )
+
+                    if (showJoinLobbyInput) {
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        JoinLobbyCodeRow(
+                            code = joinLobbyCode,
+                            onCodeChange = onJoinLobbyCodeChange,
+                            onJoinLobbySubmit = onJoinLobbySubmit
+                        )
+                    }
+                }
 
                 // Create lobby card with generated code displayed directly below it.
                 Column(
@@ -343,6 +365,84 @@ private fun LobbyCodeRow(
 }
 
 @Composable
+private fun JoinLobbyCodeRow(
+    code: String,
+    onCodeChange: (String) -> Unit,
+    onJoinLobbySubmit: () -> Unit
+) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Card(
+            modifier = Modifier
+                .width(110.dp)
+                .height(34.dp),
+            shape = RoundedCornerShape(8.dp),
+            colors = CardDefaults.cardColors(containerColor = White),
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(start = 12.dp, end = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                BasicTextField(
+                    value = code,
+                    onValueChange = { input ->
+                        onCodeChange(input.uppercase())
+                    },
+                    singleLine = true,
+                    textStyle = TextStyle(
+                        color = Color(0x4D004E7E),
+                        fontSize = MaterialTheme.typography.bodyMedium.fontSize,
+                        fontWeight = FontWeight.Bold
+                    ),
+                    modifier = Modifier.weight(1f),
+                    decorationBox = { innerTextField ->
+                        if (code.isBlank()) {
+                            Text(
+                                text = "Code",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = Color(0x4D004E7E),
+                                maxLines = 1
+                            )
+                        }
+
+                        innerTextField()
+                    }
+                )
+            }
+        }
+
+        // Sends the entered lobby code to the backend.
+        Card(
+            modifier = Modifier
+                .size(34.dp)
+                .clickable(
+                    enabled = code.isNotBlank(),
+                    onClick = onJoinLobbySubmit
+                ),
+            shape = RoundedCornerShape(6.dp),
+            colors = CardDefaults.cardColors(containerColor = White),
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        ) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Image(
+                    painter = painterResource(id = R.drawable.home_check_icon),
+                    contentDescription = "Join lobby",
+                    modifier = Modifier.size(18.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
 private fun ProfileCard(
     modifier: Modifier = Modifier
 ) {
@@ -485,6 +585,21 @@ private fun HomeScreenWithLobbyCodePreview() {
             onLogoutClick = {},
             onGoToLobbyClick = {},
             lobbyCode = "AJ25Z39"
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 917, heightDp = 412)
+@Composable
+private fun HomeScreenWithJoinLobbyCodePreview() {
+    ClientTheme {
+        HomeScreen(
+            onLogoutClick = {},
+            onGoToLobbyClick = {},
+            joinLobbyCode = "AJ25Z39",
+            showJoinLobbyInput = true,
+            onJoinLobbyCodeChange = {},
+            onJoinLobbySubmit = {},
         )
     }
 }

--- a/app/src/main/java/com/machikoro/client/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/home/HomeScreen.kt
@@ -397,7 +397,7 @@ private fun JoinLobbyCodeRow(
                     },
                     singleLine = true,
                     textStyle = TextStyle(
-                        color = Color(0x4D004E7E),
+                        color = TextBlueDark,
                         fontSize = MaterialTheme.typography.bodyMedium.fontSize,
                         fontWeight = FontWeight.Bold
                     ),

--- a/app/src/main/java/com/machikoro/client/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/home/HomeScreen.kt
@@ -80,7 +80,7 @@ fun HomeScreen(
             contentScale = ContentScale.Fit,
             modifier = Modifier
                 .align(Alignment.BottomStart)
-                .offset(x = -15.dp, y = 25.dp)
+               .offset(x = 0.dp, y = 53.dp)
                 .blur(3.5.dp)
         )
 
@@ -91,14 +91,15 @@ fun HomeScreen(
             contentScale = ContentScale.Fit,
             modifier = Modifier
                 .align(Alignment.BottomEnd)
-                .offset(x = 15.dp, y = 25.dp)
+                .offset(x = 15.dp, y = 53.dp)
                 .blur(3.5.dp)
         )
 
         // White transparent overlay for better readability.
         Box(
             modifier = Modifier
-                .matchParentSize()
+                .fillMaxSize()
+                .offset(x = 0.dp, y = 20.dp)
                 .background(Color.White.copy(alpha = 0.7f))
         )
 
@@ -110,7 +111,7 @@ fun HomeScreen(
             color = TextBlueDark,
             modifier = Modifier
                 .align(Alignment.TopCenter)
-                .padding(top = 70.dp),
+                .padding(top = 50.dp),
         )
 
         // === PROFILE SECTION ===
@@ -137,9 +138,10 @@ fun HomeScreen(
         Column(
             modifier = Modifier
                 .align(Alignment.Center)
-                .padding(top = 50.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
+                .padding(top = 50.dp)
+                .height(180.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Top        ) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(60.dp),
                 verticalAlignment = Alignment.Top,
@@ -207,7 +209,7 @@ fun HomeScreen(
             onSettingsClick = onSettingsClick,
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .padding(bottom = 0.dp)
+                .offset(x = 0.dp, y = 20.dp)
         )
     }
 }
@@ -566,7 +568,7 @@ private fun BottomMenuItem(
     }
 }
 
-@Preview(showBackground = true, widthDp = 917, heightDp = 412)
+@Preview(showBackground = true, widthDp = 915, heightDp = 430)
 @Composable
 private fun HomeScreenPreview() {
     ClientTheme {
@@ -577,7 +579,7 @@ private fun HomeScreenPreview() {
     }
 }
 
-@Preview(showBackground = true, widthDp = 917, heightDp = 412)
+@Preview(showBackground = true, widthDp = 915, heightDp = 430)
 @Composable
 private fun HomeScreenWithLobbyCodePreview() {
     ClientTheme {
@@ -589,7 +591,7 @@ private fun HomeScreenWithLobbyCodePreview() {
     }
 }
 
-@Preview(showBackground = true, widthDp = 917, heightDp = 412)
+@Preview(showBackground = true, widthDp = 915, heightDp = 430)
 @Composable
 private fun HomeScreenWithJoinLobbyCodePreview() {
     ClientTheme {

--- a/app/src/main/java/com/machikoro/client/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/home/HomeViewModel.kt
@@ -8,12 +8,19 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.network.websocket.WebSocketClient
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 
 class HomeViewModel(
     private val webSocketClient: WebSocketClient,
 ) : ViewModel() {
 
     private var createLobbyJob: Job? = null
+
+    private var joinLobbyJob: Job? = null
+
+    private val mutableJoinLobbyCode = MutableStateFlow("")
+    val joinLobbyCode: StateFlow<String> = mutableJoinLobbyCode
 
     val lobbyCode = webSocketClient.lobbyCode
     val activeGameId = webSocketClient.activeGameId
@@ -38,6 +45,41 @@ class HomeViewModel(
 
             if (status == ConnectionStatus.CONNECTED) {
                 webSocketClient.sendCreateLobby()
+            }
+        }
+    }
+
+    fun onJoinLobbyCodeChange(code: String) {
+        mutableJoinLobbyCode.value = code.trim().uppercase()
+    }
+
+    /**
+     * Sends the entered lobby code once the WebSocket connection is ready.
+     * If the socket is not connected yet, the first click starts the connection
+     * and continues automatically after CONNECTED.
+     */
+    fun joinLobby() {
+        val code = mutableJoinLobbyCode.value.trim()
+        if (code.isBlank()) return
+
+        if (webSocketClient.connectionStatus.value == ConnectionStatus.CONNECTED) {
+            webSocketClient.sendJoinLobby(code)
+            return
+        }
+
+        if (joinLobbyJob?.isActive == true) return
+
+        webSocketClient.connect()
+
+        joinLobbyJob = viewModelScope.launch {
+            val status = webSocketClient.connectionStatus.first { status ->
+                status == ConnectionStatus.CONNECTED ||
+                        status == ConnectionStatus.ERROR ||
+                        status == ConnectionStatus.DISCONNECTED
+            }
+
+            if (status == ConnectionStatus.CONNECTED) {
+                webSocketClient.sendJoinLobby(code)
             }
         }
     }

--- a/app/src/test/java/com/machikoro/client/network/websocket/FakeWebSocketClient.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/FakeWebSocketClient.kt
@@ -113,6 +113,13 @@ class FakeWebSocketClient : WebSocketClient {
         )
     }
 
+    var lastJoinLobbyCode: String? = null
+        private set
+
+    override fun sendJoinLobby(lobbyCode: String) {
+        lastJoinLobbyCode = lobbyCode
+    }
+
     override fun clearLobbyCode() {
         mutableLobbyCode.value = null
         mutableActiveGameId.value = null

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -543,6 +543,37 @@ class OkHttpWebSocketClientTest {
     }
 
     @Test
+    fun sendJoinLobbySendsStompFrameToJoinLobbyDestination() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+
+        client.sendJoinLobby("ABC1234")
+
+        assertTrue(
+            factory.socket.sentMessages.any {
+                it.startsWith("SEND\n") &&
+                        it.contains("destination:${WebSocketContract.joinLobbyDestination}") &&
+                        it.contains("\"type\":\"JOIN\"") &&
+                        it.contains("\"lobbyCode\":\"ABC1234\"")
+            }
+        )
+    }
+
+    @Test
+    fun sendJoinLobbyWithoutConnectionIsIgnored() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+
+        client.sendJoinLobby("ABC1234")
+
+        assertTrue(factory.socket.sentMessages.isEmpty())
+    }
+
+    @Test
     fun rollDiceWithTwoDiceSendsDiceCountTwo() {
         val factory = FakeWebSocketFactory()
         val client = newClient(factory)

--- a/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
@@ -25,6 +25,7 @@ class DummyWebSocketClient : WebSocketClient {
     override fun connect() {}
     override fun disconnect() {}
     override fun sendCreateLobby() {}
+    override fun sendJoinLobby(lobbyCode: String) = Unit
     override fun clearLobbyCode() {}
     override fun sendGameStart() {}
     override fun rollDice(diceCount: Int) {}

--- a/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
@@ -105,6 +105,20 @@ class HomeScreenViewModelTest {
     }
 
     @Test
+    fun joinLobbySendsJoinRequestWhenWebSocketIsConnected() {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = HomeViewModel(fakeClient)
+
+        fakeClient.mutableConnectionStatus.value = ConnectionStatus.CONNECTED
+        viewModel.onJoinLobbyCodeChange("abc123")
+
+        viewModel.joinLobby()
+
+        assertTrue(fakeClient.sendJoinLobbyCalled)
+        assertEquals("ABC123", fakeClient.joinedLobbyCode)
+    }
+
+    @Test
     fun startGameDelegatesToWebSocketClient() {
         val fakeClient = FakeWebSocketClient()
         val viewModel = HomeViewModel(fakeClient)
@@ -167,6 +181,13 @@ class HomeScreenViewModelTest {
         var disconnectCalled = false
         var sendGameStartCalled = false
         var sendCreateLobbyCalled = false
+        var sendJoinLobbyCalled = false
+        var joinedLobbyCode: String? = null
+
+        override fun sendJoinLobby(lobbyCode: String) {
+            sendJoinLobbyCalled = true
+            joinedLobbyCode = lobbyCode
+        }
 
         override fun connect() { connectCalled = true }
         override fun disconnect() { disconnectCalled = true }


### PR DESCRIPTION
This PR continues the lobby navigation and join-lobby flow improvements.

**Implemented:**
* Added join lobby input field on HomeScreen
* Added join lobby confirmation action
* Added join lobby state handling through MainActivity → AppRoot → HomeScreen
* Added join lobby code state to HomeViewModel
* Added WebSocket join lobby request support
* Added/updated tests for the join lobby flow
* Improved HomeScreen layout stability
* Prevented create-lobby and join-lobby flows from overlapping


**Behavior:**
* Clicking "Join Lobby" now reveals the lobby code input field
* Clicking "Create Lobby" hides the join flow and shows the generated lobby code
* The create and join lobby fields are never shown at the same time

**Notes**: Successful join response handling, automatic navigation to LobbyScreen, and invalid-code error handling will follow in #55.
