### PR TITLE
fix: handle session expiration by signing out and navigating to Main …

### DIFF
--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -107,6 +107,9 @@ class MainActivity : ComponentActivity() {
 
             LaunchedEffect(Unit) {
                 webSocketClient.authRejections.collect {
+                    SessionManager.signOut()
+                    navigationViewModel.leaveLobby()
+                    homeViewModel.clearLobbyCode()
                     snackbarHostState.showSnackbar(
                         "Sitzung abgelaufen, bitte erneut anmelden"
                     )

--- a/app/src/main/java/com/machikoro/client/ui/navigation/NavigationViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/navigation/NavigationViewModel.kt
@@ -82,8 +82,9 @@ class NavigationViewModel(
     /**
      * Updates navigation based on app state changes.
      *
-     * Route priority is Winner > Game > Lobby > Home > Main, matching the
-     * current game flow documented in docs/navigation.md.
+     * Unauthenticated users always return to Main. For authenticated users,
+     * route priority is Winner > Game > Lobby > Home, matching the current
+     * game flow documented in docs/navigation.md.
      */
     fun updateNavigationBasedOnState(
         gameScreenState: GameScreenState,
@@ -91,12 +92,13 @@ class NavigationViewModel(
         lobbyCode: String?,
     ) {
         viewModelScope.launch {
+            val loggedIn = startScreenState.loggedInAs != null
             val targetRoute = when {
+                !loggedIn -> AppRoute.Main
                 gameScreenState.gameStatus == GameStatus.FINISHED -> AppRoute.Winner
                 gameScreenState.gamePhase != GamePhase.NONE -> AppRoute.Game
                 uiState.value.showLobbyScreen -> AppRoute.Lobby
-                startScreenState.loggedInAs != null -> AppRoute.Home
-                else -> AppRoute.Main
+                else -> AppRoute.Home
             }
 
             val routeArguments = AppRoute.AppRouteArguments(

--- a/app/src/test/java/com/machikoro/client/ui/navigation/NavigationViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/navigation/NavigationViewModelTest.kt
@@ -76,6 +76,56 @@ class NavigationViewModelTest {
     }
 
     @Test
+    fun unauthenticatedStateNavigatesToMainEvenWhenLobbyWasShown() = runTest {
+        val viewModel = NavigationViewModel()
+        val events = collectNavigationEvents(viewModel)
+
+        viewModel.showLobby()
+        viewModel.updateNavigationBasedOnState(
+            gameScreenState = GameScreenState.initial(),
+            startScreenState = StartScreenState.placeholder(),
+            lobbyCode = "ABC1234",
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            NavigationEvent.NavigateTo(
+                route = AppRoute.Main,
+                arguments = AppRoute.AppRouteArguments(lobbyCode = "ABC1234"),
+            ),
+            events.single(),
+        )
+    }
+
+    @Test
+    fun unauthenticatedStateNavigatesToMainEvenWhenGameStateIsStale() = runTest {
+        val viewModel = NavigationViewModel()
+        val events = collectNavigationEvents(viewModel)
+
+        viewModel.updateNavigationBasedOnState(
+            gameScreenState = GameScreenState.initial().copy(
+                gameStatus = GameStatus.FINISHED,
+                gamePhase = GamePhase.ROLL_DICE,
+                gameId = 42,
+            ),
+            startScreenState = StartScreenState.placeholder(),
+            lobbyCode = "ABC1234",
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            NavigationEvent.NavigateTo(
+                route = AppRoute.Main,
+                arguments = AppRoute.AppRouteArguments(
+                    lobbyCode = "ABC1234",
+                    gameId = 42,
+                ),
+            ),
+            events.single(),
+        )
+    }
+
+    @Test
     fun activeGameNavigatesToGameWithGameId() = runTest {
         val viewModel = NavigationViewModel()
         val events = collectNavigationEvents(viewModel)


### PR DESCRIPTION
## Summary

Fixes #171.

This PR handles stale persisted sessions that are rejected by the server on WebSocket authentication. When an auth rejection is received, the app now clears the session, resets lobby navigation state, clears the lobby code, and falls back to the Start screen instead of leaving the user stuck on Home/Lobby with non-functional actions.

## Changes

- Clear the active session when `authRejections` is collected in `MainActivity`.
- Reset lobby navigation state and lobby code after auth rejection.
- Make unauthenticated navigation always route to `Main`, even if stale lobby/game state is still present.
- Add regression tests for unauthenticated routing with stale lobby and stale game state.
