### PR TITLE
66 argument passing between screens

### DIFF
--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -2,11 +2,14 @@ package com.machikoro.client.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.model.state.ConnectionStatus
@@ -60,7 +63,7 @@ fun AppRoot(
     onGoToLobbyClick: () -> Unit = {},
 ) {
     val navController = rememberNavController()
-    val appNavigator = AppNavigator(navController)
+    val appNavigator = remember(navController) { AppNavigator(navController) }
 
     // Keep the current state-based screen priority while hosting screens in one NavHost.
     // TODO(#68,#69): Move route decisions into ViewModel navigation state/events.
@@ -71,9 +74,13 @@ fun AppRoot(
         loggedInAs != null -> AppRoute.Home
         else -> AppRoute.Main
     }
+    val routeArguments = AppRoute.AppRouteArguments(
+        lobbyCode = lobbyCode,
+        gameId = gameScreenState.gameId,
+    )
 
-    LaunchedEffect(targetRoute) {
-        appNavigator.navigateTo(targetRoute)
+    LaunchedEffect(targetRoute, routeArguments) {
+        appNavigator.navigateTo(targetRoute, routeArguments)
     }
 
     NavHost(
@@ -113,19 +120,42 @@ fun AppRoot(
             )
         }
 
-        composable(AppRoute.Lobby.route) {
+        composable(
+            route = AppRoute.Lobby.route,
+            arguments = listOf(
+                navArgument(AppRoute.Lobby.LOBBY_CODE_ARGUMENT) {
+                    type = NavType.StringType
+                    nullable = true
+                    defaultValue = null
+                }
+            ),
+        ) { backStackEntry ->
+            val routedLobbyCode = backStackEntry.arguments
+                ?.getString(AppRoute.Lobby.LOBBY_CODE_ARGUMENT)
+                ?.takeIf { it.isNotBlank() }
             LobbyScreen(
                 state = lobbyScreenState,
-                lobbyCode = lobbyCode,
+                lobbyCode = routedLobbyCode ?: lobbyCode,
                 onReadyToggle = onReadyToggle,
                 onStartGame = onStartGame,
                 onLeaveLobby = onLeaveLobby,
             )
         }
 
-        composable(AppRoute.Game.route) {
+        composable(
+            route = AppRoute.Game.route,
+            arguments = listOf(
+                navArgument(AppRoute.Game.GAME_ID_ARGUMENT) {
+                    type = NavType.IntType
+                    defaultValue = AppRoute.Game.MISSING_GAME_ID
+                }
+            ),
+        ) { backStackEntry ->
+            val routedGameId = backStackEntry.arguments
+                ?.getInt(AppRoute.Game.GAME_ID_ARGUMENT)
+                ?.takeIf { it != AppRoute.Game.MISSING_GAME_ID }
             GameScreen(
-                state = gameScreenState,
+                state = gameScreenState.copy(gameId = routedGameId ?: gameScreenState.gameId),
                 onRollDice = onRollDice,
                 onPurchaseClick = onPurchaseClick,
             )

--- a/app/src/main/java/com/machikoro/client/ui/navigation/AppNavigator.kt
+++ b/app/src/main/java/com/machikoro/client/ui/navigation/AppNavigator.kt
@@ -6,15 +6,37 @@ import androidx.navigation.navOptions
 class AppNavigator(
     private val navController: NavHostController,
 ) {
-    fun navigateTo(route: AppRoute) {
-        if (navController.currentDestination?.route == route.route) return
+    fun navigateTo(
+        route: AppRoute,
+        arguments: AppRoute.AppRouteArguments = AppRoute.AppRouteArguments(),
+    ) {
+        if (isAlreadyAt(route, arguments)) return
 
         navController.navigate(
-            route.route,
+            route.destination(arguments),
             navOptions {
                 launchSingleTop = true
                 popUpTo(AppRoute.Main.route)
             }
         )
+    }
+
+    private fun isAlreadyAt(
+        route: AppRoute,
+        arguments: AppRoute.AppRouteArguments,
+    ): Boolean {
+        if (navController.currentDestination?.route != route.route) return false
+
+        val currentArguments = navController.currentBackStackEntry?.arguments
+        return when (route) {
+            AppRoute.Lobby -> {
+                val expectedLobbyCode = arguments.lobbyCode?.takeIf { it.isNotBlank() }
+                currentArguments?.getString(AppRoute.Lobby.LOBBY_CODE_ARGUMENT) == expectedLobbyCode
+            }
+            AppRoute.Game ->
+                currentArguments?.getInt(AppRoute.Game.GAME_ID_ARGUMENT)
+                    ?.takeIf { it != AppRoute.Game.MISSING_GAME_ID } == arguments.gameId
+            else -> true
+        }
     }
 }

--- a/app/src/main/java/com/machikoro/client/ui/navigation/AppRoute.kt
+++ b/app/src/main/java/com/machikoro/client/ui/navigation/AppRoute.kt
@@ -1,11 +1,44 @@
 package com.machikoro.client.ui.navigation
 
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
 // Central route definitions for the top-level app navigation graph.
-// TODO(#66): Add typed route arguments here once lobby/game context is passed through navigation.
 sealed class AppRoute(val route: String) {
     data object Main : AppRoute("main")
     data object Home : AppRoute("home")
-    data object Lobby : AppRoute("lobby")
-    data object Game : AppRoute("game")
+    data object Lobby : AppRoute("lobby?lobbyCode={lobbyCode}") {
+        const val BASE_ROUTE = "lobby"
+        const val LOBBY_CODE_ARGUMENT = "lobbyCode"
+
+        override fun destination(arguments: AppRouteArguments): String {
+            val lobbyCode = arguments.lobbyCode?.takeIf { it.isNotBlank() } ?: return BASE_ROUTE
+            return "$BASE_ROUTE?$LOBBY_CODE_ARGUMENT=${lobbyCode.encodeRouteValue()}"
+        }
+    }
+
+    data object Game : AppRoute("game?gameId={gameId}") {
+        const val BASE_ROUTE = "game"
+        const val GAME_ID_ARGUMENT = "gameId"
+        const val MISSING_GAME_ID = -1
+
+        override fun destination(arguments: AppRouteArguments): String {
+            val gameId = arguments.gameId ?: return BASE_ROUTE
+            return "$BASE_ROUTE?$GAME_ID_ARGUMENT=$gameId"
+        }
+    }
+
     data object Winner : AppRoute("winner")
+
+    open fun destination(arguments: AppRouteArguments = AppRouteArguments()): String = route
+
+    data class AppRouteArguments(
+        val lobbyCode: String? = null,
+        val gameId: Int? = null,
+    )
+
+    private companion object {
+        fun String.encodeRouteValue(): String =
+            URLEncoder.encode(this, StandardCharsets.UTF_8.toString())
+    }
 }

--- a/app/src/test/java/com/machikoro/client/ui/navigation/AppRouteTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/navigation/AppRouteTest.kt
@@ -1,0 +1,38 @@
+package com.machikoro.client.ui.navigation
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AppRouteTest {
+    @Test
+    fun lobbyDestinationOmitsArgumentWhenLobbyCodeIsMissing() {
+        val route = AppRoute.Lobby.destination()
+
+        assertEquals(AppRoute.Lobby.BASE_ROUTE, route)
+    }
+
+    @Test
+    fun lobbyDestinationIncludesLobbyCodeArgument() {
+        val route = AppRoute.Lobby.destination(
+            AppRoute.AppRouteArguments(lobbyCode = "ABC1234")
+        )
+
+        assertEquals("lobby?lobbyCode=ABC1234", route)
+    }
+
+    @Test
+    fun gameDestinationOmitsArgumentWhenGameIdIsMissing() {
+        val route = AppRoute.Game.destination()
+
+        assertEquals(AppRoute.Game.BASE_ROUTE, route)
+    }
+
+    @Test
+    fun gameDestinationIncludesGameIdArgument() {
+        val route = AppRoute.Game.destination(
+            AppRoute.AppRouteArguments(gameId = 7)
+        )
+
+        assertEquals("game?gameId=7", route)
+    }
+}


### PR DESCRIPTION
## Summary

- Implement issue #66: argument passing between top-level navigation destinations.
- Add route argument definitions and destination builders for Lobby and Game routes.
- Pass `lobbyCode` and `gameId` through navigation while preserving existing state-based screen priority.
- Safely fall back to current app state when route arguments are missing or invalid.
- Add unit coverage for route destination construction.

## Scope

This PR only handles argument passing between screens.

It does not implement:
- navigation action expansion beyond the existing `AppNavigator`
- ViewModel-driven navigation events
- single-source-of-truth navigation cleanup

Those remain for later navigation issues.

## Testing

- `./gradlew compileDebugKotlin`
- `./gradlew compileDebugAndroidTestKotlin`
- `./gradlew testDebugUnitTest`
- `./gradlew test`
