### PR TITLE
fix: Should trigger the debug endpoints now correctly

### DIFF
--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -55,7 +55,7 @@ class MainActivity : ComponentActivity() {
         AuthApiFactory.create(AppConfig.backendBaseUrl)
     }
     private val debugApi by lazy {
-        DebugApiFactory.create(AppConfig.backendBaseUrl)
+        DebugApiFactory.create(AppConfig.backendBaseUrl) { SessionManager.session.value?.sessionToken }
     }
     private val healthApi by lazy {
         HealthApiFactory.create(AppConfig.backendBaseUrl)

--- a/app/src/main/java/com/machikoro/client/network/debug/DebugApiFactory.kt
+++ b/app/src/main/java/com/machikoro/client/network/debug/DebugApiFactory.kt
@@ -3,22 +3,26 @@ package com.machikoro.client.network.debug
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import okhttp3.Request
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 
 object DebugApiFactory {
     private val json = Json { ignoreUnknownKeys = true }
 
+    // Exposed for testing — adds Bearer header when token is present
+    internal fun withAuth(request: Request, token: String?): Request =
+        if (token != null) {
+            request.newBuilder()
+                .header("Authorization", "Bearer $token")
+                .build()
+        } else request
+
     // Attach Bearer token so admin-protected debug endpoints are reachable
     fun create(baseUrl: String, tokenProvider: () -> String?): DebugApi {
         val httpClient = OkHttpClient.Builder()
             .addInterceptor { chain ->
-                val req = tokenProvider()?.let { token ->
-                    chain.request().newBuilder()
-                        .header("Authorization", "Bearer $token")
-                        .build()
-                } ?: chain.request()
-                chain.proceed(req)
+                chain.proceed(withAuth(chain.request(), tokenProvider()))
             }
             .build()
 

--- a/app/src/main/java/com/machikoro/client/network/debug/DebugApiFactory.kt
+++ b/app/src/main/java/com/machikoro/client/network/debug/DebugApiFactory.kt
@@ -2,16 +2,31 @@ package com.machikoro.client.network.debug
 
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 
 object DebugApiFactory {
     private val json = Json { ignoreUnknownKeys = true }
 
-    fun create(baseUrl: String): DebugApi =
-        Retrofit.Builder()
+    // Attach Bearer token so admin-protected debug endpoints are reachable
+    fun create(baseUrl: String, tokenProvider: () -> String?): DebugApi {
+        val httpClient = OkHttpClient.Builder()
+            .addInterceptor { chain ->
+                val req = tokenProvider()?.let { token ->
+                    chain.request().newBuilder()
+                        .header("Authorization", "Bearer $token")
+                        .build()
+                } ?: chain.request()
+                chain.proceed(req)
+            }
+            .build()
+
+        return Retrofit.Builder()
             .baseUrl(baseUrl)
+            .client(httpClient)
             .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()
             .create(DebugApi::class.java)
+    }
 }

--- a/app/src/test/java/com/machikoro/client/network/debug/DebugApiFactoryTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/debug/DebugApiFactoryTest.kt
@@ -1,9 +1,14 @@
 package com.machikoro.client.network.debug
 
+import okhttp3.Request
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class DebugApiFactoryTest {
+    private fun baseRequest(): Request = Request.Builder().url("http://localhost/").build()
+
     @Test
     fun createReturnsDebugApi() {
         val api = DebugApiFactory.create("http://localhost/") { null }
@@ -18,8 +23,37 @@ class DebugApiFactoryTest {
 
     @Test
     fun createWithTokenProviderSucceeds() {
-        // Token provider returning a value should not break construction
         val api = DebugApiFactory.create("http://localhost/") { "test-token" }
         assertNotNull(api)
+    }
+
+    @Test
+    fun withAuthAddsAuthorizationHeaderWhenTokenPresent() {
+        val result = DebugApiFactory.withAuth(baseRequest(), "my-token")
+        assertEquals("Bearer my-token", result.header("Authorization"))
+    }
+
+    @Test
+    fun withAuthReturnsOriginalRequestWhenTokenNull() {
+        val original = baseRequest()
+        val result = DebugApiFactory.withAuth(original, null)
+        // Same request returned — no header added
+        assertNull(result.header("Authorization"))
+        assertEquals(original, result)
+    }
+
+    @Test
+    fun withAuthDoesNotModifyOtherHeaders() {
+        val request = baseRequest().newBuilder().header("X-Custom", "value").build()
+        val result = DebugApiFactory.withAuth(request, "token")
+        assertEquals("value", result.header("X-Custom"))
+        assertEquals("Bearer token", result.header("Authorization"))
+    }
+
+    @Test
+    fun withAuthOverwritesExistingAuthorizationHeader() {
+        val request = baseRequest().newBuilder().header("Authorization", "Bearer old").build()
+        val result = DebugApiFactory.withAuth(request, "new-token")
+        assertEquals("Bearer new-token", result.header("Authorization"))
     }
 }

--- a/app/src/test/java/com/machikoro/client/network/debug/DebugApiFactoryTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/debug/DebugApiFactoryTest.kt
@@ -6,13 +6,20 @@ import org.junit.Test
 class DebugApiFactoryTest {
     @Test
     fun createReturnsDebugApi() {
-        val api = DebugApiFactory.create("http://localhost/")
+        val api = DebugApiFactory.create("http://localhost/") { null }
         assertNotNull(api)
     }
 
     @Test
     fun createWithTrailingSlashSucceeds() {
-        val api = DebugApiFactory.create("http://10.0.2.2:8080/")
+        val api = DebugApiFactory.create("http://10.0.2.2:8080/") { null }
+        assertNotNull(api)
+    }
+
+    @Test
+    fun createWithTokenProviderSucceeds() {
+        // Token provider returning a value should not break construction
+        val api = DebugApiFactory.create("http://localhost/") { "test-token" }
         assertNotNull(api)
     }
 }


### PR DESCRIPTION
Fixes the bug that the lobby cannot be filled with dummies.
SessionHeader is passed now