### PR TITLE
185 block game input until game is in progress

### DIFF
--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.machikoro.client.domain.enums.CardType
 import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.enums.LandmarkType
 import com.machikoro.client.domain.enums.PurchaseType
 import com.machikoro.client.domain.enums.ShopItemColor
@@ -153,7 +154,7 @@ fun GameScreen(
                 state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
             }
 
-            if (state.gamePhase == GamePhase.ROLL_DICE && state.isActivePlayer) {
+            if (state.gamePhase == GamePhase.ROLL_DICE && state.isActivePlayer  && state.gameStatus == GameStatus.IN_PROGRESS) {
                 Button(
                     onClick = onRollDice,
                     enabled = !state.isRolling,

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -499,7 +499,7 @@ private fun BuyingPhaseShop(
     onPurchaseClick: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    // Disable buying until both active-player state and a server game id are known.
+    // Disable buying until game is IN_PROGRESS, both active-player state and a server game id are known.
     val canPurchase = state.canCurrentPlayerPurchase() && state.gameId != null
     Surface(
         color = MaterialTheme.colorScheme.surface.copy(alpha = 0.96f),
@@ -613,7 +613,7 @@ private fun ShopItemCard(
     }
 }
 
-private fun GameScreenState.canCurrentPlayerPurchase(): Boolean = isActivePlayer
+private fun GameScreenState.canCurrentPlayerPurchase(): Boolean = isActivePlayer && gameStatus == GameStatus.IN_PROGRESS
 
 private fun GameScreenState.canPurchaseItem(item: ShopItem): Boolean =
     item.isAvailable &&
@@ -621,6 +621,7 @@ private fun GameScreenState.canPurchaseItem(item: ShopItem): Boolean =
         !isKnownBuiltLandmark(item)
 
 private fun GameScreenState.disabledReasonFor(item: ShopItem): String = when {
+    gameStatus != GameStatus.IN_PROGRESS -> "Game not active"
     !isActivePlayer -> "Waiting"
     gameId == null -> "No game"
     !item.isAvailable -> "Unavailable"

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -187,6 +187,11 @@ fun GameScreen(
         ) {
             Text(text = "Leave", style = MaterialTheme.typography.labelSmall)
         }
+        //shows a loading indicator when the game is not in progress and the connection status is not disconnected
+        InitializationLoadingOverlay(
+            connectionStatus = state.connectionStatus,
+            gameStatus = state.gameStatus
+        )
     }
 }
 
@@ -853,3 +858,56 @@ private fun previewMarketplace() = mapOf(
     CardType.CONVENIENCE_STORE to 4,
     CardType.FOREST to 6,
 )
+
+@Composable
+private fun InitializationLoadingOverlay(
+    connectionStatus: ConnectionStatus,
+    gameStatus: GameStatus?,
+    modifier: Modifier = Modifier
+) {
+    val isInitializing = connectionStatus != ConnectionStatus.CONNECTED || gameStatus != GameStatus.IN_PROGRESS
+
+    if (isInitializing) {
+        Box(
+            modifier = modifier
+                .fillMaxSize()
+                .background(Color.Black.copy(alpha = 0.3f)),
+            contentAlignment = Alignment.Center
+        ) {
+            Surface(
+                color = MaterialTheme.colorScheme.surface,
+                shape = RoundedCornerShape(12.dp),
+                tonalElevation = 4.dp,
+                modifier = Modifier
+                    .widthIn(min = 200.dp, max = 280.dp)
+                    .padding(24.dp)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .padding(24.dp)
+                        .fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    Text(
+                        text = "Initializing Game...",
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Text(
+                        text = when {
+                            connectionStatus == ConnectionStatus.CONNECTING -> "Connecting to server..."
+                            connectionStatus == ConnectionStatus.DISCONNECTED -> "Reconnecting..."
+                            connectionStatus == ConnectionStatus.ERROR -> "Connection error - retrying..."
+                            gameStatus == null -> "Loading game state..."
+                            else -> "Game loading..."
+                        },
+                        style = MaterialTheme.typography.bodySmall,
+                        textAlign = TextAlign.Center,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
@@ -11,6 +11,7 @@ import com.machikoro.client.domain.model.shop.PurchaseEvent
 import com.machikoro.client.domain.model.state.GameScreenState
 import com.machikoro.client.domain.model.state.PurchaseState
 import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.session.SessionStateHolder
 import com.machikoro.client.network.websocket.WebSocketClient
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -108,6 +109,7 @@ class GameScreenViewModel(
     }
 
     fun rollDice(diceCount: Int = 1) {
+        if (mutableState.value.gameStatus != GameStatus.IN_PROGRESS) return
         if (mutableState.value.gamePhase != GamePhase.ROLL_DICE) return
         if (!mutableState.value.isActivePlayer) return
         mutableState.update { it.copy(isRolling = true) }
@@ -138,6 +140,7 @@ class GameScreenViewModel(
     }
 
     private fun GameScreenState.canStartPurchase(item: ShopItem): Boolean =
+        gameStatus == GameStatus.IN_PROGRESS &&
         isBuyingPhase &&
             isActivePlayer &&
             purchaseState != PurchaseState.PENDING &&

--- a/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
@@ -192,6 +192,7 @@ class GameScreenViewModelTest {
         val fakeClient = FakeWebSocketClient()
         val viewModel = viewModel(fakeClient, userId = 42)
 
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
         fakeClient.emitGamePhase(GamePhase.ROLL_DICE)
         fakeClient.emitActivePlayerId(42)
         advanceUntilIdle()
@@ -206,6 +207,7 @@ class GameScreenViewModelTest {
         val fakeClient = FakeWebSocketClient()
         val viewModel = viewModel(fakeClient, userId = 42)
 
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
         fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
         fakeClient.emitActivePlayerId(42)
         advanceUntilIdle()
@@ -220,6 +222,7 @@ class GameScreenViewModelTest {
         val fakeClient = FakeWebSocketClient()
         val viewModel = viewModel(fakeClient, userId = 1)
 
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
         fakeClient.emitGamePhase(GamePhase.ROLL_DICE)
         fakeClient.emitActivePlayerId(99)
         advanceUntilIdle()
@@ -268,6 +271,7 @@ class GameScreenViewModelTest {
         val viewModel = viewModel(fakeClient, userId = 42)
 
         fakeClient.emitActiveGameId(7)
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
         fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
         fakeClient.emitActivePlayerId(42)
         advanceUntilIdle()
@@ -293,6 +297,7 @@ class GameScreenViewModelTest {
         val viewModel = viewModel(fakeClient, userId = 42)
 
         fakeClient.emitActiveGameId(7)
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
         fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
         fakeClient.emitActivePlayerId(42)
         advanceUntilIdle()
@@ -317,6 +322,7 @@ class GameScreenViewModelTest {
         val fakeClient = FakeWebSocketClient()
         val viewModel = viewModel(fakeClient, userId = 42)
 
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
         fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
         fakeClient.emitActivePlayerId(42)
         advanceUntilIdle()
@@ -333,6 +339,7 @@ class GameScreenViewModelTest {
         val viewModel = viewModel(fakeClient, userId = 42)
 
         fakeClient.emitActiveGameId(7)
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
         fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
         fakeClient.emitActivePlayerId(99)
         advanceUntilIdle()
@@ -349,6 +356,7 @@ class GameScreenViewModelTest {
         val viewModel = viewModel(fakeClient, userId = 42)
 
         fakeClient.emitActiveGameId(7)
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
         fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
         fakeClient.emitActivePlayerId(42)
         advanceUntilIdle()
@@ -374,6 +382,7 @@ class GameScreenViewModelTest {
         val viewModel = viewModel(fakeClient, userId = 42)
 
         fakeClient.emitActiveGameId(7)
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
         fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
         fakeClient.emitActivePlayerId(42)
         advanceUntilIdle()
@@ -399,6 +408,7 @@ class GameScreenViewModelTest {
         val viewModel = viewModel(fakeClient, userId = 42)
 
         fakeClient.emitActiveGameId(7)
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
         fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
         fakeClient.emitActivePlayerId(42)
         advanceUntilIdle()
@@ -432,6 +442,7 @@ class GameScreenViewModelTest {
         val viewModel = viewModel(fakeClient, userId = 42)
 
         fakeClient.emitActiveGameId(7)
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
         fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
         fakeClient.emitActivePlayerId(42)
         advanceUntilIdle()
@@ -458,6 +469,7 @@ class GameScreenViewModelTest {
         val fakeClient = FakeWebSocketClient()
         val viewModel = viewModel(fakeClient, userId = 42)
 
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
         fakeClient.emitGamePhase(GamePhase.ROLL_DICE)
         fakeClient.emitActivePlayerId(42)
         advanceUntilIdle()
@@ -472,6 +484,7 @@ class GameScreenViewModelTest {
         val fakeClient = FakeWebSocketClient()
         val viewModel = viewModel(fakeClient, userId = 42)
 
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
         fakeClient.emitGamePhase(GamePhase.ROLL_DICE)
         fakeClient.emitActivePlayerId(42)
         advanceUntilIdle()
@@ -490,6 +503,7 @@ class GameScreenViewModelTest {
         val fakeClient = FakeWebSocketClient()
         val viewModel = viewModel(fakeClient, userId = 42)
 
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
         fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
         fakeClient.emitActivePlayerId(42)
         advanceUntilIdle()
@@ -504,6 +518,7 @@ class GameScreenViewModelTest {
         val fakeClient = FakeWebSocketClient()
         val viewModel = viewModel(fakeClient, userId = 1)
 
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
         fakeClient.emitGamePhase(GamePhase.ROLL_DICE)
         fakeClient.emitActivePlayerId(99)
         advanceUntilIdle()
@@ -563,5 +578,52 @@ class GameScreenViewModelTest {
         advanceUntilIdle()
 
         assertEquals(marketplace, viewModel.state.value.marketplace)
+    }
+
+    @Test
+    fun rollDiceIsIgnoredWhenGameStatusIsNotInProgress() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 42)
+
+        fakeClient.emitGameStatus(GameStatus.WAITING)  // Not IN_PROGRESS
+        fakeClient.emitGamePhase(GamePhase.ROLL_DICE)
+        fakeClient.emitActivePlayerId(42)
+        advanceUntilIdle()
+
+        viewModel.rollDice(diceCount = 1)
+
+        assertNull(fakeClient.lastRolledDiceCount)
+    }
+
+    @Test
+    fun purchaseIsIgnoredWhenGameStatusIsNotInProgress() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 42)
+
+        fakeClient.emitGameStatus(GameStatus.WAITING)  // Not IN_PROGRESS
+        fakeClient.emitActiveGameId(7)
+        fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
+        fakeClient.emitActivePlayerId(42)
+        advanceUntilIdle()
+
+        viewModel.purchase("BAKERY")
+
+        assertNull(fakeClient.lastPurchase)
+        assertEquals(PurchaseState.IDLE, viewModel.state.value.purchaseState)
+    }
+
+    @Test
+    fun rollDiceIsIgnoredWhenGameStatusIsFinished() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 42)
+
+        fakeClient.emitGameStatus(GameStatus.FINISHED)
+        fakeClient.emitGamePhase(GamePhase.ROLL_DICE)
+        fakeClient.emitActivePlayerId(42)
+        advanceUntilIdle()
+
+        viewModel.rollDice(diceCount = 1)
+
+        assertNull(fakeClient.lastRolledDiceCount)
     }
 }


### PR DESCRIPTION
### Summary
This PR updated the GameScreen to only allow player actions when the Game Status is IN_PROGRESS

### Changes
- Roll dice now also checks for the correct game state
- Purchase buttons check for correct game state
- UI shows an overlay when the game is not ready for input
- ViewModel ignores dice roll and purchase triggers when the gamestate is not IN_PROGRESS
- Tests have been modifeid to account for these changes and additions