### PR TITLE
feat: abstract app navigation actions

### DIFF
--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -7,7 +7,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navOptions
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.model.state.ConnectionStatus
@@ -20,6 +19,7 @@ import com.machikoro.client.domain.model.state.StartScreenState
 import com.machikoro.client.ui.game.GameScreen
 import com.machikoro.client.ui.home.HomeScreen
 import com.machikoro.client.ui.lobby.LobbyScreen
+import com.machikoro.client.ui.navigation.AppNavigator
 import com.machikoro.client.ui.navigation.AppRoute
 import com.machikoro.client.ui.start.StartScreen
 import com.machikoro.client.ui.theme.ClientTheme
@@ -62,6 +62,7 @@ fun AppRoot(
 ) {
 
     val navController = rememberNavController()
+    val appNavigator = AppNavigator(navController)
 
     // Keep the current state-based screen priority while hosting screens in one NavHost.
     // TODO(#68,#69): Move route decisions into ViewModel navigation state/events.
@@ -74,15 +75,7 @@ fun AppRoot(
     }
 
     LaunchedEffect(targetRoute) {
-        if (navController.currentDestination?.route != targetRoute.route) {
-            navController.navigate(
-                targetRoute.route,
-                navOptions {
-                    launchSingleTop = true
-                    popUpTo(AppRoute.Main.route)
-                }
-            )
-        }
+        appNavigator.navigateTo(targetRoute)
     }
 
     NavHost(

--- a/app/src/main/java/com/machikoro/client/ui/navigation/AppNavigator.kt
+++ b/app/src/main/java/com/machikoro/client/ui/navigation/AppNavigator.kt
@@ -1,0 +1,20 @@
+package com.machikoro.client.ui.navigation
+
+import androidx.navigation.NavHostController
+import androidx.navigation.navOptions
+
+class AppNavigator(
+    private val navController: NavHostController,
+) {
+    fun navigateTo(route: AppRoute) {
+        if (navController.currentDestination?.route == route.route) return
+
+        navController.navigate(
+            route.route,
+            navOptions {
+                launchSingleTop = true
+                popUpTo(AppRoute.Main.route)
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/machikoro/client/ui/navigation/AppRoute.kt
+++ b/app/src/main/java/com/machikoro/client/ui/navigation/AppRoute.kt
@@ -1,7 +1,6 @@
 package com.machikoro.client.ui.navigation
 
 // Central route definitions for the top-level app navigation graph.
-// TODO(#65): Add navigation actions/helper methods so call sites do not navigate by raw route strings.
 // TODO(#66): Add typed route arguments here once lobby/game context is passed through navigation.
 sealed class AppRoute(val route: String) {
     data object Main : AppRoute("main")


### PR DESCRIPTION
## Summary

- Add `AppNavigator` as a dedicated helper for app navigation actions.
- Move direct `navController.navigate(...)` logic out of `AppRoot`.
- Keep navigation options centralized in `AppNavigator`, including:
  - duplicate destination guard
  - `launchSingleTop`
  - `popUpTo(AppRoute.Main.route)`
- Keep route strings centralized in `AppRoute`.
- Remove the completed `TODO(#65)` from `AppRoute`.

## Scope

This PR implements issue #65 only: navigation actions abstraction.

It intentionally does not implement:

- route argument passing (#66)
- ViewModel-driven navigation (#68)
- single-source-of-truth navigation state (#69)