### PR TITLE
64 navigation structure setup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation(libs.retrofit.kotlinx.serialization.converter)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.androidx.datastore.preferences)
+    implementation(libs.androidx.navigation.compose)
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.androidx.datastore.preferences.core)

--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -126,6 +126,7 @@ class MainActivity : ComponentActivity() {
                         onReadyToggle = lobbyScreenViewModel::onReadyToggle,
                         onStartGame = homeViewModel::startGame,
                         onLeaveLobby = {
+                            showLobbyScreen = false
                             lobbyScreenViewModel.onLeaveLobby()
                             homeViewModel.clearLobbyCode()
                         },

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -1,8 +1,13 @@
 package com.machikoro.client.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navOptions
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.GameScreenState
@@ -14,6 +19,7 @@ import com.machikoro.client.domain.model.state.StartScreenState
 import com.machikoro.client.ui.game.GameScreen
 import com.machikoro.client.ui.home.HomeScreen
 import com.machikoro.client.ui.lobby.LobbyScreen
+import com.machikoro.client.ui.navigation.AppRoute
 import com.machikoro.client.ui.start.StartScreen
 import com.machikoro.client.ui.theme.ClientTheme
 
@@ -26,7 +32,6 @@ fun AppRoot(
     loginDialogState: LoginDialogState,
     logoutState: LogoutState,
     lobbyCode: String?,
-    isLobbyHost: Boolean,
     loggedInAs: String?,
     onRegisterUsernameChange: (String) -> Unit,
     onRegisterPasswordChange: (String) -> Unit,
@@ -43,52 +48,81 @@ fun AppRoot(
     onLeaveLobby: () -> Unit = {},
     onRollDice: () -> Unit = {},
     modifier: Modifier = Modifier,
+    isLobbyHost: Boolean = false,
     showLobbyScreen: Boolean = false,
     onGoToLobbyClick: () -> Unit = {},
 ) {
-    if (gameScreenState.gamePhase != GamePhase.NONE) {
-        GameScreen(
-            state = gameScreenState,
-            onRollDice = onRollDice,
-            modifier = modifier
-        )
-    } else if (lobbyCode != null) {
-        LobbyScreen(
-            state = lobbyScreenState,
-            onReadyToggle = onReadyToggle,
-            onStartGame = onStartGame,
-            onLeaveLobby = onLeaveLobby,
-            modifier = modifier
-        )
-    } else if (loggedInAs != null) {
-        HomeScreen(
-            lobbyCode = lobbyCode,
-            isLobbyHost = isLobbyHost,
-            canStartGame = isLobbyHost &&
+    val navController = rememberNavController()
+
+    // Keep the current state-based screen priority while hosting screens in one NavHost.
+    // TODO(#68,#69): Move route decisions into ViewModel navigation state/events.
+    val targetRoute = when {
+        gameScreenState.gamePhase != GamePhase.NONE -> AppRoute.Game
+        showLobbyScreen -> AppRoute.Lobby
+        loggedInAs != null -> AppRoute.Home
+        else -> AppRoute.Main
+    }
+
+    LaunchedEffect(targetRoute) {
+        if (navController.currentDestination?.route != targetRoute.route) {
+            navController.navigate(
+                targetRoute.route,
+                navOptions {
+                    launchSingleTop = true
+                    popUpTo(AppRoute.Main.route)
+                }
+            )
+        }
+    }
+
+    NavHost(
+        navController = navController,
+        startDestination = AppRoute.Main.route,
+        modifier = modifier,
+    ) {
+        composable(AppRoute.Main.route) {
+            StartScreen(
+                state = startScreenState,
+                registerDialogState = registerDialogState,
+                loginDialogState = loginDialogState,
+                logoutState = logoutState,
+                onRegisterUsernameChange = onRegisterUsernameChange,
+                onRegisterPasswordChange = onRegisterPasswordChange,
+                onRegisterSubmit = onRegisterSubmit,
+                onRegisterDialogReset = onRegisterDialogReset,
+                onLoginUsernameChange = onLoginUsernameChange,
+                onLoginPasswordChange = onLoginPasswordChange,
+                onLoginSubmit = onLoginSubmit,
+                onLoginDialogReset = onLoginDialogReset,
+                onLogoutSubmit = onLogoutSubmit,
+            )
+        }
+        composable(AppRoute.Home.route) {
+            HomeScreen(
+                lobbyCode = lobbyCode,
+                isLobbyHost = isLobbyHost,
+                canStartGame = isLobbyHost &&
                     startScreenState.connectionStatus == ConnectionStatus.CONNECTED,
-            onCreateLobbyClick = onCreateLobbyClick,
-            onStartGame = onStartGame,
-            showLobbyScreen = showLobbyScreen,
-            onGoToLobbyClick = onGoToLobbyClick,
-            modifier = modifier
-        )
-    } else {
-        StartScreen(
-            state = startScreenState,
-            registerDialogState = registerDialogState,
-            loginDialogState = loginDialogState,
-            logoutState = logoutState,
-            onRegisterUsernameChange = onRegisterUsernameChange,
-            onRegisterPasswordChange = onRegisterPasswordChange,
-            onRegisterSubmit = onRegisterSubmit,
-            onRegisterDialogReset = onRegisterDialogReset,
-            onLoginUsernameChange = onLoginUsernameChange,
-            onLoginPasswordChange = onLoginPasswordChange,
-            onLoginSubmit = onLoginSubmit,
-            onLoginDialogReset = onLoginDialogReset,
-            onLogoutSubmit = onLogoutSubmit,
-            modifier = modifier
-        )
+                onCreateLobbyClick = onCreateLobbyClick,
+                onStartGame = onStartGame,
+                showLobbyScreen = showLobbyScreen,
+                onGoToLobbyClick = onGoToLobbyClick,
+            )
+        }
+        composable(AppRoute.Lobby.route) {
+            LobbyScreen(
+                state = lobbyScreenState,
+                onReadyToggle = onReadyToggle,
+                onStartGame = onStartGame,
+                onLeaveLobby = onLeaveLobby,
+            )
+        }
+        composable(AppRoute.Game.route) {
+            GameScreen(
+                state = gameScreenState,
+                onRollDice = onRollDice,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -57,134 +57,84 @@ fun AppRoot(
 ) {
     val navController = rememberNavController()
 
-// Keep the current state-based screen priority while hosting screens in one NavHost.
-// TODO(#68,#69): Move route decisions into ViewModel navigation state/events.
-val targetRoute = when {
-    gameScreenState.gameStatus == GameStatus.FINISHED -> AppRoute.Winner
-    gameScreenState.gamePhase != GamePhase.NONE -> AppRoute.Game
-    showLobbyScreen -> AppRoute.Lobby
-    loggedInAs != null -> AppRoute.Home
-    else -> AppRoute.Main
-}
-
-LaunchedEffect(targetRoute) {
-    if (navController.currentDestination?.route != targetRoute.route) {
-        navController.navigate(
-            targetRoute.route,
-            navOptions {
-                launchSingleTop = true
-                popUpTo(AppRoute.Main.route)
-            }
-        )
-    }
-}
-
-NavHost(
-    navController = navController,
-    startDestination = AppRoute.Main.route,
-    modifier = modifier,
-) {
-    composable(AppRoute.Main.route) {
-        StartScreen(
-            state = startScreenState,
-            registerDialogState = registerDialogState,
-            loginDialogState = loginDialogState,
-            logoutState = logoutState,
-            onRegisterUsernameChange = onRegisterUsernameChange,
-            onRegisterPasswordChange = onRegisterPasswordChange,
-            onRegisterSubmit = onRegisterSubmit,
-            onRegisterDialogReset = onRegisterDialogReset,
-            onLoginUsernameChange = onLoginUsernameChange,
-            onLoginPasswordChange = onLoginPasswordChange,
-            onLoginSubmit = onLoginSubmit,
-            onLoginDialogReset = onLoginDialogReset,
-            onLogoutSubmit = onLogoutSubmit,
-        )
+    // Keep the current state-based screen priority while hosting screens in one NavHost.
+    // TODO(#68,#69): Move route decisions into ViewModel navigation state/events.
+    val targetRoute = when {
+        gameScreenState.gameStatus == GameStatus.FINISHED -> AppRoute.Winner
+        gameScreenState.gamePhase != GamePhase.NONE -> AppRoute.Game
+        showLobbyScreen -> AppRoute.Lobby
+        loggedInAs != null -> AppRoute.Home
+        else -> AppRoute.Main
     }
 
-    composable(AppRoute.Home.route) {
-        HomeScreen(
-            lobbyCode = lobbyCode,
-            onCreateLobbyClick = onCreateLobbyClick,
-            onGoToLobbyClick = onGoToLobbyClick,
-            onLogoutClick = onLogoutSubmit,
-        )
+    LaunchedEffect(targetRoute) {
+        if (navController.currentDestination?.route != targetRoute.route) {
+            navController.navigate(
+                targetRoute.route,
+                navOptions {
+                    launchSingleTop = true
+                    popUpTo(AppRoute.Main.route)
+                }
+            )
+        }
     }
 
-    composable(AppRoute.Lobby.route) {
-        LobbyScreen(
-            state = lobbyScreenState,
-            lobbyCode = lobbyCode,
-            onReadyToggle = onReadyToggle,
-            onStartGame = onStartGame,
-            onLeaveLobby = onLeaveLobby,
-        )
-    }
+    NavHost(
+        navController = navController,
+        startDestination = AppRoute.Main.route,
+        modifier = modifier,
+    ) {
+        composable(AppRoute.Main.route) {
+            StartScreen(
+                state = startScreenState,
+                registerDialogState = registerDialogState,
+                loginDialogState = loginDialogState,
+                logoutState = logoutState,
+                onRegisterUsernameChange = onRegisterUsernameChange,
+                onRegisterPasswordChange = onRegisterPasswordChange,
+                onRegisterSubmit = onRegisterSubmit,
+                onRegisterDialogReset = onRegisterDialogReset,
+                onLoginUsernameChange = onLoginUsernameChange,
+                onLoginPasswordChange = onLoginPasswordChange,
+                onLoginSubmit = onLoginSubmit,
+                onLoginDialogReset = onLoginDialogReset,
+                onLogoutSubmit = onLogoutSubmit,
+            )
+        }
 
-    composable(AppRoute.Game.route) {
-        GameScreen(
-            state = gameScreenState,
-            onRollDice = onRollDice,
-            onPurchaseClick = onPurchaseClick,
-        )
-    }
+        composable(AppRoute.Home.route) {
+            HomeScreen(
+                lobbyCode = lobbyCode,
+                onCreateLobbyClick = onCreateLobbyClick,
+                onGoToLobbyClick = onGoToLobbyClick,
+                onLogoutClick = onLogoutSubmit,
+            )
+        }
 
-    composable(AppRoute.Winner.route) {
-        GameOverOneWinner(
-            winnerName = resolveWinnerName(gameScreenState),
-            roundsNumber = gameScreenState.roundNumber ?: 0,
-        )
-    }
-}
+        composable(AppRoute.Lobby.route) {
+            LobbyScreen(
+                state = lobbyScreenState,
+                lobbyCode = lobbyCode,
+                onReadyToggle = onReadyToggle,
+                onStartGame = onStartGame,
+                onLeaveLobby = onLeaveLobby,
+            )
+        }
 
-    if (gameScreenState.gameStatus == GameStatus.FINISHED) {
-        // A finished game outranks every other screen: even mid-phase, once the
-        // snapshot reports FINISHED the player should see the end screen.
-        GameOverOneWinner(
-            winnerName = resolveWinnerName(gameScreenState),
-            roundsNumber = gameScreenState.roundNumber ?: 0,
-        )
-    } else if (gameScreenState.gamePhase != GamePhase.NONE) {
-        GameScreen(
-            state = gameScreenState,
-            onRollDice = onRollDice,
-            onPurchaseClick = onPurchaseClick,
-            modifier = modifier
-        )
-    } else if (showLobbyScreen) {
-        LobbyScreen(
-            state = lobbyScreenState,
-            lobbyCode = lobbyCode,
-            onReadyToggle = onReadyToggle,
-            onStartGame = onStartGame,
-            onLeaveLobby = onLeaveLobby,
-            modifier = modifier
-        )
-    } else if (loggedInAs != null) {
-        HomeScreen(
-            lobbyCode = lobbyCode,
-            onCreateLobbyClick = onCreateLobbyClick,
-            onGoToLobbyClick = onGoToLobbyClick,
-            onLogoutClick = onLogoutSubmit,
-            modifier = modifier
-        )
-    } else {
-        StartScreen(
-            state = startScreenState,
-            registerDialogState = registerDialogState,
-            loginDialogState = loginDialogState,
-            logoutState = logoutState,
-            onRegisterUsernameChange = onRegisterUsernameChange,
-            onRegisterPasswordChange = onRegisterPasswordChange,
-            onRegisterSubmit = onRegisterSubmit,
-            onRegisterDialogReset = onRegisterDialogReset,
-            onLoginUsernameChange = onLoginUsernameChange,
-            onLoginPasswordChange = onLoginPasswordChange,
-            onLoginSubmit = onLoginSubmit,
-            onLoginDialogReset = onLoginDialogReset,
-            onLogoutSubmit = onLogoutSubmit,
-            modifier = modifier
-        )
+        composable(AppRoute.Game.route) {
+            GameScreen(
+                state = gameScreenState,
+                onRollDice = onRollDice,
+                onPurchaseClick = onPurchaseClick,
+            )
+        }
+
+        composable(AppRoute.Winner.route) {
+            GameOverOneWinner(
+                winnerName = resolveWinnerName(gameScreenState),
+                roundsNumber = gameScreenState.roundNumber ?: 0,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/machikoro/client/ui/navigation/AppRoute.kt
+++ b/app/src/main/java/com/machikoro/client/ui/navigation/AppRoute.kt
@@ -8,4 +8,5 @@ sealed class AppRoute(val route: String) {
     data object Home : AppRoute("home")
     data object Lobby : AppRoute("lobby")
     data object Game : AppRoute("game")
+    data object Winner : AppRoute("winner")
 }

--- a/app/src/main/java/com/machikoro/client/ui/navigation/AppRoute.kt
+++ b/app/src/main/java/com/machikoro/client/ui/navigation/AppRoute.kt
@@ -1,0 +1,11 @@
+package com.machikoro.client.ui.navigation
+
+// Central route definitions for the top-level app navigation graph.
+// TODO(#65): Add navigation actions/helper methods so call sites do not navigate by raw route strings.
+// TODO(#66): Add typed route arguments here once lobby/game context is passed through navigation.
+sealed class AppRoute(val route: String) {
+    data object Main : AppRoute("main")
+    data object Home : AppRoute("home")
+    data object Lobby : AppRoute("lobby")
+    data object Game : AppRoute("game")
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ composeMaterial3 = "1.6.0"
 retrofit = "2.11.0"
 kotlinxSerialization = "1.8.0"
 datastore = "1.1.1"
+navigation = "2.9.8"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -43,6 +44,7 @@ retrofit-kotlinx-serialization-converter = { group = "com.squareup.retrofit2", n
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 androidx-datastore-preferences-core = { group = "androidx.datastore", name = "datastore-preferences-core", version.ref = "datastore" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

- Add Navigation Compose dependency and version catalog entry.
- Define centralized top-level app routes: `main`, `home`, `lobby`, `game`, and `winner`.
- Replace manual `AppRoot` screen branching with a single `NavHost`.
- Preserve the existing Home -> Lobby flow: lobby code can be shown on Home first, and Lobby opens only after `showLobbyScreen` is set.
- Preserve existing game navigation behavior, including Game and Winner screen routing from game state.
- Reset lobby navigation state when leaving Lobby.

## Scope

This PR implements issue #64 only: navigation structure setup.

It intentionally does not implement:

- navigation action abstraction (#65)
- route argument passing (#66)
- ViewModel-driven navigation (#68)
- single-source-of-truth navigation state (#69)


