### PR TITLE
69 single source of truth for navigation state2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,21 @@ The project follows a modularized directory structure within `app/src/main/java/
 │   ├── game/         # Game board and active gameplay UI
 │   ├── home/         # Home screen UI and logic
 │   ├── lobby/        # Lobby screen UI and multiplayer setup
+│   ├── navigation/   # Top-level routes, navigator, and navigation ViewModel
 │   ├── start/        # Entry screens, login/register, and PDF viewer
 │   └── theme/        # Material 3 colors, typography, and theme definitions
 ├── network/
 │   └── websocket/    # STOMP protocol, WebSocket client, and contract constants
 └── MainActivity.kt   # Single activity entry point
+```
+
+## 🧭 Navigation
+
+The app uses a single top-level Compose `NavHost` with centralized routes,
+argument builders, an `AppNavigator` wrapper, and `NavigationViewModel`-driven
+state/events. See [docs/navigation.md](docs/navigation.md) for the full
+navigation flow and the implementation map for issue #29.
+
 ## 📰 Notable Features
 
 - **In-App PDF Viewer**: The app includes a built-in PDF viewer (`PdfViewerScreen`) for displaying documents such as game rules directly within the UI. This feature supports smooth navigation, page controls, and adapts to both portrait and landscape orientations.
@@ -53,8 +63,6 @@ The project follows a modularized directory structure within `app/src/main/java/
 - **WebSocket Contract Centralization**: All WebSocket/STOMP endpoint paths and protocol constants are defined in a single contract file (`WebSocketContract.kt`). This ensures consistency and simplifies updates to backend communication endpoints.
 
 - **Dedicated Home & Lobby Screens**: The UI layer contains specialized screens for Home (`HomeScreen.kt`) and Lobby (`LobbyScreen.kt`), providing a clear separation of concerns and supporting scalable UI development for different game phases.
-
-```
 
 ## 🏁 Getting Started
 

