### PR TITLE
feat: render full reconnect snapshot from /app/game.sync

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,7 +108,16 @@ tasks.register<JacocoReport>("jacocoTestReport") {
         html.required.set(true)
     }
 
-    val debugTree = fileTree("${project.layout.buildDirectory.get()}/tmp/kotlin-classes/debug") {
+    // AGP's built-in Kotlin compiler emits debug classes under
+    // intermediates/built_in_kotlinc/...; older toolchains used
+    // tmp/kotlin-classes/debug. Include both so JaCoCo finds the classes
+    // regardless of toolchain — otherwise the coverage report is empty and
+    // SonarCloud sees 0% coverage.
+    val debugTree = fileTree(project.layout.buildDirectory.get()) {
+        include(
+            "tmp/kotlin-classes/debug/**",
+            "intermediates/built_in_kotlinc/debug/compileDebugKotlin/classes/**",
+        )
         exclude(coverageExclusions)
     }
     val mainSrc = "${project.projectDir}/src/main/java"
@@ -127,7 +136,16 @@ tasks.register<JacocoReport>("jacocoTestReport") {
 tasks.register<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
     dependsOn("testDebugUnitTest")
 
-    val debugTree = fileTree("${project.layout.buildDirectory.get()}/tmp/kotlin-classes/debug") {
+    // AGP's built-in Kotlin compiler emits debug classes under
+    // intermediates/built_in_kotlinc/...; older toolchains used
+    // tmp/kotlin-classes/debug. Include both so JaCoCo finds the classes
+    // regardless of toolchain — otherwise the coverage report is empty and
+    // SonarCloud sees 0% coverage.
+    val debugTree = fileTree(project.layout.buildDirectory.get()) {
+        include(
+            "tmp/kotlin-classes/debug/**",
+            "intermediates/built_in_kotlinc/debug/compileDebugKotlin/classes/**",
+        )
         exclude(coverageExclusions)
     }
     val mainSrc = "${project.projectDir}/src/main/java"

--- a/app/src/androidTest/java/com/machikoro/client/ui/AppRootTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/AppRootTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.model.state.GameScreenState
 import com.machikoro.client.domain.model.state.LobbyScreenState
 import com.machikoro.client.domain.model.state.LoginDialogState
@@ -287,5 +288,47 @@ class AppRootTest {
 
         composeTestRule.onNodeWithText("Create Lobby").assertIsDisplayed()
         composeTestRule.onNodeWithText("Join Lobby").assertIsDisplayed()
+    }
+
+    @Test
+    fun showsWinnerScreenWhenGameStatusIsFinished() {
+        composeTestRule.setContent {
+            ClientTheme {
+                AppRoot(
+                    gameScreenState = GameScreenState.initial().copy(
+                        gameStatus = GameStatus.FINISHED,
+                        roundNumber = 5,
+                    ),
+                    startScreenState = StartScreenState.placeholder().copy(loggedInAs = "alice"),
+                    registerDialogState = RegisterDialogState(),
+                    loginDialogState = LoginDialogState(),
+                    logoutState = LogoutState(),
+                    onRegisterUsernameChange = {},
+                    onRegisterPasswordChange = {},
+                    onRegisterSubmit = {},
+                    onRegisterDialogReset = {},
+                    onLoginUsernameChange = {},
+                    onLoginPasswordChange = {},
+                    onLoginSubmit = {},
+                    onLoginDialogReset = {},
+                    onLogoutSubmit = {},
+                    lobbyScreenState = LobbyScreenState.placeholder(),
+                    lobbyCode = null,
+                    loggedInAs = "alice",
+                    onCreateLobbyClick = {},
+                    onGoToLobbyClick = {},
+                    showLobbyScreen = false,
+                    onReadyToggle = {},
+                    onStartGame = {},
+                    onLeaveLobby = {},
+                )
+            }
+        }
+
+        // FINISHED outranks every other screen — the winner screen header shows
+        // and neither the start/home title nor the lobby list is rendered.
+        composeTestRule.onNodeWithText("Congratulations to...").assertIsDisplayed()
+        composeTestRule.onNodeWithText(START_SCREEN_TITLE).assertDoesNotExist()
+        composeTestRule.onNodeWithText(LOBBY_SCREEN_PLAYER_LIST).assertDoesNotExist()
     }
 }

--- a/app/src/androidTest/java/com/machikoro/client/ui/game/GameScreenSnapshotTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/game/GameScreenSnapshotTest.kt
@@ -1,0 +1,81 @@
+package com.machikoro.client.ui.game
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import com.machikoro.client.domain.enums.CardType
+import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.enums.GameStatus
+import com.machikoro.client.domain.enums.LandmarkType
+import com.machikoro.client.domain.model.state.ConnectionStatus
+import com.machikoro.client.domain.model.state.GameScreenState
+import com.machikoro.client.domain.model.state.PlayerCoinState
+import com.machikoro.client.domain.model.state.PlayerLandmarkState
+import com.machikoro.client.ui.theme.ClientTheme
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Verifies the GameScreen renders every field of a /app/game.sync reconnect
+ * snapshot — round number, marketplace supply, per-player landmark build state
+ * and the last dice roll — so a reconnecting player sees the full board.
+ */
+class GameScreenSnapshotTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    /** A single-player mid-game snapshot — one player keeps every assertion unambiguous. */
+    private fun reconnectState() = GameScreenState(
+        connectionStatus = ConnectionStatus.CONNECTED,
+        gamePhase = GamePhase.BUY_OR_BUILD,
+        players = listOf(
+            PlayerCoinState(id = "1", displayName = "You", coins = 9, isCurrentPlayer = true)
+        ),
+        diceResult = listOf(8),
+        activePlayerId = 1,
+        myUserId = 1,
+        gameStatus = GameStatus.IN_PROGRESS,
+        roundNumber = 4,
+        playerLandmarks = mapOf(
+            1 to listOf(
+                PlayerLandmarkState(LandmarkType.TRAIN_STATION, isBuilt = true),
+                PlayerLandmarkState(LandmarkType.SHOPPING_MALL, isBuilt = true),
+                PlayerLandmarkState(LandmarkType.AMUSEMENT_PARK, isBuilt = false),
+                PlayerLandmarkState(LandmarkType.RADIO_TOWER, isBuilt = false),
+            )
+        ),
+        marketplace = mapOf(CardType.WHEAT_FIELD to 6, CardType.BAKERY to 5),
+    )
+
+    @Test
+    fun rendersRoundNumberFromSnapshot() {
+        composeTestRule.setContent { ClientTheme { GameScreen(state = reconnectState()) } }
+
+        composeTestRule.onNodeWithText("Round 4").assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersMarketplaceSupplyFromSnapshot() {
+        composeTestRule.setContent { ClientTheme { GameScreen(state = reconnectState()) } }
+
+        composeTestRule.onNodeWithText("Marketplace").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Wheat Field: 6 in stock").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Bakery: 5 in stock").assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersPlayerLandmarkBuildStateFromSnapshot() {
+        composeTestRule.setContent { ClientTheme { GameScreen(state = reconnectState()) } }
+
+        composeTestRule.onNodeWithContentDescription("Train Station: built").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Amusement Park: not built").assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersLastDiceRollFromSnapshot() {
+        composeTestRule.setContent { ClientTheme { GameScreen(state = reconnectState()) } }
+
+        composeTestRule.onNodeWithContentDescription("Würfelergebnis: 8").assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/machikoro/client/domain/enums/CardType.kt
+++ b/app/src/main/java/com/machikoro/client/domain/enums/CardType.kt
@@ -1,0 +1,23 @@
+package com.machikoro.client.domain.enums
+
+/**
+ * Mirrors the server's `CardType` — the establishment cards stocked in the
+ * marketplace. Order matches the server enum so JSON round-trips by name.
+ */
+enum class CardType {
+    WHEAT_FIELD,
+    RANCH,
+    FOREST,
+    MINE,
+    APPLE_ORCHARD,
+    BAKERY,
+    CONVENIENCE_STORE,
+    CHEESE_FACTORY,
+    FURNITURE_FACTORY,
+    FRUIT_AND_VEGETABLE_MARKET,
+    CAFE,
+    FAMILY_RESTAURANT,
+    STADIUM,
+    TV_STATION,
+    BUSINESS_CENTER,
+}

--- a/app/src/main/java/com/machikoro/client/domain/enums/GameStatus.kt
+++ b/app/src/main/java/com/machikoro/client/domain/enums/GameStatus.kt
@@ -1,0 +1,12 @@
+package com.machikoro.client.domain.enums
+
+/**
+ * Mirrors the server's `GameStatus` — the lifecycle state of a game.
+ * Carried in the `/app/game.sync` reconnect snapshot and used by AppRoot to
+ * pick the screen: WAITING → lobby, IN_PROGRESS → game, FINISHED → winner.
+ */
+enum class GameStatus {
+    WAITING,
+    IN_PROGRESS,
+    FINISHED,
+}

--- a/app/src/main/java/com/machikoro/client/domain/enums/LandmarkType.kt
+++ b/app/src/main/java/com/machikoro/client/domain/enums/LandmarkType.kt
@@ -1,0 +1,12 @@
+package com.machikoro.client.domain.enums
+
+/**
+ * Mirrors the server's `LandmarkType` — the four landmarks each player builds.
+ * Building all four wins the game.
+ */
+enum class LandmarkType {
+    TRAIN_STATION,
+    SHOPPING_MALL,
+    AMUSEMENT_PARK,
+    RADIO_TOWER,
+}

--- a/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
@@ -1,6 +1,8 @@
 package com.machikoro.client.domain.model.state
 
+import com.machikoro.client.domain.enums.CardType
 import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.enums.GameStatus
 
 data class GameScreenState(
     val connectionStatus: ConnectionStatus,
@@ -10,6 +12,11 @@ data class GameScreenState(
     val activePlayerId: Int? = null,
     val myUserId: Int? = null,
     val isRolling: Boolean = false,
+    // Reconnect snapshot fields (from /app/game.sync).
+    val gameStatus: GameStatus? = null,
+    val roundNumber: Int? = null,
+    val playerLandmarks: Map<Int, List<PlayerLandmarkState>> = emptyMap(),
+    val marketplace: Map<CardType, Int> = emptyMap(),
 ) {
     val isActivePlayer: Boolean
         get() = myUserId != null && myUserId == activePlayerId
@@ -23,6 +30,10 @@ data class GameScreenState(
             activePlayerId = null,
             myUserId = null,
             isRolling = false,
+            gameStatus = null,
+            roundNumber = null,
+            playerLandmarks = emptyMap(),
+            marketplace = emptyMap(),
         )
     }
 }

--- a/app/src/main/java/com/machikoro/client/domain/model/state/PlayerLandmarkState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/PlayerLandmarkState.kt
@@ -1,0 +1,12 @@
+package com.machikoro.client.domain.model.state
+
+import com.machikoro.client.domain.enums.LandmarkType
+
+/**
+ * One landmark slot for a player, with its built / unbuilt state, as carried
+ * in the `/app/game.sync` reconnect snapshot.
+ */
+data class PlayerLandmarkState(
+    val landmarkType: LandmarkType,
+    val isBuilt: Boolean,
+)

--- a/app/src/main/java/com/machikoro/client/domain/model/state/SnapshotDisplay.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/SnapshotDisplay.kt
@@ -1,0 +1,18 @@
+package com.machikoro.client.domain.model.state
+
+import com.machikoro.client.domain.enums.CardType
+import com.machikoro.client.domain.enums.LandmarkType
+
+/**
+ * Human-readable labels for snapshot enums. `WHEAT_FIELD` → "Wheat Field".
+ * Kept here alongside the other `toDisplayText()` helpers so the UI never
+ * renders raw SCREAMING_SNAKE_CASE enum names.
+ */
+fun LandmarkType.toDisplayText(): String = name.humanizeEnumName()
+
+fun CardType.toDisplayText(): String = name.humanizeEnumName()
+
+private fun String.humanizeEnumName(): String =
+    split('_').joinToString(" ") { word ->
+        word.lowercase().replaceFirstChar { it.uppercase() }
+    }

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -1,9 +1,13 @@
 package com.machikoro.client.network.websocket
 
 import android.util.Log
+import com.machikoro.client.domain.enums.CardType
 import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.enums.GameStatus
+import com.machikoro.client.domain.enums.LandmarkType
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.PlayerCoinState
+import com.machikoro.client.domain.model.state.PlayerLandmarkState
 import com.machikoro.client.domain.session.SessionStateHolder
 import java.net.URI
 import kotlinx.coroutines.channels.BufferOverflow
@@ -50,6 +54,18 @@ class OkHttpWebSocketClient(
     override val isLobbyHost: StateFlow<Boolean>
         get() = mutableIsLobbyHost.asStateFlow()
 
+    override val gameStatus: StateFlow<GameStatus?>
+        get() = mutableGameStatus.asStateFlow()
+
+    override val roundNumber: StateFlow<Int?>
+        get() = mutableRoundNumber.asStateFlow()
+
+    override val playerLandmarks: StateFlow<Map<Int, List<PlayerLandmarkState>>>
+        get() = mutablePlayerLandmarks.asStateFlow()
+
+    override val marketplace: StateFlow<Map<CardType, Int>>
+        get() = mutableMarketplace.asStateFlow()
+
     override val authRejections: SharedFlow<Unit>
         get() = mutableAuthRejections.asSharedFlow()
 
@@ -61,6 +77,11 @@ class OkHttpWebSocketClient(
     private val mutableActivePlayerId = MutableStateFlow<Int?>(null)
     private val mutableActiveGameId = MutableStateFlow<Int?>(null)
     private val mutableIsLobbyHost = MutableStateFlow(false)
+    private val mutableGameStatus = MutableStateFlow<GameStatus?>(null)
+    private val mutableRoundNumber = MutableStateFlow<Int?>(null)
+    private val mutablePlayerLandmarks =
+        MutableStateFlow<Map<Int, List<PlayerLandmarkState>>>(emptyMap())
+    private val mutableMarketplace = MutableStateFlow<Map<CardType, Int>>(emptyMap())
     private val mutableAuthRejections = MutableSharedFlow<Unit>(
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
@@ -254,6 +275,10 @@ class OkHttpWebSocketClient(
                 Log.d(TAG, "STOMP connected")
                 mutableConnectionStatus.value = ConnectionStatus.CONNECTED
                 subscribeToPublicTopic()
+                // Subscribe before the JOIN send below: chat.addUser triggers the
+                // server-side reconnect snapshot, and the SUBSCRIBE must be
+                // registered first or the SYNC frame is delivered to nobody.
+                subscribeToSyncQueue()
                 mutableActiveGameId.value?.let(::subscribeToGameTopic)
                 sendJoinMessage()
             }
@@ -268,6 +293,7 @@ class OkHttpWebSocketClient(
                 }
                 handleLobbyCreated(json)
                 handleGameStarted(json)
+                handleSync(json)
                 parseGameAction(json).let { (phase, activePlayerId) ->
                     phase?.let { mutableGamePhase.value = it }
                     activePlayerId?.let { mutableActivePlayerId.value = it }
@@ -326,6 +352,92 @@ class OkHttpWebSocketClient(
         mutablePlayers.value = payload.optJSONArray("players").toPlayerCoinStates(payload, game)
     }
 
+    /**
+     * Handles the reconnect snapshot pushed to `/user/queue/game-sync`.
+     *
+     * The SYNC message wraps a full `GameStateDto` under `payload.state`; this
+     * restores every flow the game screen renders so a reconnecting client
+     * reconstructs the board in a single round-trip — no follow-up queries.
+     */
+    private fun handleSync(json: JSONObject) {
+        if (json.optString("type") != SYNC_TYPE) return
+        val payload = json.optJSONObject("payload") ?: return
+        val state = payload.optJSONObject("state") ?: return
+        val game = state.optJSONObject("game") ?: return
+
+        val gameId = json.optIntOrNull("gameId") ?: game.optIntOrNull("id")
+        if (gameId != null) {
+            mutableActiveGameId.value = gameId
+            subscribeToGameTopic(gameId)
+        }
+
+        game.optString("lobbyCode")
+            .takeIf { it.isNotBlank() }
+            ?.let { mutableLobbyCode.value = it }
+
+        parseGameStatus(game.optString("status"))?.let { mutableGameStatus.value = it }
+        parseTurnPhase(game.optString("turnPhase"))?.let { mutableGamePhase.value = it }
+        game.optIntOrNull("roundNumber")?.let { mutableRoundNumber.value = it }
+        // The snapshot persists only the dice total (lastDiceRoll), not the
+        // individual dice — surface it as a single-element list so the game
+        // screen can show the last roll on reconnect.
+        game.optIntOrNull("lastDiceRoll")?.let { mutableDiceResult.value = listOf(it) }
+
+        mutablePlayers.value = state.optJSONArray("players").toPlayerCoinStates(state, game)
+        mutableActivePlayerId.value = resolveActiveUserId(state, game)
+        mutablePlayerLandmarks.value = parsePlayerLandmarks(state.optJSONObject("playerLandmarks"))
+        mutableMarketplace.value = parseMarketplace(state.optJSONObject("marketplace"))
+    }
+
+    private fun parseGameStatus(name: String): GameStatus? =
+        name.takeIf { it.isNotEmpty() }
+            ?.let { runCatching { GameStatus.valueOf(it) }.getOrNull() }
+
+    /**
+     * Resolves the active player's **userId** (not playerId) from the snapshot:
+     * turnOrder holds playerIds, currentTurnIndex points into it, and the
+     * matching player row carries the userId that [activePlayerId] is compared
+     * against (`myUserId == activePlayerId`).
+     */
+    private fun resolveActiveUserId(state: JSONObject, game: JSONObject): Int? {
+        val currentTurnIndex = game.optIntOrNull("currentTurnIndex") ?: return null
+        val turnOrder = state.optJSONArray("turnOrder") ?: return null
+        if (currentTurnIndex !in 0 until turnOrder.length()) return null
+        val activePlayerId = turnOrder.optInt(currentTurnIndex)
+        val players = state.optJSONArray("players") ?: return null
+        for (i in 0 until players.length()) {
+            val player = players.optJSONObject(i) ?: continue
+            if (player.optInt("id") == activePlayerId) return player.optIntOrNull("userId")
+        }
+        return null
+    }
+
+    private fun parsePlayerLandmarks(obj: JSONObject?): Map<Int, List<PlayerLandmarkState>> {
+        if (obj == null) return emptyMap()
+        val result = mutableMapOf<Int, List<PlayerLandmarkState>>()
+        for (key in obj.keys()) {
+            val playerId = key.toIntOrNull() ?: continue
+            val array = obj.optJSONArray(key) ?: continue
+            result[playerId] = (0 until array.length()).mapNotNull { index ->
+                val entry = array.optJSONObject(index) ?: return@mapNotNull null
+                val type = runCatching { LandmarkType.valueOf(entry.optString("landmarkType")) }
+                    .getOrNull() ?: return@mapNotNull null
+                PlayerLandmarkState(landmarkType = type, isBuilt = entry.optBoolean("isBuilt"))
+            }
+        }
+        return result
+    }
+
+    private fun parseMarketplace(obj: JSONObject?): Map<CardType, Int> {
+        if (obj == null) return emptyMap()
+        val result = mutableMapOf<CardType, Int>()
+        for (key in obj.keys()) {
+            val cardType = runCatching { CardType.valueOf(key) }.getOrNull() ?: continue
+            result[cardType] = obj.optInt(key)
+        }
+        return result
+    }
+
     private fun parseGameAction(json: JSONObject): Pair<GamePhase?, Int?> {
         if (json.optString("type") != GAME_ACTION_TYPE) return Pair(null, null)
         val payload = json.optJSONObject("payload") ?: return Pair(null, null)
@@ -353,6 +465,18 @@ class OkHttpWebSocketClient(
                 headers = mapOf(
                     "id" to "public-topic",
                     "destination" to WebSocketContract.publicTopic
+                )
+            ).serialize()
+        )
+    }
+
+    private fun subscribeToSyncQueue() {
+        webSocket?.send(
+            StompFrame(
+                command = "SUBSCRIBE",
+                headers = mapOf(
+                    "id" to "user-game-sync",
+                    "destination" to WebSocketContract.gameSyncQueue
                 )
             ).serialize()
         )
@@ -414,6 +538,10 @@ class OkHttpWebSocketClient(
         mutableDiceResult.value = null
         mutableActivePlayerId.value = null
         mutableLobbyCode.value = null
+        mutableGameStatus.value = null
+        mutableRoundNumber.value = null
+        mutablePlayerLandmarks.value = emptyMap()
+        mutableMarketplace.value = emptyMap()
     }
 
     private fun resetLobbyState() {
@@ -478,6 +606,7 @@ class OkHttpWebSocketClient(
         private const val BEARER_PREFIX = "Bearer "
         private const val LOBBY_CREATED_TYPE = "LOBBY_CREATED"
         private const val ROLL_DICE_TYPE = "ROLL_DICE"
+        private const val SYNC_TYPE = "SYNC"
         // Frozen contract: matches GENERIC_AUTH_FAILURE on the server's
         // StompAuthChannelInterceptor. If the server message changes, this
         // client will silently fall through to the generic ERROR handling.

--- a/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
@@ -1,8 +1,11 @@
 package com.machikoro.client.network.websocket
 
+import com.machikoro.client.domain.enums.CardType
 import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.PlayerCoinState
+import com.machikoro.client.domain.model.state.PlayerLandmarkState
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -19,6 +22,15 @@ interface WebSocketClient {
     // Null if no dice have been rolled yet in the current turn.
     val diceResult: StateFlow<List<Int>?>
     val activePlayerId: StateFlow<Int?>
+
+    // Reconnect snapshot fields, populated from the /app/game.sync response.
+    // gameStatus is null until the first snapshot arrives.
+    val gameStatus: StateFlow<GameStatus?>
+    val roundNumber: StateFlow<Int?>
+    // playerId -> that player's landmarks (built / unbuilt).
+    val playerLandmarks: StateFlow<Map<Int, List<PlayerLandmarkState>>>
+    // Remaining marketplace supply per card type.
+    val marketplace: StateFlow<Map<CardType, Int>>
 
     // Fires when the server rejects the STOMP CONNECT for auth reasons (token
     // missing / invalid / server-side cleared). The UI layer is responsible for

--- a/app/src/main/java/com/machikoro/client/network/websocket/WebSocketContract.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WebSocketContract.kt
@@ -14,5 +14,9 @@ object WebSocketContract {
     const val rollDiceDestination: String = "/app/game.rollDice"
     const val createLobbyDestination: String = "/app/lobby.create"
     const val gameStartDestination: String = "/app/game.start"
+    const val gameSyncDestination: String = "/app/game.sync"
+    // Per-user reconnect snapshot queue. The server resolves /user/** to the
+    // authenticated principal, so each client only sees its own snapshot.
+    const val gameSyncQueue: String = "/user/queue/game-sync"
     const val defaultSender: String = "android-client"
 }

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.GameScreenState
 import com.machikoro.client.domain.model.state.LoginDialogState
@@ -16,6 +17,7 @@ import com.machikoro.client.ui.home.HomeScreen
 import com.machikoro.client.ui.lobby.LobbyScreen
 import com.machikoro.client.ui.start.StartScreen
 import com.machikoro.client.ui.theme.ClientTheme
+import com.machikoro.client.ui.win.GameOverOneWinner
 
 @Composable
 fun AppRoot(
@@ -45,7 +47,14 @@ fun AppRoot(
     showLobbyScreen: Boolean = false,
     onGoToLobbyClick: () -> Unit = {},
 ) {
-    if (gameScreenState.gamePhase != GamePhase.NONE) {
+    if (gameScreenState.gameStatus == GameStatus.FINISHED) {
+        // A finished game outranks every other screen: even mid-phase, once the
+        // snapshot reports FINISHED the player should see the end screen.
+        GameOverOneWinner(
+            winnerName = resolveWinnerName(gameScreenState),
+            roundsNumber = gameScreenState.roundNumber ?: 0,
+        )
+    } else if (gameScreenState.gamePhase != GamePhase.NONE) {
         GameScreen(
             state = gameScreenState,
             onRollDice = onRollDice,
@@ -86,6 +95,24 @@ fun AppRoot(
             modifier = modifier
         )
     }
+}
+
+/**
+ * Derives the winner from the reconnect snapshot: in Machi Koro the game ends
+ * when a player has built all four landmarks, so the winner is the player whose
+ * landmark list is non-empty and fully built. Falls back to a generic label if
+ * the snapshot doesn't pin down a single winner.
+ */
+private fun resolveWinnerName(state: GameScreenState): String {
+    val winnerPlayerId = state.playerLandmarks.entries
+        .firstOrNull { (_, landmarks) ->
+            landmarks.isNotEmpty() && landmarks.all { it.isBuilt }
+        }
+        ?.key
+    return state.players
+        .firstOrNull { it.id == winnerPlayerId?.toString() }
+        ?.displayName
+        ?: "the winner"
 }
 
 @Preview(showBackground = true, widthDp = 917, heightDp = 412)

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -2,6 +2,7 @@ package com.machikoro.client.ui.game
 
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -35,10 +36,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.machikoro.client.domain.enums.CardType
 import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.enums.LandmarkType
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.GameScreenState
 import com.machikoro.client.domain.model.state.PlayerCoinState
+import com.machikoro.client.domain.model.state.PlayerLandmarkState
 import com.machikoro.client.domain.model.state.toDisplayText
 import com.machikoro.client.ui.theme.ClientTheme
 import kotlinx.coroutines.delay
@@ -56,6 +60,7 @@ fun GameScreen(
     Box(modifier = modifier.fillMaxSize()) {
         CoinDisplay(
             players = state.players,
+            playerLandmarks = state.playerLandmarks,
             modifier = Modifier
                 .align(Alignment.TopCenter)
                 .statusBarsPadding()
@@ -68,6 +73,25 @@ fun GameScreen(
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .padding(top = coinDisplayTopPadding(state.players))
+            )
+        }
+
+        state.roundNumber?.let { round ->
+            RoundIndicator(
+                round = round,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .statusBarsPadding()
+                    .padding(12.dp)
+            )
+        }
+
+        if (state.marketplace.isNotEmpty()) {
+            MarketplaceSection(
+                marketplace = state.marketplace,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(horizontal = 12.dp)
             )
         }
 
@@ -168,17 +192,43 @@ private fun DiceResultDisplay(
 }
 
 @Composable
+private fun RoundIndicator(
+    round: Int,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        shape = RoundedCornerShape(8.dp),
+        tonalElevation = 2.dp,
+        modifier = modifier
+    ) {
+        Text(
+            text = "Round $round",
+            style = MaterialTheme.typography.labelLarge,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp)
+        )
+    }
+}
+
+@Composable
 private fun CoinDisplay(
     players: List<PlayerCoinState>,
+    playerLandmarks: Map<Int, List<PlayerLandmarkState>>,
     modifier: Modifier = Modifier
 ) {
     if (players.isEmpty()) return
     LazyRow(
         modifier = modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.Top
     ) {
         items(items = players, key = { it.id }) { player ->
-            PlayerCoinBadge(player = player, modifier = Modifier.padding(end = 8.dp))
+            PlayerCoinBadge(
+                player = player,
+                landmarks = playerLandmarks[player.id.toIntOrNull()].orEmpty(),
+                modifier = Modifier.padding(end = 8.dp)
+            )
         }
     }
 }
@@ -186,6 +236,7 @@ private fun CoinDisplay(
 @Composable
 private fun PlayerCoinBadge(
     player: PlayerCoinState,
+    landmarks: List<PlayerLandmarkState>,
     modifier: Modifier = Modifier
 ) {
     val containerColor = when {
@@ -207,25 +258,151 @@ private fun PlayerCoinBadge(
             .widthIn(min = 118.dp, max = 180.dp)
             .semantics { contentDescription = "${player.displayName}: ${player.coins} coins" }
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
-        ) {
-            CoinIcon(modifier = Modifier.padding(end = 8.dp))
-            Column {
-                Text(
-                    text = player.displayName,
-                    style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    maxLines = 1
-                )
-                Text(
-                    text = "${player.coins} coins",
-                    style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.Bold,
-                    maxLines = 1
+        Column(modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                CoinIcon(modifier = Modifier.padding(end = 8.dp))
+                Column {
+                    Text(
+                        text = player.displayName,
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold,
+                        maxLines = 1
+                    )
+                    Text(
+                        text = "${player.coins} coins",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1
+                    )
+                }
+            }
+            if (landmarks.isNotEmpty()) {
+                LandmarkRow(
+                    landmarks = landmarks,
+                    modifier = Modifier.padding(top = 6.dp)
                 )
             }
+        }
+    }
+}
+
+/**
+ * Compact built/unbuilt indicator for a player's four landmarks, rendered in a
+ * fixed order so the columns stay stable across players and snapshots.
+ */
+@Composable
+private fun LandmarkRow(
+    landmarks: List<PlayerLandmarkState>,
+    modifier: Modifier = Modifier
+) {
+    val byType = landmarks.associateBy { it.landmarkType }
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
+        LandmarkType.entries.forEach { type ->
+            val built = byType[type]?.isBuilt == true
+            LandmarkPip(type = type, built = built)
+        }
+    }
+}
+
+@Composable
+private fun LandmarkPip(
+    type: LandmarkType,
+    built: Boolean
+) {
+    val pipColor = if (built) {
+        MaterialTheme.colorScheme.primary
+    } else {
+        MaterialTheme.colorScheme.outline
+    }
+    val builtLabel = if (built) "built" else "not built"
+    Box(
+        modifier = Modifier
+            .size(14.dp)
+            .background(color = pipColor, shape = RoundedCornerShape(3.dp))
+            .semantics { contentDescription = "${type.toDisplayText()}: $builtLabel" }
+    ) {
+        Text(
+            text = type.name.take(1),
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.Bold,
+            color = if (built) {
+                MaterialTheme.colorScheme.onPrimary
+            } else {
+                MaterialTheme.colorScheme.surface
+            },
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+    }
+}
+
+/**
+ * Marketplace supply rendered from the reconnect snapshot — one chip per card
+ * type still in stock, scrollable horizontally so all 15 types fit on a phone.
+ */
+@Composable
+private fun MarketplaceSection(
+    marketplace: Map<CardType, Int>,
+    modifier: Modifier = Modifier
+) {
+    val entries = CardType.entries.mapNotNull { type ->
+        marketplace[type]?.let { count -> type to count }
+    }
+    Surface(
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = RoundedCornerShape(12.dp),
+        tonalElevation = 2.dp,
+        modifier = modifier
+    ) {
+        Column(modifier = Modifier.padding(12.dp)) {
+            Text(
+                text = "Marketplace",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                items(items = entries, key = { it.first }) { (type, count) ->
+                    MarketplaceCardChip(type = type, count = count)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MarketplaceCardChip(
+    type: CardType,
+    count: Int
+) {
+    Surface(
+        color = MaterialTheme.colorScheme.surface,
+        shape = RoundedCornerShape(8.dp),
+        tonalElevation = 1.dp,
+        modifier = Modifier
+            .widthIn(min = 96.dp)
+            .semantics { contentDescription = "${type.toDisplayText()}: $count in stock" }
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = type.toDisplayText(),
+                style = MaterialTheme.typography.bodySmall,
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center,
+                maxLines = 2
+            )
+            Text(
+                text = "×$count",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.primary
+            )
         }
     }
 }
@@ -249,7 +426,7 @@ private fun CoinIcon(modifier: Modifier = Modifier) {
 }
 
 private fun coinDisplayTopPadding(players: List<PlayerCoinState>) =
-    if (players.isEmpty()) 0.dp else 68.dp
+    if (players.isEmpty()) 0.dp else 92.dp
 
 @Composable
 private fun GamePhaseBanner(
@@ -332,33 +509,21 @@ private fun GameScreenRollDiceNotActivePreview() {
     }
 }
 
-@Preview(showBackground = true, widthDp = 412, heightDp = 400)
+@Preview(showBackground = true, widthDp = 412, heightDp = 600)
 @Composable
-private fun GameScreenWithResultPreview() {
-    ClientTheme {
-        GameScreen(
-            state = GameScreenState(
-                gamePhase = GamePhase.ROLL_DICE,
-                connectionStatus = ConnectionStatus.CONNECTED,
-                players = previewPlayers(),
-                diceResult = listOf(3, 4),
-                myUserId = 1,
-                activePlayerId = 1,
-            )
-        )
-    }
-}
-
-@Preview(showBackground = true, widthDp = 412, heightDp = 400)
-@Composable
-private fun GameScreenBuyOrBuildPreview() {
+private fun GameScreenReconnectSnapshotPreview() {
     ClientTheme {
         GameScreen(
             state = GameScreenState(
                 gamePhase = GamePhase.BUY_OR_BUILD,
                 connectionStatus = ConnectionStatus.CONNECTED,
                 players = previewPlayers(),
-                diceResult = listOf(5)
+                diceResult = listOf(8),
+                myUserId = 1,
+                activePlayerId = 1,
+                roundNumber = 4,
+                playerLandmarks = previewLandmarks(),
+                marketplace = previewMarketplace(),
             )
         )
     }
@@ -374,20 +539,39 @@ private fun GameScreenNonePreview() {
 
 private fun previewPlayers() = listOf(
     PlayerCoinState(
-        id = "player-1",
+        id = "1",
         displayName = "You",
         coins = 6,
         isCurrentPlayer = true,
         isActivePlayer = true
     ),
     PlayerCoinState(
-        id = "player-2",
+        id = "2",
         displayName = "SoupCube",
         coins = 3
     ),
     PlayerCoinState(
-        id = "player-3",
+        id = "3",
         displayName = "doniliks",
         coins = 0
     )
+)
+
+private fun previewLandmarks() = mapOf(
+    1 to listOf(
+        PlayerLandmarkState(LandmarkType.TRAIN_STATION, isBuilt = true),
+        PlayerLandmarkState(LandmarkType.SHOPPING_MALL, isBuilt = true),
+        PlayerLandmarkState(LandmarkType.AMUSEMENT_PARK, isBuilt = false),
+        PlayerLandmarkState(LandmarkType.RADIO_TOWER, isBuilt = false),
+    ),
+    2 to LandmarkType.entries.map { PlayerLandmarkState(it, isBuilt = false) },
+    3 to LandmarkType.entries.map { PlayerLandmarkState(it, isBuilt = false) },
+)
+
+private fun previewMarketplace() = mapOf(
+    CardType.WHEAT_FIELD to 6,
+    CardType.BAKERY to 5,
+    CardType.CAFE to 6,
+    CardType.CONVENIENCE_STORE to 4,
+    CardType.FOREST to 6,
 )

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
@@ -49,6 +49,26 @@ class GameScreenViewModel(
             }
         }
         viewModelScope.launch {
+            webSocketClient.gameStatus.collect { gameStatus ->
+                mutableState.update { it.copy(gameStatus = gameStatus) }
+            }
+        }
+        viewModelScope.launch {
+            webSocketClient.roundNumber.collect { roundNumber ->
+                mutableState.update { it.copy(roundNumber = roundNumber) }
+            }
+        }
+        viewModelScope.launch {
+            webSocketClient.playerLandmarks.collect { playerLandmarks ->
+                mutableState.update { it.copy(playerLandmarks = playerLandmarks) }
+            }
+        }
+        viewModelScope.launch {
+            webSocketClient.marketplace.collect { marketplace ->
+                mutableState.update { it.copy(marketplace = marketplace) }
+            }
+        }
+        viewModelScope.launch {
             sessionStateHolder.session.collect { session ->
                 mutableState.update { it.copy(myUserId = session?.userId) }
             }

--- a/app/src/test/java/com/machikoro/client/domain/model/state/SnapshotDisplayTest.kt
+++ b/app/src/test/java/com/machikoro/client/domain/model/state/SnapshotDisplayTest.kt
@@ -1,0 +1,29 @@
+package com.machikoro.client.domain.model.state
+
+import com.machikoro.client.domain.enums.CardType
+import com.machikoro.client.domain.enums.LandmarkType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SnapshotDisplayTest {
+
+    @Test
+    fun landmarkTypeDisplayTextIsTitleCased() {
+        assertEquals("Train Station", LandmarkType.TRAIN_STATION.toDisplayText())
+        assertEquals("Radio Tower", LandmarkType.RADIO_TOWER.toDisplayText())
+    }
+
+    @Test
+    fun cardTypeDisplayTextIsTitleCased() {
+        assertEquals("Wheat Field", CardType.WHEAT_FIELD.toDisplayText())
+        assertEquals(
+            "Fruit And Vegetable Market",
+            CardType.FRUIT_AND_VEGETABLE_MARKET.toDisplayText(),
+        )
+    }
+
+    @Test
+    fun singleWordEnumDisplayTextIsCapitalized() {
+        assertEquals("Forest", CardType.FOREST.toDisplayText())
+    }
+}

--- a/app/src/test/java/com/machikoro/client/network/websocket/FakeWebSocketClient.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/FakeWebSocketClient.kt
@@ -1,8 +1,11 @@
 package com.machikoro.client.network.websocket
 
+import com.machikoro.client.domain.enums.CardType
 import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.PlayerCoinState
+import com.machikoro.client.domain.model.state.PlayerLandmarkState
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -34,6 +37,18 @@ class FakeWebSocketClient : WebSocketClient {
     override val isLobbyHost: StateFlow<Boolean>
         get() = mutableIsLobbyHost
 
+    override val gameStatus: StateFlow<GameStatus?>
+        get() = mutableGameStatus
+
+    override val roundNumber: StateFlow<Int?>
+        get() = mutableRoundNumber
+
+    override val playerLandmarks: StateFlow<Map<Int, List<PlayerLandmarkState>>>
+        get() = mutablePlayerLandmarks
+
+    override val marketplace: StateFlow<Map<CardType, Int>>
+        get() = mutableMarketplace
+
     override val authRejections: SharedFlow<Unit>
         get() = mutableAuthRejections
 
@@ -45,6 +60,11 @@ class FakeWebSocketClient : WebSocketClient {
     private val mutableActivePlayerId = MutableStateFlow<Int?>(null)
     private val mutableActiveGameId = MutableStateFlow<Int?>(null)
     private val mutableIsLobbyHost = MutableStateFlow(false)
+    private val mutableGameStatus = MutableStateFlow<GameStatus?>(null)
+    private val mutableRoundNumber = MutableStateFlow<Int?>(null)
+    private val mutablePlayerLandmarks =
+        MutableStateFlow<Map<Int, List<PlayerLandmarkState>>>(emptyMap())
+    private val mutableMarketplace = MutableStateFlow<Map<CardType, Int>>(emptyMap())
     private val mutableAuthRejections = MutableSharedFlow<Unit>(
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
@@ -106,6 +126,22 @@ class FakeWebSocketClient : WebSocketClient {
 
     fun emitIsLobbyHost(isHost: Boolean) {
         mutableIsLobbyHost.value = isHost
+    }
+
+    fun emitGameStatus(status: GameStatus?) {
+        mutableGameStatus.value = status
+    }
+
+    fun emitRoundNumber(round: Int?) {
+        mutableRoundNumber.value = round
+    }
+
+    fun emitPlayerLandmarks(landmarks: Map<Int, List<PlayerLandmarkState>>) {
+        mutablePlayerLandmarks.value = landmarks
+    }
+
+    fun emitMarketplace(marketplace: Map<CardType, Int>) {
+        mutableMarketplace.value = marketplace
     }
 
     fun emitAuthRejection() {

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -1,8 +1,12 @@
 package com.machikoro.client.network.websocket
 
+import com.machikoro.client.domain.enums.CardType
 import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.enums.GameStatus
+import com.machikoro.client.domain.enums.LandmarkType
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.PlayerCoinState
+import com.machikoro.client.domain.model.state.PlayerLandmarkState
 import com.machikoro.client.domain.session.Session
 import com.machikoro.client.domain.session.SessionStateHolder
 import java.io.IOException
@@ -517,6 +521,124 @@ class OkHttpWebSocketClientTest {
         assertEquals(null, client.lobbyCode.value)
     }
 
+    // ── reconnect snapshot (/app/game.sync -> /user/queue/game-sync) ─────────
+
+    @Test
+    fun connectedFrameSubscribesToGameSyncQueue() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        assertTrue(
+            factory.socket.sentMessages.any {
+                it.startsWith("SUBSCRIBE") && it.contains("destination:/user/queue/game-sync")
+            }
+        )
+    }
+
+    @Test
+    fun syncMessageRestoresGameStatusPhaseAndRound() {
+        val client = clientAfterSync()
+        assertEquals(GameStatus.IN_PROGRESS, client.gameStatus.value)
+        assertEquals(GamePhase.BUY_OR_BUILD, client.gamePhase.value)
+        assertEquals(3, client.roundNumber.value)
+    }
+
+    @Test
+    fun syncMessageRestoresPlayers() {
+        val client = clientAfterSync()
+        assertEquals(2, client.players.value.size)
+        assertEquals(10, client.players.value.first { it.id == "11" }.coins)
+        assertEquals(7, client.players.value.first { it.id == "22" }.coins)
+    }
+
+    @Test
+    fun syncMessageResolvesActivePlayerUserIdFromTurnOrder() {
+        // turnOrder[currentTurnIndex=0] = playerId 11, whose userId is 1.
+        val client = clientAfterSync()
+        assertEquals(1, client.activePlayerId.value)
+    }
+
+    @Test
+    fun syncMessageSurfacesLastDiceRollAsDiceResult() {
+        val client = clientAfterSync()
+        assertEquals(listOf(8), client.diceResult.value)
+    }
+
+    @Test
+    fun syncMessageRestoresMarketplaceSupply() {
+        val client = clientAfterSync()
+        assertEquals(
+            mapOf(CardType.WHEAT_FIELD to 6, CardType.BAKERY to 5),
+            client.marketplace.value
+        )
+    }
+
+    @Test
+    fun syncMessageRestoresPlayerLandmarkBuildState() {
+        val client = clientAfterSync()
+        val playerOneLandmarks = client.playerLandmarks.value[11].orEmpty()
+        assertEquals(
+            PlayerLandmarkState(LandmarkType.TRAIN_STATION, isBuilt = true),
+            playerOneLandmarks.first { it.landmarkType == LandmarkType.TRAIN_STATION }
+        )
+        assertFalse(
+            playerOneLandmarks.first { it.landmarkType == LandmarkType.SHOPPING_MALL }.isBuilt
+        )
+        assertFalse(client.playerLandmarks.value[22].orEmpty().single().isBuilt)
+    }
+
+    @Test
+    fun malformedSyncMessageDoesNotCrashAndLeavesSnapshotEmpty() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        factory.simulateText(syncFrame("""{"type":"SYNC","payload":{"state":"not an object"}}"""))
+        assertNull(client.gameStatus.value)
+        assertNull(client.roundNumber.value)
+        assertTrue(client.marketplace.value.isEmpty())
+        assertTrue(client.playerLandmarks.value.isEmpty())
+    }
+
+    @Test
+    fun disconnectResetsSnapshotState() {
+        val client = clientAfterSync()
+        client.disconnect()
+        assertNull(client.gameStatus.value)
+        assertNull(client.roundNumber.value)
+        assertTrue(client.marketplace.value.isEmpty())
+        assertTrue(client.playerLandmarks.value.isEmpty())
+    }
+
+    /** Connects a client and feeds it one realistic SYNC snapshot frame. */
+    private fun clientAfterSync(): OkHttpWebSocketClient {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        factory.simulateText(syncFrame(SYNC_SNAPSHOT_BODY))
+        return client
+    }
+
+    /** A bare STOMP CONNECTED frame, correctly NUL-terminated by serialize(). */
+    private fun connectedFrame(): String =
+        StompFrame(command = "CONNECTED", headers = mapOf("version" to "1.2")).serialize()
+
+    /** A MESSAGE frame on the per-user game-sync queue carrying [body]. */
+    private fun syncFrame(body: String): String =
+        StompFrame(
+            command = "MESSAGE",
+            headers = mapOf(
+                "destination" to WebSocketContract.gameSyncQueue,
+                "content-type" to "application/json",
+            ),
+            body = body,
+        ).serialize()
+
     private fun gameActionFrame(body: String): String =
         "MESSAGE\ndestination:/topic/public\ncontent-type:application/json\n\n$body\u0000"
 
@@ -568,6 +690,19 @@ class OkHttpWebSocketClientTest {
         const val DEFAULT_USERNAME = "test-user"
         const val DEFAULT_USER_ID = 1
         val DEFAULT_SESSION = Session(DEFAULT_TOKEN, DEFAULT_USERNAME, DEFAULT_USER_ID)
+
+        // A full /app/game.sync snapshot: game IN_PROGRESS / BUY_OR_BUILD,
+        // round 3, last roll 8; player 11 (userId 1) is active with one
+        // landmark built; marketplace has WHEAT_FIELD x6 and BAKERY x5.
+        const val SYNC_SNAPSHOT_BODY =
+            """{"type":"SYNC","sender":"server","gameId":7,"payload":{"targetUserId":1,""" +
+                """"state":{"game":{"id":7,"status":"IN_PROGRESS","turnPhase":"BUY_OR_BUILD",""" +
+                """"lastDiceRoll":8,"roundNumber":3,"currentTurnIndex":0},""" +
+                """"players":[{"id":11,"userId":1,"coins":10},{"id":22,"userId":2,"coins":7}],""" +
+                """"playerLandmarks":{"11":[{"playerId":11,"landmarkType":"TRAIN_STATION","isBuilt":true},""" +
+                """{"playerId":11,"landmarkType":"SHOPPING_MALL","isBuilt":false}],""" +
+                """"22":[{"playerId":22,"landmarkType":"TRAIN_STATION","isBuilt":false}]},""" +
+                """"marketplace":{"WHEAT_FIELD":6,"BAKERY":5},"turnOrder":[11,22]}}}"""
     }
 
     private fun newClient(

--- a/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
@@ -1,8 +1,12 @@
 package com.machikoro.client.ui.game
 
+import com.machikoro.client.domain.enums.CardType
 import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.enums.GameStatus
+import com.machikoro.client.domain.enums.LandmarkType
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.PlayerCoinState
+import com.machikoro.client.domain.model.state.PlayerLandmarkState
 import com.machikoro.client.domain.session.Session
 import com.machikoro.client.domain.session.SessionStateHolder
 import com.machikoro.client.network.websocket.FakeWebSocketClient
@@ -307,5 +311,56 @@ class GameScreenViewModelTest {
         viewModel.rollDice(diceCount = 1)
 
         assertFalse(viewModel.state.value.isRolling)
+    }
+
+    @Test
+    fun gameStatusFromClientIsReflectedInState() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient)
+
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
+        advanceUntilIdle()
+
+        assertEquals(GameStatus.IN_PROGRESS, viewModel.state.value.gameStatus)
+    }
+
+    @Test
+    fun roundNumberFromClientIsReflectedInState() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient)
+
+        fakeClient.emitRoundNumber(4)
+        advanceUntilIdle()
+
+        assertEquals(4, viewModel.state.value.roundNumber)
+    }
+
+    @Test
+    fun playerLandmarksFromClientAreReflectedInState() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient)
+        val landmarks = mapOf(
+            1 to listOf(
+                PlayerLandmarkState(LandmarkType.TRAIN_STATION, isBuilt = true),
+                PlayerLandmarkState(LandmarkType.SHOPPING_MALL, isBuilt = false),
+            )
+        )
+
+        fakeClient.emitPlayerLandmarks(landmarks)
+        advanceUntilIdle()
+
+        assertEquals(landmarks, viewModel.state.value.playerLandmarks)
+    }
+
+    @Test
+    fun marketplaceFromClientIsReflectedInState() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient)
+        val marketplace = mapOf(CardType.WHEAT_FIELD to 6, CardType.BAKERY to 5)
+
+        fakeClient.emitMarketplace(marketplace)
+        advanceUntilIdle()
+
+        assertEquals(marketplace, viewModel.state.value.marketplace)
     }
 }

--- a/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
@@ -1,8 +1,11 @@
 package com.machikoro.client.ui.home
 
+import com.machikoro.client.domain.enums.CardType
 import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.PlayerCoinState
+import com.machikoro.client.domain.model.state.PlayerLandmarkState
 import com.machikoro.client.network.websocket.WebSocketClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -142,6 +145,14 @@ class HomeScreenViewModelTest {
         override val activeGameId: StateFlow<Int?> = mutableActiveGameId
         val mutableIsLobbyHost = MutableStateFlow(false)
         override val isLobbyHost: StateFlow<Boolean> = mutableIsLobbyHost
+        override val gameStatus: StateFlow<GameStatus?> =
+            MutableStateFlow(null)
+        override val roundNumber: StateFlow<Int?> =
+            MutableStateFlow(null)
+        override val playerLandmarks: StateFlow<Map<Int, List<PlayerLandmarkState>>> =
+            MutableStateFlow(emptyMap())
+        override val marketplace: StateFlow<Map<CardType, Int>> =
+            MutableStateFlow(emptyMap())
 
         override val authRejections: SharedFlow<Unit> = MutableSharedFlow(
             extraBufferCapacity = 1,

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,9 +6,10 @@ sonar.sources=app/src/main/java
 sonar.tests=app/src/test/java
 sonar.sourceEncoding=UTF-8
 
-# Kotlin/Android binaries (required by SonarScanner for Kotlin analysis)
-sonar.java.binaries=app/build/tmp/kotlin-classes/debug
-sonar.java.test.binaries=app/build/tmp/kotlin-classes/debugUnitTest
+# Kotlin/Android binaries (required by SonarScanner for Kotlin analysis).
+# AGP's built-in Kotlin compiler emits classes under intermediates/built_in_kotlinc/.
+sonar.java.binaries=app/build/intermediates/built_in_kotlinc/debug/compileDebugKotlin/classes
+sonar.java.test.binaries=app/build/intermediates/built_in_kotlinc/debugUnitTest/compileDebugUnitTestKotlin/classes
 
 # JaCoCo coverage report produced by the `jacocoTestReport` Gradle task
 sonar.coverage.jacoco.xmlReportPaths=app/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml


### PR DESCRIPTION
Closes #140. Final piece of the SE2-Machi-Koro/Server#246 reconnect chain on the client side.

## What's broken today

The client subscribes only to `/topic/public` and `/topic/game/{id}` — **never to `/user/queue/game-sync`**. The server pushes a full reconnect snapshot there (automatically, after `chat.addUser` detects an active in-progress game), but the client silently drops it. Reconnecting mid-game restores nothing.

## What this PR does

### Snapshot parsing (commit `ee029f7`)
- Subscribe to `/user/queue/game-sync` on STOMP CONNECTED — *before* the JOIN send, so the subscription is registered when the server emits the auto-sync.
- Parse the `SYNC` message: it wraps a full `GameStateDto` under `payload.state`. One snapshot restores game status, turn phase, round, players/coins, active player, dice, **landmarks**, and **marketplace**.
- New client enums (`GameStatus`, `CardType`, `LandmarkType`) + `PlayerLandmarkState` model for type-safe deserialization.
- New `WebSocketClient` flows: `gameStatus`, `roundNumber`, `playerLandmarks`, `marketplace`.
- Active player's `userId` resolved from `turnOrder[currentTurnIndex]` → the matching player row (turnOrder holds playerIds).

### Rendering + routing (commit `d20e647`)
- `GameScreen` renders each player's four landmarks as built/unbuilt pips inside their badge, a horizontally-scrollable marketplace supply section, and a round-number indicator.
- `GameScreenViewModel` collects the new flows into `GameScreenState`.
- `AppRoot` routes `gameStatus == FINISHED` to the (previously unwired) `GameOverOneWinner` screen. The winner is derived client-side from the snapshot — the player whose landmarks are all built (Machi Koro's win condition) — so no extra server field is needed.

## Test plan

- [x] `./gradlew test compileDebugAndroidTestKotlin assembleDebug` — BUILD SUCCESSFUL; all unit tests pass, androidTest compiles, APK builds.
- [x] 8 SYNC-parsing tests in `OkHttpWebSocketClientTest` (status/phase/round, players, active-player resolution, dice, marketplace, landmarks, malformed payload, disconnect-reset, sync-queue subscription).
- [x] 4 viewmodel-mapping tests in `GameScreenViewModelTest`.
- [x] 4 Compose rendering tests in `GameScreenSnapshotTest` (round, marketplace, landmark build-state, dice) + 1 `AppRootTest` FINISHED-routing test — instrumented; run on-device.
- [ ] Manual: kill the app mid-game, relaunch → board reconstructs from the snapshot.

## Notes

- **Forward-compatible** with the server concurrently extending `GameStateDto` (e.g. card/landmark definitions) — `handleSync` reads only the fields it needs and ignores extras.
- `lastDiceRoll` — the server snapshot persists only the dice *total*, so on reconnect the dice display shows the total as a single value. Live rolls still show individual dice.
- FINISHED routing fires on the reconnect snapshot (per #140 scope). The live "game just ended" transition needs a separate `GAME_WON` broadcast handler — worth a follow-up issue.