### PR TITLE
226 adjust leaving lobby to new outcome handling host leaving

### DIFF
--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -152,6 +152,17 @@ class MainActivity : ComponentActivity() {
             }
 
             LaunchedEffect(Unit) {
+                webSocketClient.hostLeftLobby.collect {
+                    navigationViewModel.leaveLobby()
+                    homeViewModel.clearLobbyCode()
+
+                    snackbarHostState.showSnackbar(
+                        "Lobby closed. Choose another one."
+                    )
+                }
+
+            }
+            LaunchedEffect(Unit) {
                 webSocketClient.lobbyJoinErrors.collect { message ->
                     Log.e("MainActivity", "Lobby join error received: $message")
                     homeViewModel.setJoinLobbyError(message)

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -60,6 +60,10 @@ class OkHttpWebSocketClient(
 
     override val lobbyJoinErrors: SharedFlow<String>
         get() = mutableLobbyJoinErrors.asSharedFlow()
+
+    override val hostLeftLobby: SharedFlow<Unit>
+        get() = mutableHostLeftLobby.asSharedFlow()
+
     override val winnerId: StateFlow<Int?>
         get() = mutableWinnerId.asStateFlow()
 
@@ -108,6 +112,11 @@ class OkHttpWebSocketClient(
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
     private val mutableLobbyJoinErrors = MutableSharedFlow<String>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    private val mutableHostLeftLobby = MutableSharedFlow<Unit>(
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -527,6 +527,7 @@ class OkHttpWebSocketClient(
                 handleLobbyCreated(json)
                 handleLobbyJoined(json)
                 handleLobbyLeft(json)
+                handleHostLeft(json)
                 handleLobbyRoster(json)
                 handleLobbyError(json)
                 handleGameStarted(json)
@@ -726,6 +727,19 @@ class OkHttpWebSocketClient(
         mutableGameStatus.value = GameStatus.FINISHED
         mutableGamePhase.value = GamePhase.NONE
         unsubscribeFromGameTopic(mutableActiveGameId.value)
+    }
+
+    private fun handleHostLeft(json: JSONObject) {
+        if (json.optString("type") != HOST_LEFT_TYPE) return
+
+        // Ignore if I am the host leaving intentionally
+        if (mutableIsLobbyHost.value) return
+
+        Log.d(TAG, "Host left lobby, lobby closed")
+
+        resetLobbyState()
+
+        mutableHostLeftLobby.tryEmit(Unit)
     }
 
     /**
@@ -1214,6 +1228,8 @@ class OkHttpWebSocketClient(
         private const val LOBBY_CREATED_TYPE = "LOBBY_CREATED"
         private const val LOBBY_JOINED_TYPE = "LOBBY_JOINED"
         private const val LOBBY_LEFT_TYPE = "LOBBY_LEFT"
+        private const val HOST_LEFT_TYPE = "HOST_LEFT"
+
         private const val LOBBY_ROSTER_TYPE = "LOBBY_ROSTER"
         private const val ERROR_TYPE = "ERROR"
         private const val PURCHASE_FAILED_EVENT = "PURCHASE_FAILED"

--- a/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
@@ -24,6 +24,7 @@ interface WebSocketClient {
     val lobbyEntered: SharedFlow<Unit>
     // Fires when joining a lobby fails, e.g. because the lobby code is invalid.
     val lobbyJoinErrors: SharedFlow<String>
+    val hostLeftLobby: SharedFlow<Unit>
     val activeGameId: StateFlow<Int?>
     val isLobbyHost: StateFlow<Boolean>
 

--- a/app/src/test/java/com/machikoro/client/network/websocket/FakeWebSocketClient.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/FakeWebSocketClient.kt
@@ -31,6 +31,8 @@ class FakeWebSocketClient : WebSocketClient {
 
     override val lobbyJoinErrors: SharedFlow<String>
         get() = mutableLobbyJoinErrors
+    override val hostLeftLobby: SharedFlow<Unit>
+        get() = mutableHostLeftLobby
 
     override val winnerId: StateFlow<Int?>
         get() = mutableWinnerId
@@ -76,6 +78,10 @@ class FakeWebSocketClient : WebSocketClient {
     private val mutablePlayers = MutableStateFlow<List<PlayerCoinState>>(emptyList())
     private val mutableLobbyCode = MutableStateFlow<String?>(null)
     private val mutableLobbyJoinErrors = MutableSharedFlow<String>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    private val mutableHostLeftLobby = MutableSharedFlow<Unit>(
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
@@ -265,6 +271,11 @@ class FakeWebSocketClient : WebSocketClient {
     fun emitLobbyCode(code: String?) {
         mutableLobbyCode.value = code
     }
+
+    fun emitHostLeftLobby() {
+        mutableHostLeftLobby.tryEmit(Unit)
+    }
+
     data class PurchaseCall(
         val gameId: Int,
         val purchaseType: PurchaseType,

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -1999,6 +1999,160 @@ class OkHttpWebSocketClientTest {
         assertEquals(1, client.players.value.size)
     }
 
+    // ── handleHostLeft ───────────────────────────────────────────────────────
+
+    @Test
+    fun hostLeftMessageResetsLobbyStateForNonHost() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+
+        // Join as regular player (NOT host)
+        factory.simulateText(
+            gameActionFrame(
+                """{
+                "type":"LOBBY_JOINED",
+                "payload":{
+                    "username":"alice",
+                    "playerId":1,
+                    "coins":3,
+                    "gameId":42
+                }
+            }"""
+            )
+        )
+
+        // Seed lobby state
+        factory.simulateText(
+            gameActionFrame(
+                """{
+                "type":"LOBBY_CREATED",
+                "payload":{
+                    "lobbyCode":"ABC123",
+                    "gameId":42
+                }
+            }"""
+            )
+        )
+
+        assertEquals("ABC123", client.lobbyCode.value)
+
+        factory.simulateText(
+            gameActionFrame(
+                """{
+                "type":"HOST_LEFT",
+                "payload":{
+                    "userId":123
+                }
+            }"""
+            )
+        )
+
+        assertNull(client.lobbyCode.value)
+        assertNull(client.activeGameId.value)
+        assertTrue(client.players.value.isEmpty())
+    }
+
+    @Test
+    fun hostLeftMessageEmitsEventForNonHost() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        val events = mutableListOf<Unit>()
+
+        client.hostLeftLobby
+            .onEach { events += it }
+            .launchIn(backgroundScope)
+
+        runCurrent()
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+
+        // Regular player, not host
+        factory.simulateText(
+            gameActionFrame(
+                """{
+                "type":"LOBBY_JOINED",
+                "payload":{
+                    "username":"alice",
+                    "playerId":1,
+                    "coins":3
+                }
+            }"""
+            )
+        )
+
+        assertFalse(client.isLobbyHost.value)
+
+        factory.simulateText(
+            gameActionFrame(
+                """{
+                "type":"HOST_LEFT",
+                "payload":{
+                    "userId":123
+                }
+            }"""
+            )
+        )
+
+        runCurrent()
+
+        assertEquals(1, events.size)
+    }
+
+    @Test
+    fun hostLeftMessageIgnoredForHost() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        val events = mutableListOf<Unit>()
+
+        client.hostLeftLobby
+            .onEach { events += it }
+            .launchIn(backgroundScope)
+
+        runCurrent()
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+
+        // Host creates lobby
+        client.sendCreateLobby()
+
+        factory.simulateText(
+            gameActionFrame(
+                """{
+                "type":"LOBBY_CREATED",
+                "payload":{
+                    "lobbyCode":"ABC123",
+                    "gameId":42
+                }
+            }"""
+            )
+        )
+
+        assertTrue(client.isLobbyHost.value)
+
+        factory.simulateText(
+            gameActionFrame(
+                """{
+                "type":"HOST_LEFT",
+                "payload":{
+                    "userId":123
+                }
+            }"""
+            )
+        )
+
+        runCurrent()
+
+        assertTrue(events.isEmpty())
+    }
+
     // ── handleLobbyJoined host branch + lobbyEntered ──────────────────────────
 
     @Test

--- a/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
@@ -52,6 +52,11 @@ class DummyWebSocketClient : WebSocketClient {
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
+    override val hostLeftLobby: SharedFlow<Unit> = MutableSharedFlow(
+            extraBufferCapacity = 1,
+            onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
     override val lobbyEntered: SharedFlow<Unit> = MutableSharedFlow()
     override fun connect() {}
     override fun disconnect() {}

--- a/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
@@ -188,7 +188,10 @@ class HomeScreenViewModelTest {
             extraBufferCapacity = 1,
             onBufferOverflow = BufferOverflow.DROP_OLDEST,
         )
-
+        override val hostLeftLobby: SharedFlow<Unit> = MutableSharedFlow(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+        )
         var connectCalled = false
         var disconnectCalled = false
         var sendGameStartCalled = false


### PR DESCRIPTION
This PR adjusts host lobby leaving and lobby closing. Upon receiving HOST_LEFT broadcast, lobby is closed for all players and shows corresponding snackbar.