--- a/app/src/androidTest/java/com/machikoro/client/ui/AppRootTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/AppRootTest.kt
@@ -62,7 +62,6 @@ class AppRootTest {
                     lobbyCode = null,
                     onCreateLobbyClick = {},
                     onGoToLobbyClick = {},
-                    showLobbyScreen = false,
                     onReadyToggle = {},
                     onStartGame = {},
                     onLeaveLobby = {},
@@ -101,7 +100,6 @@ class AppRootTest {
                     lobbyCode = null,
                     onCreateLobbyClick = {},
                     onGoToLobbyClick = {},
-                    showLobbyScreen = false,
                     onReadyToggle = {},
                     onStartGame = {},
                     onLeaveLobby = {},
@@ -135,13 +133,7 @@ class AppRootTest {
 
     @Test
     fun routesAuthenticatedUserToLobbyWhenShowLobbyScreenFlipsTrue() {
-        // Pins the contract for #51: while authenticated, the user stays on
-        // HomeScreen until the confirm/check icon flips `showLobbyScreen` to
-        // true — only then do they navigate into LobbyScreen. The reverse
-        // direction is also exercised so a future regression that pins the
-        // routing one-way (e.g. via an absorbing state) is caught.
         val navigationViewModel = NavigationViewModel()
-        var showLobbyScreen by mutableStateOf(false)
         composeTestRule.setContent {
             ClientTheme {
                 AppRoot(
@@ -164,7 +156,6 @@ class AppRootTest {
                     lobbyCode = "ABC1234",
                     onCreateLobbyClick = {},
                     onGoToLobbyClick = {},
-                    showLobbyScreen = showLobbyScreen,
                     onReadyToggle = {},
                     onStartGame = {},
                     onLeaveLobby = {},
@@ -175,11 +166,13 @@ class AppRootTest {
         composeTestRule.onNodeWithText(HOME_SCREEN_LOBBY_CARD).assertIsDisplayed()
         composeTestRule.onNodeWithText(LOBBY_SCREEN_PLAYER_LIST).assertDoesNotExist()
 
-        showLobbyScreen = true
+        navigationViewModel.showLobby()
+        composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText(LOBBY_SCREEN_PLAYER_LIST).assertIsDisplayed()
         composeTestRule.onNodeWithText(HOME_SCREEN_LOBBY_CARD).assertDoesNotExist()
 
-        showLobbyScreen = false
+        navigationViewModel.leaveLobby()
+        composeTestRule.waitForIdle()
         composeTestRule.onNodeWithText(HOME_SCREEN_LOBBY_CARD).assertIsDisplayed()
         composeTestRule.onNodeWithText(LOBBY_SCREEN_PLAYER_LIST).assertDoesNotExist()
     }
@@ -209,7 +202,6 @@ class AppRootTest {
                     lobbyCode = null,
                     onCreateLobbyClick = {},
                     onGoToLobbyClick = {},
-                    showLobbyScreen = false,
                     onReadyToggle = {},
                     onStartGame = {},
                     onLeaveLobby = {},
@@ -244,7 +236,6 @@ class AppRootTest {
                     lobbyCode = null,
                     onCreateLobbyClick = {},
                     onGoToLobbyClick = {},
-                    showLobbyScreen = false,
                     onReadyToggle = {},
                     onStartGame = {},
                     onLeaveLobby = {},
@@ -289,7 +280,6 @@ class AppRootTest {
                     lobbyCode = null,
                     onCreateLobbyClick = {},
                     onGoToLobbyClick = {},
-                    showLobbyScreen = false,
                     onReadyToggle = {},
                     onStartGame = {},
                     onLeaveLobby = {},
@@ -330,7 +320,6 @@ class AppRootTest {
                     lobbyCode = null,
                     onCreateLobbyClick = {},
                     onGoToLobbyClick = {},
-                    showLobbyScreen = false,
                     onReadyToggle = {},
                     onStartGame = {},
                     onLeaveLobby = {},

--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -68,7 +68,7 @@ class MainActivity : ComponentActivity() {
         LogoutViewModel.Factory(authApi, SessionManager)
     }
 
-    private val navigationViewModel by viewModels<NavigationViewModel>{
+    private val navigationViewModel by viewModels<NavigationViewModel> {
         NavigationViewModel.Factory()
     }
 
@@ -89,7 +89,6 @@ class MainActivity : ComponentActivity() {
             val registerDialogState by registerDialogViewModel.state.collectAsState()
             val loginDialogState by loginDialogViewModel.state.collectAsState()
             val logoutState by logoutViewModel.state.collectAsState()
-            var showLobbyScreen by remember { mutableStateOf(false) }
             var showJoinLobbyInput by remember { mutableStateOf(false) }
             val snackbarHostState = remember { SnackbarHostState() }
 
@@ -114,7 +113,7 @@ class MainActivity : ComponentActivity() {
             LaunchedEffect(activeGameId, isLobbyHost) {
                 if (activeGameId != null && !isLobbyHost) {
                     showJoinLobbyInput = false
-                    showLobbyScreen = true
+                    navigationViewModel.showLobby()
                 }
             }
 
@@ -150,7 +149,7 @@ class MainActivity : ComponentActivity() {
                         onReadyToggle = lobbyScreenViewModel::onReadyToggle,
                         onStartGame = homeViewModel::startGame,
                         onLeaveLobby = {
-                            showLobbyScreen = false
+                            navigationViewModel.leaveLobby()
                             lobbyScreenViewModel.onLeaveLobby()
                             homeViewModel.clearLobbyCode()
                         },
@@ -160,9 +159,8 @@ class MainActivity : ComponentActivity() {
                         joinLobbyCode = joinLobbyCode,
                         joinLobbyError = joinLobbyError,
                         showJoinLobbyInput = showJoinLobbyInput,
-                        showLobbyScreen = showLobbyScreen,
                         onGoToLobbyClick = {
-                            showLobbyScreen = true
+                            navigationViewModel.showLobby()
                         },
                         onCreateLobbyClick = {
                             showJoinLobbyInput = false

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -2,8 +2,10 @@ package com.machikoro.client.ui
 
 import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.navigation.NavController
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -64,11 +66,11 @@ fun AppRoot(
     onRollDice: () -> Unit = {},
     onPurchaseClick: (String) -> Unit = {},
     modifier: Modifier = Modifier,
-    showLobbyScreen: Boolean = false,
     onGoToLobbyClick: () -> Unit = {},
 ) {
     val navController = rememberNavController()
     val appNavigator = remember(navController) { AppNavigator(navController) }
+    val navigationUiState by navigationViewModel.uiState.collectAsState()
 
     // Reset NavigationViewModel idempotency cache when the NavController actually
     // changes destination, so the same navigation can be re-emitted later if
@@ -83,21 +85,6 @@ fun AppRoot(
         }
     }
 
-    // Delegate state-based route decisions to NavigationViewModel
-    LaunchedEffect(
-        gameScreenState,
-        startScreenState,
-        lobbyCode,
-        showLobbyScreen
-    ) {
-        navigationViewModel.updateNavigationBasedOnState(
-            gameScreenState = gameScreenState,
-            startScreenState = startScreenState,
-            lobbyCode = lobbyCode,
-            showLobbyScreen = showLobbyScreen
-        )
-    }
-
     // Listen to navigation events from ViewModel and apply them
     LaunchedEffect(navigationViewModel) {
         navigationViewModel.navigationEvent.collectLatest { event ->
@@ -106,6 +93,20 @@ fun AppRoot(
                     appNavigator.navigateTo(event.route, event.arguments)
             }
         }
+    }
+
+    // Delegate state-based route decisions to NavigationViewModel
+    LaunchedEffect(
+        gameScreenState,
+        startScreenState,
+        lobbyCode,
+        navigationUiState.showLobbyScreen
+    ) {
+        navigationViewModel.updateNavigationBasedOnState(
+            gameScreenState = gameScreenState,
+            startScreenState = startScreenState,
+            lobbyCode = lobbyCode,
+        )
     }
 
     NavHost(

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -72,6 +72,9 @@ fun AppRoot(
     val appNavigator = remember(navController) { AppNavigator(navController) }
     val navigationUiState by navigationViewModel.uiState.collectAsState()
 
+    // AppRoot owns the NavHost lifecycle, but route decisions are delegated to
+    // NavigationViewModel so navigation state has one source of truth.
+
     // Reset NavigationViewModel idempotency cache when the NavController actually
     // changes destination, so the same navigation can be re-emitted later if
     // needed.

--- a/app/src/main/java/com/machikoro/client/ui/navigation/AppNavigator.kt
+++ b/app/src/main/java/com/machikoro/client/ui/navigation/AppNavigator.kt
@@ -3,6 +3,12 @@ package com.machikoro.client.ui.navigation
 import androidx.navigation.NavHostController
 import androidx.navigation.navOptions
 
+/**
+ * Thin wrapper around NavHostController for app-wide navigation actions.
+ *
+ * AppRoot owns the NavHost, NavigationViewModel decides the target route, and
+ * this class owns the concrete navigate(...) options and duplicate guard.
+ */
 class AppNavigator(
     private val navController: NavHostController,
 ) {
@@ -16,6 +22,8 @@ class AppNavigator(
             route.destination(arguments),
             navOptions {
                 launchSingleTop = true
+                // Keep Main as the graph root while replacing transient screens
+                // such as Home, Lobby, Game, and Winner.
                 popUpTo(AppRoute.Main.route)
             }
         )

--- a/app/src/main/java/com/machikoro/client/ui/navigation/AppRoute.kt
+++ b/app/src/main/java/com/machikoro/client/ui/navigation/AppRoute.kt
@@ -3,7 +3,12 @@ package com.machikoro.client.ui.navigation
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
-// Central route definitions for the top-level app navigation graph.
+/**
+ * Central route definitions for the top-level app navigation graph.
+ *
+ * Route strings and argument names should live here so callers do not assemble
+ * hardcoded destinations across the UI layer.
+ */
 sealed class AppRoute(val route: String) {
     data object Main : AppRoute("main")
     data object Home : AppRoute("home")
@@ -30,8 +35,16 @@ sealed class AppRoute(val route: String) {
 
     data object Winner : AppRoute("winner")
 
+    /**
+     * Builds the concrete destination used by NavController.navigate(...).
+     * Routes without arguments return their route unchanged.
+     */
     open fun destination(arguments: AppRouteArguments = AppRouteArguments()): String = route
 
+    /**
+     * Optional top-level route arguments. Only the destination that understands
+     * an argument consumes it; carrying both keeps navigation events uniform.
+     */
     data class AppRouteArguments(
         val lobbyCode: String? = null,
         val gameId: Int? = null,

--- a/app/src/main/java/com/machikoro/client/ui/navigation/NavigationViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/navigation/NavigationViewModel.kt
@@ -3,22 +3,41 @@ package com.machikoro.client.ui.navigation
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.model.state.GameScreenState
 import com.machikoro.client.domain.model.state.StartScreenState
 
+data class NavigationUiState(
+    val showLobbyScreen: Boolean = false,
+)
+
 class NavigationViewModel : ViewModel() {
+
+    private val mutableUiState = MutableStateFlow(NavigationUiState())
+    val uiState: StateFlow<NavigationUiState> = mutableUiState.asStateFlow()
 
     private val _navigationEvent = MutableSharedFlow<NavigationEvent>(extraBufferCapacity = 1)
     val navigationEvent: SharedFlow<NavigationEvent> = _navigationEvent.asSharedFlow()
     // Track last emitted navigation to avoid emitting duplicate navigation events
     // which can cause unnecessary navigation attempts and UI churn.
     private var lastNavigation: Pair<AppRoute, AppRoute.AppRouteArguments>? = null
+
+    fun showLobby() {
+        mutableUiState.update { it.copy(showLobbyScreen = true) }
+    }
+
+    fun leaveLobby() {
+        mutableUiState.update { it.copy(showLobbyScreen = false) }
+    }
 
     fun navigateTo(
         route: AppRoute,
@@ -38,14 +57,13 @@ class NavigationViewModel : ViewModel() {
         gameScreenState: GameScreenState,
         startScreenState: StartScreenState,
         lobbyCode: String?,
-        showLobbyScreen: Boolean
     ) {
         viewModelScope.launch {
             // Determine target route based on current app state
             val targetRoute = when {
                 gameScreenState.gameStatus == GameStatus.FINISHED -> AppRoute.Winner
                 gameScreenState.gamePhase != GamePhase.NONE -> AppRoute.Game
-                showLobbyScreen -> AppRoute.Lobby
+                uiState.value.showLobbyScreen -> AppRoute.Lobby
                 startScreenState.loggedInAs != null -> AppRoute.Home
                 else -> AppRoute.Main
             }

--- a/app/src/main/java/com/machikoro/client/ui/navigation/NavigationViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/navigation/NavigationViewModel.kt
@@ -16,10 +16,22 @@ import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.model.state.GameScreenState
 import com.machikoro.client.domain.model.state.StartScreenState
 
+/**
+ * Durable navigation UI state.
+ *
+ * This belongs in a ViewModel instead of MainActivity remember state so route
+ * decisions survive recomposition and configuration changes.
+ */
 data class NavigationUiState(
     val showLobbyScreen: Boolean = false,
 )
 
+/**
+ * Single source for top-level navigation state and route decisions.
+ *
+ * The ViewModel converts app state into NavigationEvent commands while keeping
+ * persistent navigation UI state separate from one-time navigation events.
+ */
 class NavigationViewModel : ViewModel() {
 
     private val mutableUiState = MutableStateFlow(NavigationUiState())
@@ -50,8 +62,10 @@ class NavigationViewModel : ViewModel() {
     }
 
     /**
-     * Updates navigation based on app state changes (game status, login state, lobby state).
-     * This centralizes all state-based routing logic that was previously in AppRoot.
+     * Updates navigation based on app state changes.
+     *
+     * Route priority is Winner > Game > Lobby > Home > Main, matching the
+     * current game flow documented in docs/navigation.md.
      */
     fun updateNavigationBasedOnState(
         gameScreenState: GameScreenState,
@@ -59,7 +73,6 @@ class NavigationViewModel : ViewModel() {
         lobbyCode: String?,
     ) {
         viewModelScope.launch {
-            // Determine target route based on current app state
             val targetRoute = when {
                 gameScreenState.gameStatus == GameStatus.FINISHED -> AppRoute.Winner
                 gameScreenState.gamePhase != GamePhase.NONE -> AppRoute.Game
@@ -98,6 +111,9 @@ class NavigationViewModel : ViewModel() {
 }
 
 sealed class NavigationEvent {
+    /**
+     * One-time command consumed by AppRoot and applied through AppNavigator.
+     */
     data class NavigateTo(
         val route: AppRoute,
         val arguments: AppRoute.AppRouteArguments = AppRoute.AppRouteArguments(),

--- a/app/src/test/java/com/machikoro/client/ui/navigation/NavigationViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/navigation/NavigationViewModelTest.kt
@@ -13,6 +13,8 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 
@@ -30,7 +32,6 @@ class NavigationViewModelTest {
             gameScreenState = GameScreenState.initial(),
             startScreenState = StartScreenState.placeholder(),
             lobbyCode = null,
-            showLobbyScreen = false,
         )
         advanceUntilIdle()
 
@@ -46,7 +47,6 @@ class NavigationViewModelTest {
             gameScreenState = GameScreenState.initial(),
             startScreenState = StartScreenState.placeholder().copy(loggedInAs = "alice"),
             lobbyCode = null,
-            showLobbyScreen = false,
         )
         advanceUntilIdle()
 
@@ -58,11 +58,11 @@ class NavigationViewModelTest {
         val viewModel = NavigationViewModel()
         val events = collectNavigationEvents(viewModel)
 
+        viewModel.showLobby()
         viewModel.updateNavigationBasedOnState(
             gameScreenState = GameScreenState.initial(),
             startScreenState = StartScreenState.placeholder().copy(loggedInAs = "alice"),
             lobbyCode = "ABC1234",
-            showLobbyScreen = true,
         )
         advanceUntilIdle()
 
@@ -80,6 +80,7 @@ class NavigationViewModelTest {
         val viewModel = NavigationViewModel()
         val events = collectNavigationEvents(viewModel)
 
+        viewModel.showLobby()
         viewModel.updateNavigationBasedOnState(
             gameScreenState = GameScreenState.initial().copy(
                 gamePhase = GamePhase.ROLL_DICE,
@@ -87,7 +88,6 @@ class NavigationViewModelTest {
             ),
             startScreenState = StartScreenState.placeholder().copy(loggedInAs = "alice"),
             lobbyCode = "ABC1234",
-            showLobbyScreen = true,
         )
         advanceUntilIdle()
 
@@ -108,6 +108,7 @@ class NavigationViewModelTest {
         val viewModel = NavigationViewModel()
         val events = collectNavigationEvents(viewModel)
 
+        viewModel.showLobby()
         viewModel.updateNavigationBasedOnState(
             gameScreenState = GameScreenState.initial().copy(
                 gameStatus = GameStatus.FINISHED,
@@ -116,7 +117,6 @@ class NavigationViewModelTest {
             ),
             startScreenState = StartScreenState.placeholder().copy(loggedInAs = "alice"),
             lobbyCode = "ABC1234",
-            showLobbyScreen = true,
         )
         advanceUntilIdle()
 
@@ -161,6 +161,19 @@ class NavigationViewModelTest {
             ),
             events,
         )
+    }
+
+    @Test
+    fun lobbyVisibilityIsOwnedByNavigationState() {
+        val viewModel = NavigationViewModel()
+
+        assertFalse(viewModel.uiState.value.showLobbyScreen)
+
+        viewModel.showLobby()
+        assertTrue(viewModel.uiState.value.showLobbyScreen)
+
+        viewModel.leaveLobby()
+        assertFalse(viewModel.uiState.value.showLobbyScreen)
     }
 
     private fun TestScope.collectNavigationEvents(

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -1,0 +1,125 @@
+# Navigation Architecture
+
+This document describes the client navigation setup implemented for parent issue
+[#29](https://github.com/SE2-Machi-Koro/Client/issues/29).
+
+## Scope
+
+The navigation work covers the top-level game flow:
+
+```text
+Main/Start -> Home -> Lobby -> Game -> Winner
+```
+
+The route priority is:
+
+```text
+Winner > Game > Lobby > Home > Main
+```
+
+This means a finished game always shows the winner screen, an active game phase
+shows the game screen, a requested lobby shows the lobby screen, a logged-in
+user shows the home screen, and unauthenticated users stay on the main/start
+screen.
+
+## Main Files
+
+| File | Responsibility |
+| :--- | :--- |
+| `ui/AppRoot.kt` | Hosts the single top-level `NavHost`, declares destinations, observes navigation events, and renders the current screen. |
+| `ui/navigation/AppRoute.kt` | Defines all top-level routes and builds concrete destinations with optional arguments. |
+| `ui/navigation/AppNavigator.kt` | Wraps `NavHostController.navigate(...)` and owns navigation options and duplicate-route guards. |
+| `ui/navigation/NavigationViewModel.kt` | Owns navigation state, chooses target routes from app state, and emits navigation events. |
+| `MainActivity.kt` | Creates the screen ViewModels, forwards user actions, and calls navigation state actions such as `showLobby()` and `leaveLobby()`. |
+
+## Routes
+
+`AppRoute` is the single source for route strings.
+
+| Route | Purpose | Arguments |
+| :--- | :--- | :--- |
+| `Main` | Start screen with login/register entry points. | None |
+| `Home` | Authenticated home screen with lobby actions. | None |
+| `Lobby` | Lobby screen before a game starts. | Optional `lobbyCode` |
+| `Game` | Active game screen. | Optional `gameId` |
+| `Winner` | Finished-game winner screen. | None |
+
+Argumented destinations are built through `AppRoute.destination(arguments)`.
+Callers should not assemble route strings manually.
+
+## Navigation Flow
+
+`NavigationViewModel.updateNavigationBasedOnState(...)` derives the target route
+from the current app state:
+
+```text
+gameStatus == FINISHED      -> Winner
+gamePhase != NONE           -> Game
+uiState.showLobbyScreen     -> Lobby
+startScreenState.loggedInAs -> Home
+else                        -> Main
+```
+
+The ViewModel then emits `NavigationEvent.NavigateTo(route, arguments)`.
+`AppRoot` collects that event and delegates the actual `NavHostController`
+operation to `AppNavigator`.
+
+## State And Events
+
+Navigation keeps state and commands separate:
+
+- `NavigationUiState` stores durable navigation UI state, currently
+  `showLobbyScreen`.
+- `NavigationEvent` represents one-time navigation commands.
+- `NavigationViewModel.showLobby()` and `leaveLobby()` update navigation state.
+- `NavigationViewModel.navigateTo(...)` emits navigation events.
+
+This keeps navigation state stable across recompositions and configuration
+changes because `MainActivity` no longer owns lobby navigation as local
+`remember` state.
+
+## AppRoot Responsibilities
+
+`AppRoot` is intentionally thin:
+
+- it creates and owns the Compose `NavHost`;
+- it declares top-level destinations;
+- it observes `NavigationViewModel.uiState` so state changes trigger route
+  recalculation;
+- it collects `NavigationEvent` and applies navigation through `AppNavigator`.
+
+`AppRoot` should not add independent route priority logic. New route decisions
+belong in `NavigationViewModel` unless there is a Compose-only reason to keep
+them local.
+
+## MainActivity Responsibilities
+
+`MainActivity` wires user actions to ViewModels:
+
+- `onGoToLobbyClick` calls `navigationViewModel.showLobby()`;
+- `onLeaveLobby` calls `navigationViewModel.leaveLobby()`, then clears lobby
+  data through the lobby and home ViewModels;
+- when a joined game is detected for a non-host, it calls
+  `navigationViewModel.showLobby()`.
+
+Transient Home-screen form state, such as whether the join-lobby input is
+visible, remains local UI state and is separate from navigation state.
+
+## Tests
+
+Navigation behavior is covered by:
+
+- `NavigationViewModelTest` for route priority, route arguments, duplicate
+  event suppression, and `NavigationUiState`;
+- `AppRouteTest` for route argument construction;
+- `AppRootTest` for screen-level routing behavior in Compose.
+
+Run the relevant checks with:
+
+```bash
+./gradlew compileDebugKotlin
+./gradlew compileDebugAndroidTestKotlin
+./gradlew testDebugUnitTest
+./gradlew lint
+```
+


### PR DESCRIPTION
## Summary

- Centralize lobby navigation state in `NavigationViewModel` for issue #69.
- Add `NavigationUiState` with `showLobbyScreen` as the single source of truth for Lobby routing.
- Replace local `showLobbyScreen` state in `MainActivity` with `navigationViewModel.showLobby()` and `navigationViewModel.leaveLobby()`.
- Update `AppRoot` so state-based routing reads from `NavigationViewModel.uiState` instead of receiving lobby navigation state as a parameter.
- Update navigation tests to cover the new state ownership and keep the existing route priority behavior.
- Add navigation documentation for parent issue #29, including route flow, route priority, file responsibilities, and state/event separation.

## Scope

This PR completes issue #69: Single Source of Truth for Navigation State.

It does not change the user-facing navigation flow. The flow remains:

`Main/Start -> Home -> Lobby -> Game -> Winner`

Route priority remains:

`Winner > Game > Lobby > Home > Main`

## Implementation Notes

- `NavigationViewModel` now owns durable navigation UI state through `NavigationUiState`.
- `NavigationEvent` remains the one-time command channel consumed by `AppRoot`.
- `AppNavigator` continues to own the actual `NavHostController.navigate(...)` call and duplicate-route guard.
- `MainActivity` still owns transient Home UI state such as the join-lobby input visibility.
