### PR TITLE
fix: align reconnect active player parsing with turn order contract

### DIFF
--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -773,11 +773,10 @@ class OkHttpWebSocketClient(
      * `activePlayerId`. Current server snapshots already send `activePlayerId`
      * and `turnOrder` in user-id space, so that value is authoritative.
      *
-     * The fallback below exists for older/incomplete snapshots that only have
-     * `currentTurnIndex` + `turnOrder`: if the turn entry matches a player row
-     * id, convert it to that row's userId; otherwise keep the turn entry as the
-     * userId. This preserves old reconnect payloads without breaking the new
-     * server contract.
+     * When `activePlayerId` is absent, `currentTurnIndex` selects the active
+     * user ID directly from `turnOrder`, as defined by the server contract.
+     * It must not be reinterpreted as a database player ID: those independent
+     * ID spaces can contain the same numeric value.
      */
     private fun resolveActiveUserId(state: JSONObject, game: JSONObject): Int? {
         state.optIntOrNull("activePlayerId")?.let { return it }
@@ -785,15 +784,7 @@ class OkHttpWebSocketClient(
         val currentTurnIndex = game.optIntOrNull("currentTurnIndex") ?: return null
         val turnOrder = state.optJSONArray("turnOrder") ?: return null
         if (currentTurnIndex !in 0 until turnOrder.length()) return null
-        val activeTurnEntry = turnOrder.optInt(currentTurnIndex)
-        val players = state.optJSONArray("players") ?: return activeTurnEntry
-        for (i in 0 until players.length()) {
-            val player = players.optJSONObject(i) ?: continue
-            if (player.optInt("id") == activeTurnEntry) {
-                return player.optIntOrNull("userId") ?: activeTurnEntry
-            }
-        }
-        return activeTurnEntry
+        return turnOrder.optInt(currentTurnIndex)
     }
 
     private fun parsePlayerCards(obj: JSONObject?): Map<Int, List<PlayerCardState>> {

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -1443,7 +1443,7 @@ class OkHttpWebSocketClientTest {
 
     @Test
     fun syncMessageResolvesActivePlayerUserIdFromTurnOrder() {
-        // Legacy fallback: turnOrder[currentTurnIndex=0] is playerId 11, whose userId is 1.
+        // Backend contract: turnOrder[currentTurnIndex=0] is userId 1.
         val client = clientAfterSync()
         assertEquals(1, client.activePlayerId.value)
     }
@@ -1819,7 +1819,7 @@ class OkHttpWebSocketClientTest {
         factory.simulateText(connectedFrame())
         factory.simulateText(
             syncFrame(
-                """{"type":"SYNC","sender":"server","gameId":7,"payload":{"targetUserId":1,"state":{"game":{"id":7,"status":"IN_PROGRESS","turnPhase":"BUY_OR_BUILD","currentTurnIndex":0},"players":[{"id":11,"userId":1,"coins":10},{"id":22,"userId":2,"coins":7}],"playerUsernames":{"11":"alice","22":"bob"},"playerLandmarks":{},"marketplace":{},"turnOrder":[11,22]}}}"""
+                """{"type":"SYNC","sender":"server","gameId":7,"payload":{"targetUserId":1,"state":{"game":{"id":7,"status":"IN_PROGRESS","turnPhase":"BUY_OR_BUILD","currentTurnIndex":0},"players":[{"id":11,"userId":1,"coins":10},{"id":22,"userId":2,"coins":7}],"playerUsernames":{"11":"alice","22":"bob"},"playerLandmarks":{},"marketplace":{},"turnOrder":[1,2]}}}"""
             )
         )
 
@@ -2292,7 +2292,7 @@ class OkHttpWebSocketClientTest {
                 """"cardDefinitions":[{"cardType":"BAKERY","cost":1,"income":1,"color":"GREEN",""" +
                 """"establishmentType":"BREAD","paymentSource":"BANK","activationNumbers":[2,3]}],""" +
                 """"landmarkDefinitions":[{"landmarkType":"TRAIN_STATION","cost":4}],""" +
-                """"turnOrder":[11,22]}}}"""
+                """"turnOrder":[1,2]}}}"""
     }
 
     private fun newClient(

--- a/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
@@ -174,6 +174,17 @@ class WebSocketClientTest {
         assertEquals(mapOf(CardType.WHEAT_FIELD to 0, CardType.BAKERY to 4), fixture.client.marketplace.value)
     }
 
+    @Test
+    fun syncUsesTurnOrderUserIdWhenPlayerDatabaseIdHasSameValue() {
+        val fixture = okHttpClientFixture()
+
+        fixture.deliverMessage(syncMessage(snapshot(includeActivePlayerId = false, firstPlayerId = 202)))
+
+        assertEquals(202, fixture.client.activePlayerId.value)
+        assertFalse(fixture.client.players.value.first { it.id == "202" }.isActivePlayer)
+        assertEquals(true, fixture.client.players.value.first { it.id == "22" }.isActivePlayer)
+    }
+
     private fun okHttpClientFixture(): OkHttpClientFixture {
         val factory = CapturingWebSocketFactory()
         val sessionHolder = object : SessionStateHolder {
@@ -281,7 +292,7 @@ class WebSocketClientTest {
             }
         """.trimIndent()
 
-    private fun syncMessage(): String =
+    private fun syncMessage(state: String = snapshot()): String =
         """
             {
               "type":"SYNC",
@@ -289,13 +300,19 @@ class WebSocketClientTest {
               "gameId":77,
               "payload":{
                 "targetUserId":101,
-                "state":${snapshot(status = "IN_PROGRESS", phase = "BUY_OR_BUILD")}
+                "state":$state
               }
             }
         """.trimIndent()
 
-    private fun snapshot(status: String, phase: String): String =
-        """
+    private fun snapshot(
+        status: String = "IN_PROGRESS",
+        phase: String = "BUY_OR_BUILD",
+        includeActivePlayerId: Boolean = true,
+        firstPlayerId: Int = 11,
+    ): String {
+        val activePlayerField = if (includeActivePlayerId) ",\n              \"activePlayerId\":202" else ""
+        return """
             {
               "game":{
                 "id":77,
@@ -310,7 +327,7 @@ class WebSocketClientTest {
                 "hasPurchasedThisTurn":false
               },
               "players":[
-                {"id":11,"gameId":77,"userId":101,"turnOrder":0,"coins":1,"lastSeenAt":null},
+                {"id":$firstPlayerId,"gameId":77,"userId":101,"turnOrder":0,"coins":1,"lastSeenAt":null},
                 {"id":22,"gameId":77,"userId":202,"turnOrder":1,"coins":4,"lastSeenAt":null}
               ],
               "playerCards":{
@@ -330,12 +347,12 @@ class WebSocketClientTest {
               "landmarkDefinitions":[
                 {"landmarkType":"TRAIN_STATION","cost":4}
               ],
-              "turnOrder":[101,202],
-              "activePlayerId":202,
+              "turnOrder":[101,202]$activePlayerField,
               "playerUsernames":{
                 "11":"Alice",
                 "22":"Bob"
               }
             }
         """.trimIndent()
+    }
 }

--- a/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
@@ -331,7 +331,7 @@ class WebSocketClientTest {
                 {"id":22,"gameId":77,"userId":202,"turnOrder":1,"coins":4,"lastSeenAt":null}
               ],
               "playerCards":{
-                "11":[{"playerId":11,"cardType":"WHEAT_FIELD","quantity":1}]
+                "$firstPlayerId":[{"playerId":$firstPlayerId,"cardType":"WHEAT_FIELD","quantity":1}]
               },
               "playerLandmarks":{
                 "22":[{"playerId":22,"landmarkType":"TRAIN_STATION","isBuilt":true}]
@@ -349,7 +349,7 @@ class WebSocketClientTest {
               ],
               "turnOrder":[101,202]$activePlayerField,
               "playerUsernames":{
-                "11":"Alice",
+                "$firstPlayerId":"Alice",
                 "22":"Bob"
               }
             }


### PR DESCRIPTION
### Summary

- Align reconnect active-player resolution with the backend GameStateDto contract.
- Treat turnOrder entries as user IDs when restoring state from SYNC.
- Prevent numeric collisions between database player IDs and user IDs from assigning active-player controls to the wrong user.
- Update reconnect test snapshots to use backend-compatible turnOrder values.
- Add regression coverage for the ID-collision scenario.

### Problem
During reconnect, the client restores the active player from a server snapshot. When activePlayerId is unavailable, the client falls back to turnOrder[currentTurnIndex].

The backend sends turnOrder as user IDs, but the client previously attempted to reinterpret the selected value as a possible database player ID and convert it again to a user ID.

This could produce the wrong active player when the two ID spaces contain the same numeric value.

### Example:

players:
  player id=202, userId=101
  player id=22,  userId=202

turnOrder: [101, 202]
currentTurnIndex: 1
The active user should be 202, but the previous fallback could match database player ID 202 and incorrectly resolve the active user as 101.

### Changes
Simplified resolveActiveUserId in OkHttpWebSocketClient:

- Use activePlayerId when supplied by the snapshot.
- Otherwise, return turnOrder[currentTurnIndex] directly as the active user ID.
- Removed legacy player-ID conversion logic that conflicts with the current server contract.
- Updated existing SYNC fixtures so turnOrder contains user IDs.
- Added a regression test verifying correct active-player restoration when a database player ID collides with another player's user ID.

### Result
After reconnect:

- The correct active player is restored from the server snapshot.
- Active-player UI controls remain restricted to the correct logged-in user.
- turnOrder handling matches the backend contract.


Related Issue
Closes #178