### PR TITLE
feat: connection status banner on post-login screens

### DIFF
--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -29,6 +29,7 @@ import com.machikoro.client.network.health.BackendHealthRepository
 import com.machikoro.client.network.health.HealthApiFactory
 import com.machikoro.client.network.websocket.OkHttpWebSocketClient
 import com.machikoro.client.ui.AppRoot
+import com.machikoro.client.ui.connection.ConnectionBannerViewModel
 import com.machikoro.client.ui.game.GameScreenViewModel
 import com.machikoro.client.ui.home.HomeViewModel
 import com.machikoro.client.ui.lobby.LobbyScreenViewModel
@@ -85,6 +86,10 @@ class MainActivity : ComponentActivity() {
         NavigationViewModel.Factory()
     }
 
+    private val connectionBannerViewModel by viewModels<ConnectionBannerViewModel> {
+        ConnectionBannerViewModel.Factory(webSocketClient, SessionManager)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         SessionManager.attach(DataStoreSessionStorage(applicationContext))
@@ -102,6 +107,7 @@ class MainActivity : ComponentActivity() {
             val registerDialogState by registerDialogViewModel.state.collectAsState()
             val loginDialogState by loginDialogViewModel.state.collectAsState()
             val logoutState by logoutViewModel.state.collectAsState()
+            val connectionBannerState by connectionBannerViewModel.state.collectAsState()
             var showJoinLobbyInput by remember { mutableStateOf(false) }
             val snackbarHostState = remember { SnackbarHostState() }
             val hasActiveGame = activeGameId != null && gameScreenState.gamePhase != GamePhase.NONE
@@ -162,6 +168,7 @@ class MainActivity : ComponentActivity() {
                         registerDialogState = registerDialogState,
                         loginDialogState = loginDialogState,
                         logoutState = logoutState,
+                        connectionBannerState = connectionBannerState,
                         onRegisterUsernameChange = registerDialogViewModel::usernameChanged,
                         onRegisterPasswordChange = registerDialogViewModel::passwordChanged,
                         onRegisterSubmit = registerDialogViewModel::submit,

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -1,6 +1,8 @@
 package com.machikoro.client.ui
 
 import android.annotation.SuppressLint
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.layout.Column
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.DisposableEffect
@@ -13,6 +15,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.machikoro.client.domain.enums.GamePhase
@@ -22,6 +25,8 @@ import com.machikoro.client.domain.model.state.LobbyScreenState
 import com.machikoro.client.domain.model.state.LogoutState
 import com.machikoro.client.domain.model.state.RegisterDialogState
 import com.machikoro.client.domain.model.state.StartScreenState
+import com.machikoro.client.ui.connection.ConnectionBannerState
+import com.machikoro.client.ui.connection.ConnectionStatusBanner
 import com.machikoro.client.ui.game.GameScreen
 import com.machikoro.client.ui.home.HomeScreen
 import com.machikoro.client.ui.lobby.LobbyScreen
@@ -47,6 +52,7 @@ fun AppRoot(
     joinLobbyCode: String = "",
     showJoinLobbyInput: Boolean = false,
     joinLobbyError: Boolean = false,
+    connectionBannerState: ConnectionBannerState = ConnectionBannerState.Hidden,
     onRegisterUsernameChange: (String) -> Unit,
     onRegisterPasswordChange: (String) -> Unit,
     onRegisterSubmit: () -> Unit,
@@ -76,6 +82,9 @@ fun AppRoot(
     val navController = rememberNavController()
     val appNavigator = remember(navController) { AppNavigator(navController) }
     val navigationUiState by navigationViewModel.uiState.collectAsState()
+    val currentBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = currentBackStackEntry?.destination?.route
+    val showConnectionBanner = currentRoute != null && currentRoute != AppRoute.Main.route
 
     // AppRoot owns the NavHost lifecycle, but route decisions are delegated to
     // NavigationViewModel so navigation state has one source of truth.
@@ -117,95 +126,101 @@ fun AppRoot(
         )
     }
 
-    NavHost(
-        navController = navController,
-        startDestination = AppRoute.Main.route,
-        modifier = modifier,
-    ) {
-        composable(AppRoute.Main.route) {
-            StartScreen(
-                state = startScreenState,
-                registerDialogState = registerDialogState,
-                loginDialogState = loginDialogState,
-                logoutState = logoutState,
-                onRegisterUsernameChange = onRegisterUsernameChange,
-                onRegisterPasswordChange = onRegisterPasswordChange,
-                onRegisterSubmit = onRegisterSubmit,
-                onRegisterDialogReset = onRegisterDialogReset,
-                onLoginUsernameChange = onLoginUsernameChange,
-                onLoginPasswordChange = onLoginPasswordChange,
-                onLoginSubmit = onLoginSubmit,
-                onLoginDialogReset = onLoginDialogReset,
-                onLogoutSubmit = onLogoutSubmit,
-            )
+    Column(modifier = modifier) {
+        AnimatedVisibility(
+            visible = showConnectionBanner && connectionBannerState !is ConnectionBannerState.Hidden,
+        ) {
+            ConnectionStatusBanner(state = connectionBannerState)
         }
+        NavHost(
+            navController = navController,
+            startDestination = AppRoute.Main.route,
+        ) {
+            composable(AppRoute.Main.route) {
+                StartScreen(
+                    state = startScreenState,
+                    registerDialogState = registerDialogState,
+                    loginDialogState = loginDialogState,
+                    logoutState = logoutState,
+                    onRegisterUsernameChange = onRegisterUsernameChange,
+                    onRegisterPasswordChange = onRegisterPasswordChange,
+                    onRegisterSubmit = onRegisterSubmit,
+                    onRegisterDialogReset = onRegisterDialogReset,
+                    onLoginUsernameChange = onLoginUsernameChange,
+                    onLoginPasswordChange = onLoginPasswordChange,
+                    onLoginSubmit = onLoginSubmit,
+                    onLoginDialogReset = onLoginDialogReset,
+                    onLogoutSubmit = onLogoutSubmit,
+                )
+            }
 
-        composable(AppRoute.Home.route) {
-            HomeScreen(
-                joinLobbyCode = joinLobbyCode,
-                showJoinLobbyInput = showJoinLobbyInput && lobbyCode == null,
-                onJoinLobbyClick = onJoinLobbyClick,
-                onJoinLobbyCodeChange = onJoinLobbyCodeChange,
-                onJoinLobbySubmit = onJoinLobbySubmit,
-                joinLobbyError = joinLobbyError,
-                onCreateLobbyClick = onCreateLobbyClick,
-                hasActiveGame = hasActiveGame,
-                onResumeGameClick = onResumeGameClick,
-                onPurgeClick = onPurgeClick,
-                onLogoutClick = onLogoutSubmit,
-                modifier = modifier
-            )
-        }
+            composable(AppRoute.Home.route) {
+                HomeScreen(
+                    joinLobbyCode = joinLobbyCode,
+                    showJoinLobbyInput = showJoinLobbyInput && lobbyCode == null,
+                    onJoinLobbyClick = onJoinLobbyClick,
+                    onJoinLobbyCodeChange = onJoinLobbyCodeChange,
+                    onJoinLobbySubmit = onJoinLobbySubmit,
+                    joinLobbyError = joinLobbyError,
+                    onCreateLobbyClick = onCreateLobbyClick,
+                    hasActiveGame = hasActiveGame,
+                    onResumeGameClick = onResumeGameClick,
+                    onPurgeClick = onPurgeClick,
+                    onLogoutClick = onLogoutSubmit,
+                    modifier = modifier,
+                )
+            }
 
-        composable(
-            route = AppRoute.Lobby.route,
-            arguments = listOf(
-                navArgument(AppRoute.Lobby.LOBBY_CODE_ARGUMENT) {
-                    type = NavType.StringType
-                    nullable = true
-                    defaultValue = null
-                }
-            ),
-        ) { backStackEntry ->
-            val routedLobbyCode = backStackEntry.arguments
-                ?.getString(AppRoute.Lobby.LOBBY_CODE_ARGUMENT)
-                ?.takeIf { it.isNotBlank() }
-            LobbyScreen(
-                state = lobbyScreenState,
-                lobbyCode = routedLobbyCode ?: lobbyCode,
-                onReadyToggle = onReadyToggle,
-                onStartGame = onStartGame,
-                onLeaveLobby = onLeaveLobby,
-                onFillWithDummies = onFillWithDummies,
-                onResetLobby = onResetLobby,
-            )
-        }
+            composable(
+                route = AppRoute.Lobby.route,
+                arguments = listOf(
+                    navArgument(AppRoute.Lobby.LOBBY_CODE_ARGUMENT) {
+                        type = NavType.StringType
+                        nullable = true
+                        defaultValue = null
+                    },
+                ),
+            ) { backStackEntry ->
+                val routedLobbyCode = backStackEntry.arguments
+                    ?.getString(AppRoute.Lobby.LOBBY_CODE_ARGUMENT)
+                    ?.takeIf { it.isNotBlank() }
+                LobbyScreen(
+                    state = lobbyScreenState,
+                    lobbyCode = routedLobbyCode ?: lobbyCode,
+                    onReadyToggle = onReadyToggle,
+                    onStartGame = onStartGame,
+                    onLeaveLobby = onLeaveLobby,
+                    onFillWithDummies = onFillWithDummies,
+                    onResetLobby = onResetLobby,
+                )
+            }
 
-        composable(
-            route = AppRoute.Game.route,
-            arguments = listOf(
-                navArgument(AppRoute.Game.GAME_ID_ARGUMENT) {
-                    type = NavType.IntType
-                    defaultValue = AppRoute.Game.MISSING_GAME_ID
-                }
-            ),
-        ) { backStackEntry ->
-            val routedGameId = backStackEntry.arguments
-                ?.getInt(AppRoute.Game.GAME_ID_ARGUMENT)
-                ?.takeIf { it != AppRoute.Game.MISSING_GAME_ID }
-            GameScreen(
-                state = gameScreenState.copy(gameId = routedGameId ?: gameScreenState.gameId),
-                onRollDice = onRollDice,
-                onPurchaseClick = onPurchaseClick,
-                onLeaveGame = onLeaveGame,
-            )
-        }
+            composable(
+                route = AppRoute.Game.route,
+                arguments = listOf(
+                    navArgument(AppRoute.Game.GAME_ID_ARGUMENT) {
+                        type = NavType.IntType
+                        defaultValue = AppRoute.Game.MISSING_GAME_ID
+                    },
+                ),
+            ) { backStackEntry ->
+                val routedGameId = backStackEntry.arguments
+                    ?.getInt(AppRoute.Game.GAME_ID_ARGUMENT)
+                    ?.takeIf { it != AppRoute.Game.MISSING_GAME_ID }
+                GameScreen(
+                    state = gameScreenState.copy(gameId = routedGameId ?: gameScreenState.gameId),
+                    onRollDice = onRollDice,
+                    onPurchaseClick = onPurchaseClick,
+                    onLeaveGame = onLeaveGame,
+                )
+            }
 
-        composable(AppRoute.Winner.route) {
-            GameOverOneWinner(
-                winnerName = resolveWinnerName(gameScreenState),
-                roundsNumber = gameScreenState.roundNumber ?: 0,
-            )
+            composable(AppRoute.Winner.route) {
+                GameOverOneWinner(
+                    winnerName = resolveWinnerName(gameScreenState),
+                    roundsNumber = gameScreenState.roundNumber ?: 0,
+                )
+            }
         }
     }
 }
@@ -251,7 +266,7 @@ private fun AppRootStartScreenPreview() {
             onLogoutSubmit = {},
             lobbyCode = null,
             onCreateLobbyClick = {},
-            navigationViewModel = NavigationViewModel()
+            navigationViewModel = NavigationViewModel(),
         )
     }
 }
@@ -279,7 +294,8 @@ private fun AppRootGameScreenPreview() {
             onLogoutSubmit = {},
             lobbyCode = null,
             onCreateLobbyClick = {},
-            navigationViewModel = NavigationViewModel()
+            connectionBannerState = ConnectionBannerState.Disconnected,
+            navigationViewModel = NavigationViewModel(),
         )
     }
 }

--- a/app/src/main/java/com/machikoro/client/ui/connection/ConnectionBannerState.kt
+++ b/app/src/main/java/com/machikoro/client/ui/connection/ConnectionBannerState.kt
@@ -1,0 +1,7 @@
+package com.machikoro.client.ui.connection
+
+sealed class ConnectionBannerState {
+    object Hidden : ConnectionBannerState()
+    object Disconnected : ConnectionBannerState()
+    object Reconnected : ConnectionBannerState()
+}

--- a/app/src/main/java/com/machikoro/client/ui/connection/ConnectionBannerState.kt
+++ b/app/src/main/java/com/machikoro/client/ui/connection/ConnectionBannerState.kt
@@ -1,7 +1,7 @@
 package com.machikoro.client.ui.connection
 
 sealed class ConnectionBannerState {
-    object Hidden : ConnectionBannerState()
-    object Disconnected : ConnectionBannerState()
-    object Reconnected : ConnectionBannerState()
+    data object Hidden : ConnectionBannerState()
+    data object Disconnected : ConnectionBannerState()
+    data object Reconnected : ConnectionBannerState()
 }

--- a/app/src/main/java/com/machikoro/client/ui/connection/ConnectionBannerViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/connection/ConnectionBannerViewModel.kt
@@ -1,0 +1,89 @@
+package com.machikoro.client.ui.connection
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.machikoro.client.domain.model.state.ConnectionStatus
+import com.machikoro.client.domain.session.SessionStateHolder
+import com.machikoro.client.network.websocket.WebSocketClient
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class ConnectionBannerViewModel(
+    private val webSocketClient: WebSocketClient,
+    private val sessionStateHolder: SessionStateHolder,
+    private val reconnectedDisplayMs: Long = DEFAULT_RECONNECTED_DISPLAY_MS,
+) : ViewModel() {
+
+    private val mutableState = MutableStateFlow<ConnectionBannerState>(ConnectionBannerState.Hidden)
+    val state: StateFlow<ConnectionBannerState> = mutableState.asStateFlow()
+
+    // Tracks whether the user has seen a successful CONNECTED at least once in
+    // the current session. Without this guard the initial CONNECTING after
+    // login would falsely flash "Connection lost" before the first connect.
+    private var hasEverConnectedThisSession = false
+    private var recoveryJob: Job? = null
+
+    init {
+        viewModelScope.launch {
+            webSocketClient.connectionStatus.collect { status -> onStatusChange(status) }
+        }
+        viewModelScope.launch {
+            sessionStateHolder.session.collect { session ->
+                if (session == null) {
+                    recoveryJob?.cancel()
+                    recoveryJob = null
+                    hasEverConnectedThisSession = false
+                    mutableState.value = ConnectionBannerState.Hidden
+                }
+            }
+        }
+    }
+
+    private fun onStatusChange(status: ConnectionStatus) {
+        if (status == ConnectionStatus.CONNECTED) {
+            if (hasEverConnectedThisSession) {
+                recoveryJob?.cancel()
+                recoveryJob = viewModelScope.launch {
+                    mutableState.value = ConnectionBannerState.Reconnected
+                    delay(reconnectedDisplayMs)
+                    if (mutableState.value is ConnectionBannerState.Reconnected) {
+                        mutableState.value = ConnectionBannerState.Hidden
+                    }
+                }
+            } else {
+                mutableState.value = ConnectionBannerState.Hidden
+            }
+            hasEverConnectedThisSession = true
+        } else {
+            recoveryJob?.cancel()
+            recoveryJob = null
+            mutableState.value = if (hasEverConnectedThisSession) {
+                ConnectionBannerState.Disconnected
+            } else {
+                ConnectionBannerState.Hidden
+            }
+        }
+    }
+
+    class Factory(
+        private val webSocketClient: WebSocketClient,
+        private val sessionStateHolder: SessionStateHolder,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            require(modelClass.isAssignableFrom(ConnectionBannerViewModel::class.java)) {
+                "Unknown ViewModel class: ${modelClass.name}"
+            }
+            return ConnectionBannerViewModel(webSocketClient, sessionStateHolder) as T
+        }
+    }
+
+    companion object {
+        private const val DEFAULT_RECONNECTED_DISPLAY_MS = 3_000L
+    }
+}

--- a/app/src/main/java/com/machikoro/client/ui/connection/ConnectionStatusBanner.kt
+++ b/app/src/main/java/com/machikoro/client/ui/connection/ConnectionStatusBanner.kt
@@ -1,0 +1,60 @@
+package com.machikoro.client.ui.connection
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.machikoro.client.ui.theme.GreenDark
+import com.machikoro.client.ui.theme.GreenLight
+import com.machikoro.client.ui.theme.RedDark
+import com.machikoro.client.ui.theme.RedLight
+
+@Composable
+fun ConnectionStatusBanner(
+    state: ConnectionBannerState,
+    modifier: Modifier = Modifier,
+) {
+    val (background, textColor, label) = when (state) {
+        ConnectionBannerState.Hidden -> return
+        ConnectionBannerState.Disconnected ->
+            Triple(RedLight, RedDark, "Connection lost — reconnecting…")
+        ConnectionBannerState.Reconnected ->
+            Triple(GreenLight, GreenDark, "Reconnected")
+    }
+    BannerSurface(background = background, textColor = textColor, label = label, modifier = modifier)
+}
+
+@Composable
+private fun BannerSurface(
+    background: Color,
+    textColor: Color,
+    label: String,
+    modifier: Modifier,
+) {
+    Surface(color = background, modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = label,
+            color = textColor,
+            style = MaterialTheme.typography.labelLarge,
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 400)
+@Composable
+private fun ConnectionStatusBannerDisconnectedPreview() {
+    ConnectionStatusBanner(state = ConnectionBannerState.Disconnected)
+}
+
+@Preview(showBackground = true, widthDp = 400)
+@Composable
+private fun ConnectionStatusBannerReconnectedPreview() {
+    ConnectionStatusBanner(state = ConnectionBannerState.Reconnected)
+}

--- a/app/src/main/java/com/machikoro/client/ui/connection/ConnectionStatusBanner.kt
+++ b/app/src/main/java/com/machikoro/client/ui/connection/ConnectionStatusBanner.kt
@@ -20,14 +20,21 @@ fun ConnectionStatusBanner(
     state: ConnectionBannerState,
     modifier: Modifier = Modifier,
 ) {
-    val (background, textColor, label) = when (state) {
-        ConnectionBannerState.Hidden -> return
-        ConnectionBannerState.Disconnected ->
-            Triple(RedLight, RedDark, "Connection lost — reconnecting…")
-        ConnectionBannerState.Reconnected ->
-            Triple(GreenLight, GreenDark, "Reconnected")
+    when (state) {
+        ConnectionBannerState.Hidden -> Unit
+        ConnectionBannerState.Disconnected -> BannerSurface(
+            background = RedLight,
+            textColor = RedDark,
+            label = "Connection lost — reconnecting…",
+            modifier = modifier,
+        )
+        ConnectionBannerState.Reconnected -> BannerSurface(
+            background = GreenLight,
+            textColor = GreenDark,
+            label = "Reconnected",
+            modifier = modifier,
+        )
     }
-    BannerSurface(background = background, textColor = textColor, label = label, modifier = modifier)
 }
 
 @Composable

--- a/app/src/test/java/com/machikoro/client/ui/connection/ConnectionBannerViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/connection/ConnectionBannerViewModelTest.kt
@@ -1,0 +1,153 @@
+package com.machikoro.client.ui.connection
+
+import com.machikoro.client.domain.model.state.ConnectionStatus
+import com.machikoro.client.domain.session.Session
+import com.machikoro.client.domain.session.SessionStateHolder
+import com.machikoro.client.network.websocket.FakeWebSocketClient
+import com.machikoro.client.ui.start.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConnectionBannerViewModelTest {
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun initialStateIsHidden() = runTest {
+        val viewModel = newViewModel()
+        assertEquals(ConnectionBannerState.Hidden, viewModel.state.value)
+    }
+
+    @Test
+    fun firstConnectingDoesNotShowBanner() = runTest {
+        val client = FakeWebSocketClient()
+        val viewModel = newViewModel(client = client)
+        client.emitConnectionStatus(ConnectionStatus.CONNECTING)
+        advanceUntilIdle()
+        assertEquals(ConnectionBannerState.Hidden, viewModel.state.value)
+    }
+
+    @Test
+    fun disconnectedWithoutPriorConnectedStaysHidden() = runTest {
+        val client = FakeWebSocketClient()
+        val viewModel = newViewModel(client = client)
+        client.emitConnectionStatus(ConnectionStatus.DISCONNECTED)
+        advanceUntilIdle()
+        assertEquals(ConnectionBannerState.Hidden, viewModel.state.value)
+    }
+
+    @Test
+    fun firstConnectedLeavesStateHidden() = runTest {
+        val client = FakeWebSocketClient()
+        val viewModel = newViewModel(client = client)
+        client.emitConnectionStatus(ConnectionStatus.CONNECTING)
+        client.emitConnectionStatus(ConnectionStatus.CONNECTED)
+        advanceUntilIdle()
+        assertEquals(ConnectionBannerState.Hidden, viewModel.state.value)
+    }
+
+    @Test
+    fun dropAfterConnectedTransitionsToDisconnected() = runTest {
+        val client = FakeWebSocketClient()
+        val viewModel = newViewModel(client = client)
+        client.emitConnectionStatus(ConnectionStatus.CONNECTED)
+        advanceUntilIdle()
+        client.emitConnectionStatus(ConnectionStatus.DISCONNECTED)
+        advanceUntilIdle()
+        assertEquals(ConnectionBannerState.Disconnected, viewModel.state.value)
+    }
+
+    @Test
+    fun errorAfterConnectedTransitionsToDisconnected() = runTest {
+        val client = FakeWebSocketClient()
+        val viewModel = newViewModel(client = client)
+        client.emitConnectionStatus(ConnectionStatus.CONNECTED)
+        advanceUntilIdle()
+        client.emitConnectionStatus(ConnectionStatus.ERROR)
+        advanceUntilIdle()
+        assertEquals(ConnectionBannerState.Disconnected, viewModel.state.value)
+    }
+
+    @Test
+    fun reconnectShowsRecoveryAndReturnsToHidden() = runTest {
+        val client = FakeWebSocketClient()
+        val viewModel = newViewModel(client = client, reconnectedDisplayMs = 3_000L)
+        client.emitConnectionStatus(ConnectionStatus.CONNECTED)
+        advanceUntilIdle()
+        client.emitConnectionStatus(ConnectionStatus.DISCONNECTED)
+        advanceUntilIdle()
+        client.emitConnectionStatus(ConnectionStatus.CONNECTED)
+        runCurrent()
+        assertEquals(ConnectionBannerState.Reconnected, viewModel.state.value)
+        advanceTimeBy(3_001L)
+        runCurrent()
+        assertEquals(ConnectionBannerState.Hidden, viewModel.state.value)
+    }
+
+    @Test
+    fun dropDuringRecoveryWindowCancelsTimerAndShowsDisconnected() = runTest {
+        val client = FakeWebSocketClient()
+        val viewModel = newViewModel(client = client, reconnectedDisplayMs = 3_000L)
+        client.emitConnectionStatus(ConnectionStatus.CONNECTED)
+        advanceUntilIdle()
+        client.emitConnectionStatus(ConnectionStatus.DISCONNECTED)
+        advanceUntilIdle()
+        client.emitConnectionStatus(ConnectionStatus.CONNECTED)
+        runCurrent()
+        assertEquals(ConnectionBannerState.Reconnected, viewModel.state.value)
+        client.emitConnectionStatus(ConnectionStatus.ERROR)
+        advanceUntilIdle()
+        assertEquals(ConnectionBannerState.Disconnected, viewModel.state.value)
+    }
+
+    @Test
+    fun signOutResetsAndConnectingDoesNotFlashDisconnected() = runTest {
+        val client = FakeWebSocketClient()
+        val session = FakeSessionStateHolder().apply { signIn("t1", "u1", 1) }
+        val viewModel = newViewModel(client = client, session = session)
+        client.emitConnectionStatus(ConnectionStatus.CONNECTED)
+        advanceUntilIdle()
+        client.emitConnectionStatus(ConnectionStatus.DISCONNECTED)
+        advanceUntilIdle()
+        assertEquals(ConnectionBannerState.Disconnected, viewModel.state.value)
+        session.signOut()
+        advanceUntilIdle()
+        assertEquals(ConnectionBannerState.Hidden, viewModel.state.value)
+        session.signIn("t2", "u2", 2)
+        client.emitConnectionStatus(ConnectionStatus.CONNECTING)
+        advanceUntilIdle()
+        assertEquals(ConnectionBannerState.Hidden, viewModel.state.value)
+    }
+
+    private fun newViewModel(
+        client: FakeWebSocketClient = FakeWebSocketClient(),
+        // Default to a signed-in session so the VM's logout-reset doesn't clear
+        // hasEverConnectedThisSession out from under tests that assert the
+        // state-machine. Tests that exercise sign-out pass their own holder.
+        session: SessionStateHolder = FakeSessionStateHolder().apply { signIn("t", "u", 1) },
+        reconnectedDisplayMs: Long = 3_000L,
+    ) = ConnectionBannerViewModel(
+        webSocketClient = client,
+        sessionStateHolder = session,
+        reconnectedDisplayMs = reconnectedDisplayMs,
+    )
+
+    private class FakeSessionStateHolder : SessionStateHolder {
+        private val mutableSession = MutableStateFlow<Session?>(null)
+        override val session: StateFlow<Session?> = mutableSession.asStateFlow()
+        override fun signIn(token: String, username: String, userId: Int) {
+            mutableSession.value = Session(token, username, userId)
+        }
+        override fun signOut() { mutableSession.value = null }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a connection status banner on post-login screens (Home, Lobby, Game, Winner): a persistent **red** "Connection lost — reconnecting…" while `webSocketClient.connectionStatus != CONNECTED`, and a brief **green** "Reconnected" for ~3 s when the connection returns. Suppressed on the Start screen, which already has the backend health chip from #198.
- New `ConnectionBannerViewModel` in `ui/connection/` observes `WebSocketClient.connectionStatus` and `SessionStateHolder.session`. Tracks `hasEverConnectedThisSession` so the first `CONNECTING` of a session never falsely flashes "Connection lost"; resets that flag on `signOut` so a fresh post-login `CONNECTING` doesn't either. Recovery is a cancellable `Job` so a quick re-drop during the green window cleanly returns to red.
- `AppRoot` wraps the existing `NavHost` in a `Column` with an `AnimatedVisibility` banner above, gated on `navController.currentBackStackEntryAsState().value?.destination?.route != AppRoute.Main.route`. `MainActivity` wires the new VM via `Factory(webSocketClient, SessionManager)` and pipes state into `AppRoot`.

Closes #200.

## Test plan
- [x] `:app:testDebugUnitTest` (full suite) + `:app:jacocoTestReport` + `:app:lintDebug` all green locally.
- [x] `ConnectionBannerViewModelTest` (9 cases) covers: initial `Hidden`, first `CONNECTING` / `CONNECTED` keep `Hidden`, `DISCONNECTED` / `ERROR` after `CONNECTED` → `Disconnected`, recovery shows `Reconnected` for 3 s then `Hidden`, re-drop during the green window cancels the timer and returns to `Disconnected`, `signOut` resets per-session state so the next login's `CONNECTING` does not flash `Disconnected`.
- [ ] Manual on emulator: log in — no banner (status `CONNECTED`).
- [ ] Manual: stop the backend → banner turns red within ~5–10 s; navigate Home / Lobby — banner stays.
- [ ] Manual: restart the backend → banner flashes green "Reconnected" for ~3 s, then hides.
- [ ] Manual: log out → banner hides (Start screen chip from #198 takes over).
- [ ] Manual: log back in → no spurious red flash during the initial `CONNECTING`.
