### PR TITLE
feat: auto-reconnect the WebSocket after an unexpected drop

### DIFF
--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -14,13 +14,19 @@ import com.machikoro.client.domain.model.state.PlayerCoinState
 import com.machikoro.client.domain.model.state.PlayerLandmarkState
 import com.machikoro.client.domain.session.SessionStateHolder
 import java.net.URI
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
@@ -33,6 +39,8 @@ class OkHttpWebSocketClient(
     private val websocketUrl: String,
     private val sessionStateHolder: SessionStateHolder,
     private val webSocketFactory: WebSocketFactory = OkHttpWebSocketFactory(),
+    private val reconnectScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    private val reconnectDelaysMs: List<Long> = RECONNECT_DELAYS_MS,
 ) : WebSocketClient {
     override val connectionStatus: StateFlow<ConnectionStatus>
         get() = mutableConnectionStatus.asStateFlow()
@@ -114,8 +122,21 @@ class OkHttpWebSocketClient(
     private var webSocket: WebSocket? = null
     private var subscribedGameId: Int? = null
 
+    // Auto-reconnect state. `intentionalDisconnect` is set whenever the client
+    // tears the connection down itself (disconnect() or an auth rejection) so
+    // the listener can tell a deliberate close apart from an unexpected drop.
+    @Volatile
+    private var intentionalDisconnect = false
+    private var reconnectJob: Job? = null
+    private var reconnectAttempt = 0
+
+    init {
+        require(reconnectDelaysMs.isNotEmpty()) { "reconnectDelaysMs must not be empty" }
+    }
+
     override fun connect() {
         synchronized(this) {
+            intentionalDisconnect = false
             if (webSocket != null) return
             if (sessionStateHolder.session.value == null) {
                 Log.d(TAG, "Skipping WS connect — no session token")
@@ -136,6 +157,8 @@ class OkHttpWebSocketClient(
     }
 
     override fun disconnect() {
+        intentionalDisconnect = true
+        cancelReconnect()
         val currentSocket = synchronized(this) {
             val socket = webSocket
             webSocket = null
@@ -349,6 +372,7 @@ class OkHttpWebSocketClient(
             clearSocket()
             mutableConnectionStatus.value = ConnectionStatus.DISCONNECTED
             resetGameState()
+            scheduleReconnect()
         }
 
         override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
@@ -357,6 +381,7 @@ class OkHttpWebSocketClient(
             clearSocket()
             mutableConnectionStatus.value = ConnectionStatus.ERROR
             resetGameState()
+            scheduleReconnect()
         }
     }
 
@@ -364,6 +389,8 @@ class OkHttpWebSocketClient(
         when (frame.command) {
             "CONNECTED" -> {
                 Log.d(TAG, "STOMP connected")
+                // A live STOMP session: drop any pending retry and reset backoff.
+                cancelReconnect()
                 mutableConnectionStatus.value = ConnectionStatus.CONNECTED
                 subscribeToPublicTopic()
                 subscribeToErrorsQueue()
@@ -399,6 +426,8 @@ class OkHttpWebSocketClient(
             "ERROR" -> {
                 Log.e(TAG, "STOMP error frame received: ${frame.body}")
                 if (isAuthRejection(frame.body)) {
+                    // An auth rejection is terminal — do not auto-reconnect.
+                    intentionalDisconnect = true
                     mutableConnectionStatus.value = ConnectionStatus.DISCONNECTED
                     resetGameState()
                     sessionStateHolder.signOut()
@@ -794,6 +823,43 @@ class OkHttpWebSocketClient(
         }
     }
 
+    /**
+     * Schedules an automatic reconnect after an unexpected drop (network blip
+     * or backend container restart). No-op when the client closed the
+     * connection itself (disconnect() / auth rejection) or when there is no
+     * session to reconnect with. Uses exponential backoff so a backend restart
+     * is ridden out without hammering the server; a successful STOMP CONNECT
+     * resets the backoff. The CONNECTED handler re-subscribes to the game-sync
+     * queue and re-sends the JOIN, so reconnect-snapshot recovery is triggered
+     * automatically once the connection is back.
+     */
+    private fun scheduleReconnect() {
+        synchronized(this) {
+            if (intentionalDisconnect) return
+            if (sessionStateHolder.session.value == null) return
+            val attempt = reconnectAttempt
+            reconnectAttempt = attempt + 1
+            val delayMs = reconnectDelaysMs.getOrElse(attempt) { reconnectDelaysMs.last() }
+            reconnectJob?.cancel()
+            reconnectJob = reconnectScope.launch {
+                delay(delayMs)
+                if (!intentionalDisconnect && sessionStateHolder.session.value != null) {
+                    Log.d(TAG, "Auto-reconnect attempt ${attempt + 1}")
+                    connect()
+                }
+            }
+        }
+    }
+
+    /** Cancels any pending reconnect and resets the backoff counter. */
+    private fun cancelReconnect() {
+        synchronized(this) {
+            reconnectJob?.cancel()
+            reconnectJob = null
+            reconnectAttempt = 0
+        }
+    }
+
     private fun isAuthRejection(body: String): Boolean =
         body.trim().contains(AUTH_REJECTION_BODY)
 
@@ -870,6 +936,10 @@ class OkHttpWebSocketClient(
     companion object {
         private const val NORMAL_CLOSURE_STATUS = 1000
         private const val TAG = "OkHttpWebSocketClient"
+        // Exponential backoff for auto-reconnect; the final value repeats once
+        // the list is exhausted. Long enough to ride out a backend container
+        // restart without hammering the server.
+        private val RECONNECT_DELAYS_MS = listOf(1_000L, 2_000L, 4_000L, 8_000L, 16_000L)
         private const val GAME_ACTION_TYPE = "GAME_ACTION"
         private const val GAME_STARTED_TYPE = "GAME_STARTED"
         private const val AUTH_HEADER = "Authorization"

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -12,7 +12,10 @@ import com.machikoro.client.domain.model.state.PlayerLandmarkState
 import com.machikoro.client.domain.session.Session
 import com.machikoro.client.domain.session.SessionStateHolder
 import java.io.IOException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -1428,6 +1431,116 @@ class OkHttpWebSocketClientTest {
         assertTrue(client.playerLandmarks.value.isEmpty())
     }
 
+    // ── auto-reconnect (#166) ────────────────────────────────────────────────
+
+    @Test
+    fun unexpectedFailureTriggersAutomaticReconnect() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory, reconnectScope = backgroundScope)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        assertEquals(1, factory.createCount)
+
+        factory.simulateFailure(IOException("backend container restarted"))
+        runCurrent()
+
+        assertEquals(2, factory.createCount)
+    }
+
+    @Test
+    fun unexpectedCloseTriggersAutomaticReconnect() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory, reconnectScope = backgroundScope)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+
+        factory.simulateClosed()
+        runCurrent()
+
+        assertEquals(2, factory.createCount)
+    }
+
+    @Test
+    fun clientInitiatedDisconnectDoesNotReconnect() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory, reconnectScope = backgroundScope)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+
+        client.disconnect()
+        factory.simulateClosed()
+        runCurrent()
+
+        assertEquals(1, factory.createCount)
+    }
+
+    @Test
+    fun authRejectionDoesNotReconnect() = runTest {
+        val factory = FakeWebSocketFactory()
+        val sessionHolder = FakeSessionStateHolder(DEFAULT_SESSION)
+        val client = newClient(
+            factory,
+            sessionStateHolder = sessionHolder,
+            reconnectScope = backgroundScope,
+        )
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(
+            StompFrame(command = "ERROR", body = "Authentication failed").serialize()
+        )
+        factory.simulateClosed()
+        runCurrent()
+
+        assertEquals(1, factory.createCount)
+        assertNull(sessionHolder.session.value)
+    }
+
+    @Test
+    fun reconnectKeepsRetryingWhileBackendStaysDown() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory, reconnectScope = backgroundScope)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+
+        factory.simulateFailure(IOException("down"))
+        runCurrent()
+        assertEquals(2, factory.createCount)
+
+        factory.simulateFailure(IOException("still down"))
+        runCurrent()
+        assertEquals(3, factory.createCount)
+    }
+
+    @Test
+    fun reconnectReSubscribesToGameSyncQueueAndReTriggersSnapshot() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory, reconnectScope = backgroundScope)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+
+        factory.simulateFailure(IOException("backend container restarted"))
+        runCurrent()
+        factory.simulateOpen()
+        factory.socket.sentMessages.clear()
+        factory.simulateText(connectedFrame())
+
+        assertTrue(
+            factory.socket.sentMessages.any {
+                it.startsWith("SUBSCRIBE") && it.contains("destination:/user/queue/game-sync")
+            }
+        )
+        assertTrue(
+            factory.socket.sentMessages.any {
+                it.startsWith("SEND") && it.contains("destination:/app/chat.addUser")
+            }
+        )
+    }
+
     /** Connects a client and feeds it one realistic SYNC snapshot frame. */
     private fun clientAfterSync(): OkHttpWebSocketClient {
         val factory = FakeWebSocketFactory()
@@ -1527,9 +1640,13 @@ class OkHttpWebSocketClientTest {
     private fun newClient(
         factory: FakeWebSocketFactory,
         sessionStateHolder: SessionStateHolder = FakeSessionStateHolder(DEFAULT_SESSION),
+        reconnectScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+        reconnectDelaysMs: List<Long> = listOf(0L),
     ) = OkHttpWebSocketClient(
         websocketUrl = "ws://10.0.2.2:8080/ws",
         sessionStateHolder = sessionStateHolder,
         webSocketFactory = factory,
+        reconnectScope = reconnectScope,
+        reconnectDelaysMs = reconnectDelaysMs,
     )
 }

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -13,14 +13,13 @@ import com.machikoro.client.domain.session.Session
 import com.machikoro.client.domain.session.SessionStateHolder
 import java.io.IOException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import okhttp3.Protocol
@@ -1640,7 +1639,11 @@ class OkHttpWebSocketClientTest {
     private fun newClient(
         factory: FakeWebSocketFactory,
         sessionStateHolder: SessionStateHolder = FakeSessionStateHolder(DEFAULT_SESSION),
-        reconnectScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+        // Inert by default: a StandardTestDispatcher whose scheduler is never
+        // advanced, so an auto-reconnect scheduled by a close/failure stays
+        // queued and does not race assertions in tests that don't drive it.
+        // Reconnect tests pass backgroundScope explicitly and drive it.
+        reconnectScope: CoroutineScope = CoroutineScope(StandardTestDispatcher()),
         reconnectDelaysMs: List<Long> = listOf(0L),
     ) = OkHttpWebSocketClient(
         websocketUrl = "ws://10.0.2.2:8080/ws",


### PR DESCRIPTION
## What

`OkHttpWebSocketClient` now automatically reconnects after an unexpected WebSocket drop — a network blip or a backend container restart — using exponential backoff.

## Why

Game-state recovery (disconnect/reconnect and backend container restart) depends on the client re-establishing the WebSocket: on STOMP `CONNECTED` it re-subscribes to `/user/queue/game-sync` and re-sends `chat.addUser`, which makes the server push the recovery snapshot. Previously the client never reconnected on its own — recovery only happened if the user manually backgrounded and re-foregrounded the app, so a backend restart mid-game left every connected player stuck.

## Changes

- On a non-deliberate close/failure with a live session, retry `connect()` with exponential backoff (1s, 2s, 4s, 8s, 16s; the last value repeats).
- Stop retrying on a client-initiated `disconnect()` (including app backgrounding) and on an auth rejection.
- A successful STOMP `CONNECT` cancels any pending retry and resets the backoff.
- The backoff schedule and the coroutine scope are constructor-injectable, so the behaviour is unit-testable.

## Testing

- 6 new unit tests in `OkHttpWebSocketClientTest`: reconnect on failure, reconnect on close, no reconnect on client-initiated disconnect, no reconnect on auth rejection, keeps retrying while the backend stays down, and re-subscribes to the game-sync queue after reconnecting.
- All 94 tests in `OkHttpWebSocketClientTest` pass; `lintDebug` is clean.

## Note

Fully automatic end-to-end recovery also depends on #163 — this change restores the game state on reconnect, but routing to the Game screen still goes through `NavigationViewModel`, which has a separate dropped-navigation bug.

Closes #166
