### PR TITLE
fix: ensure rollDice sends correct gameId and diceCount in payload

### DIFF
--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -287,6 +287,19 @@ class OkHttpWebSocketClient(
             Log.w(TAG, "rollDice called but no active WebSocket connection")
             return
         }
+        val gameId = mutableActiveGameId.value
+        if (gameId == null) {
+            Log.w(TAG, "rollDice called but no active game id")
+            return
+        }
+        val payload = JSONObject()
+            .put("gameId", gameId)
+            .put("diceCount", diceCount)
+        val body = JSONObject()
+            .put("type", ROLL_DICE_TYPE)
+            .put("gameId", gameId)
+            .put("payload", payload)
+            .toString()
         socket.send(
             StompFrame(
                 command = "SEND",
@@ -294,10 +307,10 @@ class OkHttpWebSocketClient(
                     "destination" to WebSocketContract.rollDiceDestination,
                     "content-type" to "application/json"
                 ),
-                body = """{"type":"ROLL_DICE","payload":{"diceCount":$diceCount}}"""
+                body = body
             ).serialize()
         )
-        Log.d(TAG, "Roll dice message sent (diceCount=$diceCount)")
+        Log.d(TAG, "Roll dice message sent (gameId=$gameId, diceCount=$diceCount)")
     }
 
     override fun sendPurchase(
@@ -535,6 +548,7 @@ class OkHttpWebSocketClient(
 
         mutableActiveGameId.value = gameId
         subscribeToGameTopic(gameId)
+        payload.optIntOrNull("activePlayerId")?.let { mutableActivePlayerId.value = it }
 
         game.optString("lobbyCode")
             .takeIf { it.isNotBlank() }

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -634,6 +634,7 @@ class OkHttpWebSocketClientTest {
                 "type":"GAME_STARTED",
                 "gameId":42,
                 "payload":{
+                    "activePlayerId":1,
                     "game":{
                         "id":42,
                         "lobbyCode":"ABC1234",
@@ -647,6 +648,7 @@ class OkHttpWebSocketClientTest {
 
         assertEquals(42, client.activeGameId.value)
         assertEquals("ABC1234", client.lobbyCode.value)
+        assertEquals(1, client.activePlayerId.value)
     }
 
     @Test
@@ -656,9 +658,13 @@ class OkHttpWebSocketClientTest {
         client.connect()
         factory.simulateOpen()
         factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
+        factory.simulateText(gameStartedFrame(gameId = 7, activePlayerId = 1))
         client.rollDice(diceCount = 1)
         assertTrue(factory.socket.sentMessages.any {
-            it.startsWith("SEND\n") && it.contains("destination:/app/game.rollDice") && it.contains("\"diceCount\":1")
+            it.startsWith("SEND\n") &&
+                it.contains("destination:/app/game.rollDice") &&
+                it.contains("\"gameId\":7") &&
+                it.contains("\"diceCount\":1")
         })
     }
 
@@ -950,6 +956,7 @@ class OkHttpWebSocketClientTest {
         client.connect()
         factory.simulateOpen()
         factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
+        factory.simulateText(gameStartedFrame(gameId = 7, activePlayerId = 1))
         client.rollDice(diceCount = 2)
         assertTrue(factory.socket.sentMessages.any { it.contains("\"diceCount\":2") })
     }
@@ -1568,6 +1575,11 @@ class OkHttpWebSocketClientTest {
 
     private fun gameActionFrame(body: String): String =
         "MESSAGE\ndestination:/topic/public\ncontent-type:application/json\n\n$body\u0000"
+
+    private fun gameStartedFrame(gameId: Int, activePlayerId: Int): String =
+        gameActionFrame(
+            """{"type":"GAME_STARTED","gameId":$gameId,"payload":{"activePlayerId":$activePlayerId,"game":{"id":$gameId,"lobbyCode":"ABC1234","turnPhase":"ROLL_DICE"},"players":[]}}"""
+        )
 
     private class FakeWebSocketFactory : WebSocketFactory {
         lateinit var listener: WebSocketListener

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -28,6 +28,7 @@ import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okio.ByteString
+import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
@@ -666,6 +667,37 @@ class OkHttpWebSocketClientTest {
                 it.contains("\"gameId\":7") &&
                 it.contains("\"diceCount\":1")
         })
+    }
+
+    @Test
+    fun rollDiceIncludesGameIdInTopLevelAndPayload() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        factory.simulateText(gameStartedFrame(gameId = 7, activePlayerId = 1))
+
+        client.rollDice(diceCount = 2)
+
+        val body = JSONObject(factory.socket.rollDiceFrames().last().body)
+        assertEquals("ROLL_DICE", body.getString("type"))
+        assertEquals(7, body.getInt("gameId"))
+        assertEquals(7, body.getJSONObject("payload").getInt("gameId"))
+        assertEquals(2, body.getJSONObject("payload").getInt("diceCount"))
+    }
+
+    @Test
+    fun rollDiceWithoutActiveGameIdIsIgnored() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+
+        client.rollDice(diceCount = 1)
+
+        assertTrue(factory.socket.rollDiceFrames().isEmpty())
     }
 
     @Test
@@ -1580,6 +1612,10 @@ class OkHttpWebSocketClientTest {
         gameActionFrame(
             """{"type":"GAME_STARTED","gameId":$gameId,"payload":{"activePlayerId":$activePlayerId,"game":{"id":$gameId,"lobbyCode":"ABC1234","turnPhase":"ROLL_DICE"},"players":[]}}"""
         )
+
+    private fun FakeWebSocket.rollDiceFrames(): List<StompFrame> =
+        sentMessages.flatMap { parseFrames(StringBuilder(it)) }
+            .filter { it.headers["destination"] == WebSocketContract.rollDiceDestination }
 
     private class FakeWebSocketFactory : WebSocketFactory {
         lateinit var listener: WebSocketListener


### PR DESCRIPTION
## Summary
Fixes the **Roll Dice** button not working after a game starts.

## Changes
* **Read `activePlayerId`** from the `GAME_STARTED` payload in `OkHttpWebSocketClient`.
* **Include the active `gameId`** in the `rollDice()` request body.
* **Ignore `rollDice()` calls** when no active game ID is available.
* **Added regression tests** for:
  * `GAME_STARTED` updating `activePlayerId`.
  * `roll-dice` WebSocket frames containing both `gameId` and `diceCount`.
Closes #167