### PR TITLE
Fix gradle version catalog deps

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,8 +103,8 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.test.manifest)
 
     // Mockito for unit tests
-    testImplementation("org.mockito:mockito-core:5.2.0")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:4.1.0")
+    testImplementation(libs.mockito.core)
+    testImplementation(libs.mockito.kotlin)
 }
 
 tasks.register<JacocoReport>("jacocoTestReport") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,8 @@ navigation = "2.9.8"
 foundationLayout = "1.11.2"
 foundation = "1.11.2"
 sonarqube = "7.3.0.8198"
+mockitoCore = "5.2.0"
+mockitoKotlin = "4.1.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -50,6 +52,8 @@ androidx-datastore-preferences-core = { group = "androidx.datastore", name = "da
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation" }
 androidx-compose-foundation-layout = { group = "androidx.compose.foundation", name = "foundation-layout", version.ref = "foundationLayout" }
 androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "foundation" }
+mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockitoCore" }
+mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockitoKotlin" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Added Mockito dependency versions to `gradle/libs.versions.toml`
- Added version catalog aliases for `mockito-core` and `mockito-kotlin`
- Replaced hardcoded Mockito dependency coordinates in `app/build.gradle.kts`

## Why
Sonar reported hardcoded version numbers in the Gradle dependency declarations. Moving these dependencies to the version catalog keeps dependency versions centralized and consistent with the rest of the project.

## Testing
- `./gradlew testDebugUnitTest`

Result: `BUILD SUCCESSFUL`