### PR TITLE
feat: backend reachability indicator on the Start screen

### DIFF
--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -25,6 +25,8 @@ import com.machikoro.client.domain.session.DataStoreSessionStorage
 import com.machikoro.client.domain.session.SessionManager
 import com.machikoro.client.network.auth.AuthApiFactory
 import com.machikoro.client.network.debug.DebugApiFactory
+import com.machikoro.client.network.health.BackendHealthRepository
+import com.machikoro.client.network.health.HealthApiFactory
 import com.machikoro.client.network.websocket.OkHttpWebSocketClient
 import com.machikoro.client.ui.AppRoot
 import com.machikoro.client.ui.game.GameScreenViewModel
@@ -51,8 +53,14 @@ class MainActivity : ComponentActivity() {
     private val debugApi by lazy {
         DebugApiFactory.create(AppConfig.backendBaseUrl)
     }
+    private val healthApi by lazy {
+        HealthApiFactory.create(AppConfig.backendBaseUrl)
+    }
+    private val healthRepository by lazy {
+        BackendHealthRepository(healthApi)
+    }
     private val startScreenViewModel by viewModels<StartScreenViewModel> {
-        StartScreenViewModel.Factory(webSocketClient, SessionManager)
+        StartScreenViewModel.Factory(webSocketClient, SessionManager, healthRepository)
     }
     private val gameScreenViewModel by viewModels<GameScreenViewModel> {
         GameScreenViewModel.Factory(webSocketClient, SessionManager)

--- a/app/src/main/java/com/machikoro/client/domain/model/state/BackendHealth.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/BackendHealth.kt
@@ -1,0 +1,7 @@
+package com.machikoro.client.domain.model.state
+
+enum class BackendHealth {
+    UP,
+    DOWN,
+    UNKNOWN,
+}

--- a/app/src/main/java/com/machikoro/client/domain/model/state/StartScreenState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/StartScreenState.kt
@@ -4,12 +4,14 @@ data class StartScreenState(
     val title: String,
     val connectionStatus: ConnectionStatus,
     val loggedInAs: String? = null,
+    val backendHealth: BackendHealth = BackendHealth.UNKNOWN,
 ) {
     companion object {
         fun placeholder() = StartScreenState(
             title = "Machi Koro Client",
             connectionStatus = ConnectionStatus.IDLE,
             loggedInAs = null,
+            backendHealth = BackendHealth.UNKNOWN,
         )
     }
 }

--- a/app/src/main/java/com/machikoro/client/network/health/BackendHealthRepository.kt
+++ b/app/src/main/java/com/machikoro/client/network/health/BackendHealthRepository.kt
@@ -1,0 +1,38 @@
+package com.machikoro.client.network.health
+
+import com.machikoro.client.domain.model.state.BackendHealth
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.isActive
+
+open class BackendHealthRepository(
+    private val api: HealthApi,
+    private val pollIntervalMs: Long = DEFAULT_POLL_INTERVAL_MS,
+) {
+    open fun observe(): Flow<BackendHealth> = flow {
+        while (currentCoroutineContext().isActive) {
+            emit(probe())
+            delay(pollIntervalMs)
+        }
+    }
+
+    private suspend fun probe(): BackendHealth = try {
+        val response = api.checkHealth()
+        if (response.isSuccessful && response.body()?.status == "UP") {
+            BackendHealth.UP
+        } else {
+            BackendHealth.DOWN
+        }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        BackendHealth.DOWN
+    }
+
+    companion object {
+        private const val DEFAULT_POLL_INTERVAL_MS = 5_000L
+    }
+}

--- a/app/src/main/java/com/machikoro/client/network/health/HealthApi.kt
+++ b/app/src/main/java/com/machikoro/client/network/health/HealthApi.kt
@@ -1,0 +1,15 @@
+package com.machikoro.client.network.health
+
+import kotlinx.serialization.Serializable
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface HealthApi {
+    @GET("/actuator/health")
+    suspend fun checkHealth(): Response<HealthResponse>
+}
+
+@Serializable
+data class HealthResponse(
+    val status: String? = null,
+)

--- a/app/src/main/java/com/machikoro/client/network/health/HealthApiFactory.kt
+++ b/app/src/main/java/com/machikoro/client/network/health/HealthApiFactory.kt
@@ -1,0 +1,29 @@
+package com.machikoro.client.network.health
+
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import java.util.concurrent.TimeUnit
+
+object HealthApiFactory {
+    private val json = Json {
+        ignoreUnknownKeys = true
+    }
+
+    // Short timeouts so probes against a dead server fail fast and don't
+    // pile up — polling cadence (5s) must outpace each probe.
+    private val httpClient: OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(3, TimeUnit.SECONDS)
+        .readTimeout(3, TimeUnit.SECONDS)
+        .build()
+
+    fun create(baseUrl: String): HealthApi =
+        Retrofit.Builder()
+            .baseUrl(baseUrl)
+            .client(httpClient)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(HealthApi::class.java)
+}

--- a/app/src/main/java/com/machikoro/client/ui/start/StartScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/StartScreen.kt
@@ -1,13 +1,19 @@
 package com.machikoro.client.ui.start
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -20,11 +26,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.machikoro.client.R
+import com.machikoro.client.domain.model.state.BackendHealth
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.LoginDialogState
 import com.machikoro.client.domain.model.state.LogoutState
@@ -35,6 +43,12 @@ import com.machikoro.client.ui.theme.ClientTheme
 private val SecondaryActionShape = RoundedCornerShape(8.dp)
 private val SecondaryActionColor = Color(0xFF64B5F6)
 private val SecondaryActionTextColor = Color.Black
+
+private val HealthChipShape = RoundedCornerShape(12.dp)
+private val HealthChipBackground = Color.White.copy(alpha = 0.85f)
+private val HealthUpColor = Color(0xFF4CAF50)
+private val HealthDownColor = Color(0xFFE53935)
+private val HealthUnknownColor = Color(0xFFB0BEC5)
 
 @Composable
 fun StartScreen(
@@ -73,6 +87,12 @@ fun StartScreen(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .padding(top = 16.dp, end = 16.dp),
+            )
+            BackendHealthChip(
+                health = state.backendHealth,
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .padding(top = 16.dp, start = 16.dp),
             )
 
             Column(
@@ -186,6 +206,38 @@ private fun SecondaryActionButton(
     }
 }
 
+@Composable
+private fun BackendHealthChip(
+    health: BackendHealth,
+    modifier: Modifier = Modifier,
+) {
+    val (dotColor, label) = when (health) {
+        BackendHealth.UP -> HealthUpColor to "Connected"
+        BackendHealth.DOWN -> HealthDownColor to "Backend unreachable"
+        BackendHealth.UNKNOWN -> HealthUnknownColor to "Checking…"
+    }
+    Row(
+        modifier = modifier
+            .clip(HealthChipShape)
+            .background(HealthChipBackground)
+            .padding(horizontal = 10.dp, vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(10.dp)
+                .clip(CircleShape)
+                .background(dotColor),
+        )
+        Spacer(modifier = Modifier.width(6.dp))
+        Text(
+            text = label,
+            color = Color.Black,
+            style = MaterialTheme.typography.labelMedium,
+        )
+    }
+}
+
 @Preview(
     showBackground = true,
     widthDp = 917,
@@ -196,7 +248,8 @@ private fun StartScreenPreview() {
     ClientTheme {
         StartScreen(
             state = StartScreenState.placeholder().copy(
-                connectionStatus = ConnectionStatus.CONNECTED
+                connectionStatus = ConnectionStatus.CONNECTED,
+                backendHealth = BackendHealth.UP,
             ),
             registerDialogState = RegisterDialogState(),
             loginDialogState = LoginDialogState(),
@@ -226,6 +279,7 @@ private fun StartScreenAuthenticatedPreview() {
             state = StartScreenState.placeholder().copy(
                 connectionStatus = ConnectionStatus.CONNECTED,
                 loggedInAs = "alice",
+                backendHealth = BackendHealth.DOWN,
             ),
             registerDialogState = RegisterDialogState(),
             loginDialogState = LoginDialogState(),

--- a/app/src/main/java/com/machikoro/client/ui/start/StartScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/start/StartScreenViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.machikoro.client.domain.model.state.StartScreenState
 import com.machikoro.client.domain.session.SessionStateHolder
+import com.machikoro.client.network.health.BackendHealthRepository
 import com.machikoro.client.network.websocket.WebSocketClient
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -15,6 +16,7 @@ import kotlinx.coroutines.launch
 class StartScreenViewModel(
     private val webSocketClient: WebSocketClient,
     private val sessionStateHolder: SessionStateHolder,
+    private val healthRepository: BackendHealthRepository,
 ) : ViewModel() {
     val state: StateFlow<StartScreenState>
         get() = mutableState.asStateFlow()
@@ -36,18 +38,30 @@ class StartScreenViewModel(
                 }
             }
         }
-    }
-
-        class Factory(
-            private val webSocketClient: WebSocketClient,
-            private val sessionStateHolder: SessionStateHolder,
-        ) : ViewModelProvider.Factory {
-            @Suppress("UNCHECKED_CAST")
-            override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                require(modelClass.isAssignableFrom(StartScreenViewModel::class.java)) {
-                    "Unknown ViewModel class: ${modelClass.name}"
+        viewModelScope.launch {
+            healthRepository.observe().collect { health ->
+                mutableState.update { current ->
+                    current.copy(backendHealth = health)
                 }
-                return StartScreenViewModel(webSocketClient, sessionStateHolder) as T
             }
         }
     }
+
+    class Factory(
+        private val webSocketClient: WebSocketClient,
+        private val sessionStateHolder: SessionStateHolder,
+        private val healthRepository: BackendHealthRepository,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            require(modelClass.isAssignableFrom(StartScreenViewModel::class.java)) {
+                "Unknown ViewModel class: ${modelClass.name}"
+            }
+            return StartScreenViewModel(
+                webSocketClient,
+                sessionStateHolder,
+                healthRepository,
+            ) as T
+        }
+    }
+}

--- a/app/src/test/java/com/machikoro/client/network/health/BackendHealthRepositoryTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/health/BackendHealthRepositoryTest.kt
@@ -1,0 +1,80 @@
+package com.machikoro.client.network.health
+
+import com.machikoro.client.domain.model.state.BackendHealth
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BackendHealthRepositoryTest {
+
+    @Test
+    fun `observe emits UP on 2xx with status UP body`() = runTest {
+        val api: HealthApi = mock()
+        whenever(api.checkHealth()).thenReturn(Response.success(HealthResponse("UP")))
+        val repo = BackendHealthRepository(api, pollIntervalMs = 100L)
+
+        val result = repo.observe().first()
+
+        assertEquals(BackendHealth.UP, result)
+    }
+
+    @Test
+    fun `observe emits DOWN on non-2xx response`() = runTest {
+        val api: HealthApi = mock()
+        whenever(api.checkHealth()).thenReturn(
+            Response.error(503, "".toResponseBody("application/json".toMediaType()))
+        )
+        val repo = BackendHealthRepository(api, pollIntervalMs = 100L)
+
+        val result = repo.observe().first()
+
+        assertEquals(BackendHealth.DOWN, result)
+    }
+
+    @Test
+    fun `observe emits DOWN when body status is not UP`() = runTest {
+        val api: HealthApi = mock()
+        whenever(api.checkHealth()).thenReturn(Response.success(HealthResponse("DOWN")))
+        val repo = BackendHealthRepository(api, pollIntervalMs = 100L)
+
+        val result = repo.observe().first()
+
+        assertEquals(BackendHealth.DOWN, result)
+    }
+
+    @Test
+    fun `observe emits DOWN when api throws IOException`() = runTest {
+        val api: HealthApi = mock()
+        whenever(api.checkHealth()).thenAnswer { throw IOException("timeout") }
+        val repo = BackendHealthRepository(api, pollIntervalMs = 100L)
+
+        val result = repo.observe().first()
+
+        assertEquals(BackendHealth.DOWN, result)
+    }
+
+    @Test
+    fun `observe emits at poll interval cadence`() = runTest {
+        val api: HealthApi = mock()
+        whenever(api.checkHealth()).thenReturn(Response.success(HealthResponse("UP")))
+        val repo = BackendHealthRepository(api, pollIntervalMs = 1_000L)
+
+        val emissions = repo.observe().take(3).toList()
+
+        assertEquals(listOf(BackendHealth.UP, BackendHealth.UP, BackendHealth.UP), emissions)
+        verify(api, times(3)).checkHealth()
+    }
+}

--- a/app/src/test/java/com/machikoro/client/network/health/HealthApiFactoryTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/health/HealthApiFactoryTest.kt
@@ -1,0 +1,18 @@
+package com.machikoro.client.network.health
+
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+
+class HealthApiFactoryTest {
+    @Test
+    fun createReturnsHealthApi() {
+        val api = HealthApiFactory.create("http://localhost/")
+        assertNotNull(api)
+    }
+
+    @Test
+    fun createWithTrailingSlashSucceeds() {
+        val api = HealthApiFactory.create("http://10.0.2.2:8080/")
+        assertNotNull(api)
+    }
+}

--- a/app/src/test/java/com/machikoro/client/ui/start/StartScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/start/StartScreenViewModelTest.kt
@@ -1,10 +1,15 @@
 package com.machikoro.client.ui.start
 
+import com.machikoro.client.domain.model.state.BackendHealth
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.session.Session
 import com.machikoro.client.domain.session.SessionStateHolder
+import com.machikoro.client.network.health.BackendHealthRepository
+import com.machikoro.client.network.health.HealthApi
+import com.machikoro.client.network.health.HealthResponse
 import com.machikoro.client.network.websocket.FakeWebSocketClient
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -14,6 +19,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
+import retrofit2.Response
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class StartScreenViewModelTest {
@@ -22,17 +28,26 @@ class StartScreenViewModelTest {
 
     @Test
     fun initialStateUsesPlaceholderValues() = runTest {
-        val viewModel = StartScreenViewModel(FakeWebSocketClient(), FakeSessionStateHolder())
+        val viewModel = StartScreenViewModel(
+            FakeWebSocketClient(),
+            FakeSessionStateHolder(),
+            FakeBackendHealthRepository(),
+        )
         advanceUntilIdle()
         assertEquals("Machi Koro Client", viewModel.state.value.title)
         assertEquals(ConnectionStatus.IDLE, viewModel.state.value.connectionStatus)
         assertNull(viewModel.state.value.loggedInAs)
+        assertEquals(BackendHealth.UNKNOWN, viewModel.state.value.backendHealth)
     }
 
     @Test
     fun clientStatusUpdatesAreReflectedInScreenState() = runTest {
         val fakeClient = FakeWebSocketClient()
-        val viewModel = StartScreenViewModel(fakeClient, FakeSessionStateHolder())
+        val viewModel = StartScreenViewModel(
+            fakeClient,
+            FakeSessionStateHolder(),
+            FakeBackendHealthRepository(),
+        )
         fakeClient.emitConnectionStatus(ConnectionStatus.CONNECTING)
         advanceUntilIdle()
         assertEquals(ConnectionStatus.CONNECTING, viewModel.state.value.connectionStatus)
@@ -47,13 +62,37 @@ class StartScreenViewModelTest {
     @Test
     fun sessionUpdatesAreReflectedInLoggedInAs() = runTest {
         val sessionHolder = FakeSessionStateHolder()
-        val viewModel = StartScreenViewModel(FakeWebSocketClient(), sessionHolder)
+        val viewModel = StartScreenViewModel(
+            FakeWebSocketClient(),
+            sessionHolder,
+            FakeBackendHealthRepository(),
+        )
         sessionHolder.signIn(token = "uuid-123", username = "alice", userId = 1)
         advanceUntilIdle()
         assertEquals("alice", viewModel.state.value.loggedInAs)
         sessionHolder.signOut()
         advanceUntilIdle()
         assertNull(viewModel.state.value.loggedInAs)
+    }
+
+    @Test
+    fun backendHealthUpdatesAreReflectedInScreenState() = runTest {
+        val healthRepo = FakeBackendHealthRepository()
+        val viewModel = StartScreenViewModel(
+            FakeWebSocketClient(),
+            FakeSessionStateHolder(),
+            healthRepo,
+        )
+        advanceUntilIdle()
+        assertEquals(BackendHealth.UNKNOWN, viewModel.state.value.backendHealth)
+
+        healthRepo.emit(BackendHealth.UP)
+        advanceUntilIdle()
+        assertEquals(BackendHealth.UP, viewModel.state.value.backendHealth)
+
+        healthRepo.emit(BackendHealth.DOWN)
+        advanceUntilIdle()
+        assertEquals(BackendHealth.DOWN, viewModel.state.value.backendHealth)
     }
 
     private class FakeSessionStateHolder : SessionStateHolder {
@@ -63,5 +102,18 @@ class StartScreenViewModelTest {
             mutableSession.value = Session(token, username, userId)
         }
         override fun signOut() { mutableSession.value = null }
+    }
+
+    private object NoOpHealthApi : HealthApi {
+        override suspend fun checkHealth(): Response<HealthResponse> = throw NotImplementedError()
+    }
+
+    private class FakeBackendHealthRepository : BackendHealthRepository(
+        api = NoOpHealthApi,
+        pollIntervalMs = Long.MAX_VALUE,
+    ) {
+        private val flow = MutableStateFlow(BackendHealth.UNKNOWN)
+        override fun observe(): Flow<BackendHealth> = flow
+        fun emit(value: BackendHealth) { flow.value = value }
     }
 }


### PR DESCRIPTION
## Summary
- Adds a backend reachability indicator to the Start screen: a small status chip (**Connected** / **Backend unreachable** / **Checking…**) in the top-left, polling `${AppConfig.backendBaseUrl}/actuator/health` every 5 s with a 3 s OkHttp timeout.
- New probe layer in `network/health/`: `HealthApi`, `HealthApiFactory` (with custom OkHttp timeouts), `BackendHealthRepository` (cold `Flow<BackendHealth>`; rethrows `CancellationException`, collapses every other failure to `DOWN`).
- `StartScreenViewModel` observes the repository and surfaces the value on `StartScreenState.backendHealth`; `MainActivity` lazy-wires the dependency chain. Server side already exposes `/actuator/health` publicly via Spring Boot Actuator — no server changes required.

Closes #198.

## Test plan
- [x] `:app:testDebugUnitTest` (full suite) + `:app:jacocoTestReport` + `:app:lintDebug` all green locally.
- [x] New `BackendHealthRepositoryTest` covers `UP` on 2xx, `DOWN` on non-2xx / body != UP / `IOException`, and the polling cadence.
- [x] `StartScreenViewModelTest` extended with `backendHealthUpdatesAreReflectedInScreenState` and an `UNKNOWN` placeholder assertion.
- [x] Manual: with the backend up, the chip shows **Connected** (green) within ~5 s of opening the Start screen.
- [x] Manual: stop the backend → chip transitions to **Backend unreachable** (red) within ~5–10 s.
- [x] Manual: restart the backend → chip returns to **Connected** (green) within ~5–10 s.
