### PR TITLE
Feat 119 dynamic host start button

### DIFF
--- a/app/src/androidTest/java/com/machikoro/client/ui/game/GameScreenSnapshotTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/game/GameScreenSnapshotTest.kt
@@ -1,5 +1,8 @@
 package com.machikoro.client.ui.game
 
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
@@ -10,6 +13,7 @@ import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.enums.LandmarkType
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.GameScreenState
+import com.machikoro.client.domain.model.state.PlayerCardState
 import com.machikoro.client.domain.model.state.PlayerCoinState
 import com.machikoro.client.domain.model.state.PlayerLandmarkState
 import com.machikoro.client.domain.model.state.PurchaseState
@@ -46,6 +50,12 @@ class GameScreenSnapshotTest {
                 PlayerLandmarkState(LandmarkType.RADIO_TOWER, isBuilt = false),
             )
         ),
+        playerCards = mapOf(
+            1 to listOf(
+                PlayerCardState(CardType.WHEAT_FIELD, quantity = 1),
+                PlayerCardState(CardType.BAKERY, quantity = 2),
+            )
+        ),
         marketplace = mapOf(CardType.WHEAT_FIELD to 6, CardType.BAKERY to 5),
         gameId = 1,
         purchaseState = PurchaseState.IDLE,
@@ -73,6 +83,34 @@ class GameScreenSnapshotTest {
 
         composeTestRule.onNodeWithContentDescription("Train Station: built").assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription("Amusement Park: not built").assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersOwnedPlayerCardsFromSnapshot() {
+        composeTestRule.setContent { ClientTheme { GameScreen(state = reconnectState()) } }
+
+        composeTestRule.onNodeWithContentDescription("Owned by You: Wheat Field, 1 card").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Owned by You: Bakery, 2 cards").assertIsDisplayed()
+    }
+
+    @Test
+    fun updatesOwnedPlayerCardsWhenSnapshotChanges() {
+        var state by mutableStateOf(reconnectState())
+        composeTestRule.setContent { ClientTheme { GameScreen(state = state) } }
+
+        composeTestRule.runOnIdle {
+            state = state.copy(
+                playerCards = mapOf(
+                    1 to listOf(
+                        PlayerCardState(CardType.WHEAT_FIELD, quantity = 3),
+                        PlayerCardState(CardType.CAFE, quantity = 1),
+                    )
+                )
+            )
+        }
+
+        composeTestRule.onNodeWithContentDescription("Owned by You: Wheat Field, 3 cards").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Owned by You: Cafe, 1 card").assertIsDisplayed()
     }
 
     @Test

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -1322,8 +1322,6 @@ class OkHttpWebSocketClient(
         // StompAuthChannelInterceptor. If the server message changes, this
         // client will silently fall through to the generic ERROR handling.
         private const val AUTH_REJECTION_BODY = "Authentication failed"
-        private const val GAME_START_BODY =
-            """{"type":"START","sender":"${WebSocketContract.defaultSender}"}"""
 
         private fun purchaseBody(
             gameId: Int,

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -148,6 +148,8 @@ class OkHttpWebSocketClient(
     @Volatile
     private var webSocket: WebSocket? = null
     private var subscribedGameId: Int? = null
+    @Volatile
+    private var pendingCreatedLobbyJoin = false
     // STOMP session ID assigned by the server on CONNECTED — used for lobby queue subscription
     private var stompSessionId: String? = null
 
@@ -230,7 +232,7 @@ class OkHttpWebSocketClient(
         )
 
         if (sent) {
-            mutableIsLobbyHost.value = true
+            pendingCreatedLobbyJoin = true
             Log.d(TAG, "Lobby create message sent")
         } else {
             Log.w(TAG, "sendCreateLobby: failed to send create-lobby frame")
@@ -571,6 +573,8 @@ class OkHttpWebSocketClient(
         val code = payload.optString("lobbyCode")
         val gameId = json.optIntOrNull("gameId") ?: payload.optIntOrNull("gameId")
 
+        updateLobbyHostOwnership(resolveHostUserId(json, payload, payload.optJSONObject("game")))
+
         if (code.isNotBlank()) {
             Log.d(TAG, "Lobby created with code: $code")
             mutableLobbyCode.value = code
@@ -592,7 +596,8 @@ class OkHttpWebSocketClient(
             }
         }
         // Host must join their own lobby to become a player in the roster
-        if (mutableIsLobbyHost.value && code.isNotBlank()) {
+        if (pendingCreatedLobbyJoin && code.isNotBlank()) {
+            pendingCreatedLobbyJoin = false
             sendJoinLobby(code)
         }
     }
@@ -605,6 +610,8 @@ class OkHttpWebSocketClient(
 
         val payload = json.optJSONObject("payload") ?: return
         val gameId = json.optIntOrNull("gameId") ?: payload.optIntOrNull("gameId")
+
+        updateLobbyHostOwnership(resolveHostUserId(json, payload, payload.optJSONObject("game")))
 
         if (gameId != null) {
             Log.d(TAG, "Joined lobby with gameId: $gameId")
@@ -655,6 +662,10 @@ class OkHttpWebSocketClient(
         val payload = json.optJSONObject("payload") ?: return
         val players = payload.optJSONArray("players") ?: return
         val gameId = json.optIntOrNull("gameId") ?: payload.optIntOrNull("gameId")
+        updateLobbyHostOwnership(
+            resolveHostUserId(json, payload, payload.optJSONObject("game"))
+                ?: resolveHostUserIdFromRoster(players)
+        )
         if (gameId != null) {
             mutableActiveGameId.value = gameId
             subscribeToGameTopic(gameId)
@@ -777,6 +788,8 @@ class OkHttpWebSocketClient(
         game.optString("lobbyCode")
             .takeIf { it.isNotBlank() }
             ?.let { mutableLobbyCode.value = it }
+
+        updateLobbyHostOwnership(resolveHostUserId(state, game))
 
         parseGameStatus(game.optString("status"))?.let { mutableGameStatus.value = it }
         parseTurnPhase(game.optString("turnPhase"))?.let { mutableGamePhase.value = it }
@@ -1197,6 +1210,7 @@ class OkHttpWebSocketClient(
         mutableActiveGameId.value = null
         mutableIsLobbyHost.value = false
         mutablePlayers.value = emptyList()
+        pendingCreatedLobbyJoin = false
     }
 
     private fun parseTurnPhase(phaseName: String): GamePhase? =
@@ -1238,6 +1252,30 @@ class OkHttpWebSocketClient(
     private fun JSONObject.optIntOrNull(key: String): Int? =
         if (has(key) && !isNull(key)) optInt(key) else null
 
+    private fun updateLobbyHostOwnership(hostUserId: Int?) {
+        if (hostUserId == null) return
+        mutableIsLobbyHost.value = sessionStateHolder.session.value?.userId == hostUserId
+    }
+
+    private fun resolveHostUserId(vararg sources: JSONObject?): Int? =
+        sources.firstNotNullOfOrNull { source ->
+            source?.hostUserId()
+        }
+
+    private fun JSONObject.hostUserId(): Int? =
+        HOST_USER_ID_KEYS.firstNotNullOfOrNull { key -> optIntOrNull(key) }
+
+    private fun resolveHostUserIdFromRoster(players: JSONArray): Int? =
+        (0 until players.length()).firstNotNullOfOrNull { index ->
+            val entry = players.optJSONObject(index) ?: return@firstNotNullOfOrNull null
+            if (!entry.optBoolean("isHost", false) && !entry.optBoolean("host", false)) {
+                return@firstNotNullOfOrNull null
+            }
+            entry.optIntOrNull("userId")
+                ?: entry.optIntOrNull("user_id")
+                ?: entry.optIntOrNull("id")
+        }
+
     private fun websocketHostHeader(): String {
         val uri = URI(websocketUrl)
         val port = uri.port
@@ -1273,6 +1311,13 @@ class OkHttpWebSocketClient(
         private const val PURCHASE_FAILED_EVENT = "PURCHASE_FAILED"
         private const val ROLL_DICE_TYPE = "ROLL_DICE"
         private const val SYNC_TYPE = "SYNC"
+        private val HOST_USER_ID_KEYS = listOf(
+            "hostId",
+            "host_id",
+            "hostUserId",
+            "host_user_id",
+            "hostUserID",
+        )
         // Frozen contract: matches GENERIC_AUTH_FAILURE on the server's
         // StompAuthChannelInterceptor. If the server message changes, this
         // client will silently fall through to the generic ERROR handling.

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -148,6 +148,7 @@ fun GameScreen(
                     PlayersTopBar(
                         players = state.players,
                         playerLandmarks = state.playerLandmarks,
+                        playerCards = state.playerCards,
                         modifier = Modifier.align(Alignment.Center)
                     )
 

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/PlayersTopBar.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/PlayersTopBar.kt
@@ -1,16 +1,21 @@
 package com.machikoro.client.ui.game.ui
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
@@ -19,13 +24,18 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.machikoro.client.domain.enums.CardType
 import com.machikoro.client.domain.enums.LandmarkType
+import com.machikoro.client.domain.model.state.PlayerCardState
 import com.machikoro.client.domain.model.state.PlayerCoinState
 import com.machikoro.client.domain.model.state.PlayerLandmarkState
 import com.machikoro.client.domain.model.state.toDisplayText
@@ -36,6 +46,7 @@ import kotlin.collections.get
 fun PlayersTopBar(
     players: List<PlayerCoinState>,
     playerLandmarks: Map<Int, List<PlayerLandmarkState>>,
+    playerCards: Map<Int, List<PlayerCardState>>,
     modifier: Modifier = Modifier
 ) {
     if (players.isEmpty()) return
@@ -44,9 +55,11 @@ fun PlayersTopBar(
         verticalAlignment = Alignment.Top
     ) {
         items(items = players, key = { it.id }) { player ->
+            val playerSnapshotId = player.id.toIntOrNull()
             PlayerCoinBadge(
                 player = player,
-                landmarks = playerLandmarks[player.id.toIntOrNull()].orEmpty(),
+                landmarks = playerLandmarks[playerSnapshotId].orEmpty(),
+                cards = playerCards[playerSnapshotId].orEmpty(),
                 modifier = Modifier.padding(end = 8.dp)
             )
         }
@@ -56,6 +69,7 @@ fun PlayersTopBar(
 private fun PlayerCoinBadge(
     player: PlayerCoinState,
     landmarks: List<PlayerLandmarkState>,
+    cards: List<PlayerCardState>,
     modifier: Modifier = Modifier
 ) {
     val containerColor = when {
@@ -74,21 +88,29 @@ private fun PlayerCoinBadge(
         shape = RoundedCornerShape(8.dp),
         tonalElevation = 3.dp,
         modifier = modifier
-            .widthIn(min = 118.dp, max = 180.dp)
+            .widthIn(min = 138.dp, max = 232.dp)
             .semantics { contentDescription = "${player.displayName}: ${player.coins} coins" }
     ) {
         Column(modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
-                CoinIcon(player.coins,
-                    modifier = Modifier.padding(end = 8.dp))
+                CoinIcon(
+                    amount = player.coins,
+                    modifier = Modifier.padding(end = 8.dp)
+                )
 
-                    Text(
-                        text = player.displayName,
-                        style = MaterialTheme.typography.bodyMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        maxLines = 1
-                    )
-
+                Text(
+                    text = player.displayName,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1
+                )
+            }
+            if (cards.hasVisibleCards()) {
+                OwnedCardRow(
+                    playerName = player.displayName,
+                    cards = cards,
+                    modifier = Modifier.padding(top = 6.dp)
+                )
             }
             if (landmarks.isNotEmpty()) {
                 LandmarkRow(
@@ -98,6 +120,75 @@ private fun PlayerCoinBadge(
             }
         }
     }
+}
+
+@Composable
+private fun OwnedCardRow(
+    playerName: String,
+    cards: List<PlayerCardState>,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.horizontalScroll(rememberScrollState()),
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        cards.visibleInDisplayOrder().forEach { card ->
+            OwnedCardChip(
+                playerName = playerName,
+                card = card
+            )
+        }
+    }
+}
+
+@Composable
+private fun OwnedCardChip(
+    playerName: String,
+    card: PlayerCardState
+) {
+    val cardName = card.cardType.toDisplayText()
+    val cardUnit = if (card.quantity == 1) "card" else "cards"
+    Surface(
+        color = MaterialTheme.colorScheme.surface,
+        contentColor = MaterialTheme.colorScheme.onSurface,
+        shape = RoundedCornerShape(6.dp),
+        tonalElevation = 1.dp,
+        modifier = Modifier
+            .widthIn(min = 58.dp, max = 72.dp)
+            .border(1.dp, MaterialTheme.colorScheme.outline, RoundedCornerShape(6.dp))
+            .semantics {
+                contentDescription = "Owned by $playerName: $cardName, ${card.quantity} $cardUnit"
+            }
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(4.dp)
+        ) {
+            Image(
+                painter = painterResource(ShopImageResolver.drawableForCardType(card.cardType)),
+                contentDescription = null,
+                contentScale = ContentScale.Crop,
+                modifier = Modifier
+                    .height(34.dp)
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(4.dp))
+            )
+            Text(
+                text = "x${card.quantity}",
+                style = MaterialTheme.typography.labelLarge,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+private fun List<PlayerCardState>.hasVisibleCards(): Boolean =
+    any { it.quantity > 0 }
+
+private fun List<PlayerCardState>.visibleInDisplayOrder(): List<PlayerCardState> {
+    val cardsByType = filter { it.quantity > 0 }.associateBy { it.cardType }
+    return CardType.entries.mapNotNull { cardsByType[it] }
 }
 
 /**

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/ShopImageResolver.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/ShopImageResolver.kt
@@ -1,6 +1,7 @@
 package com.machikoro.client.ui.game.ui
 
 import com.machikoro.client.R
+import com.machikoro.client.domain.enums.CardType
 import com.machikoro.client.domain.enums.PurchaseType
 import com.machikoro.client.domain.model.shop.ShopItem
 
@@ -48,4 +49,7 @@ internal object ShopImageResolver {
                 item.imageKey
             }
         )
+
+    fun drawableForCardType(cardType: CardType): Int =
+        drawableFor("card_${cardType.name.lowercase()}")
 }

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -673,7 +673,7 @@ class OkHttpWebSocketClientTest {
         client.connect()
         factory.simulateOpen()
         factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
-        factory.simulateText(gameStartedFrame(gameId = 7, activePlayerId = 1))
+        factory.simulateText(gameStartedFrame(gameId = 7))
         client.rollDice(diceCount = 1)
         assertTrue(factory.socket.sentMessages.any {
             it.startsWith("SEND\n") &&
@@ -690,7 +690,7 @@ class OkHttpWebSocketClientTest {
         client.connect()
         factory.simulateOpen()
         factory.simulateText(connectedFrame())
-        factory.simulateText(gameStartedFrame(gameId = 7, activePlayerId = 1))
+        factory.simulateText(gameStartedFrame(gameId = 7))
 
         client.rollDice(diceCount = 2)
 
@@ -1109,7 +1109,7 @@ class OkHttpWebSocketClientTest {
         client.connect()
         factory.simulateOpen()
         factory.simulateText("CONNECTED\nversion:1.2\n\n\u0000")
-        factory.simulateText(gameStartedFrame(gameId = 7, activePlayerId = 1))
+        factory.simulateText(gameStartedFrame(gameId = 7))
         client.rollDice(diceCount = 2)
         assertTrue(factory.socket.sentMessages.any { it.contains("\"diceCount\":2") })
     }
@@ -1217,9 +1217,7 @@ class OkHttpWebSocketClientTest {
         runCurrent()
         assertEquals(null, client.lobbyCode.value)
     }
-    private fun authRejectionErrorFrame(): String =
-        "ERROR\nmessage:Authentication failed\n\nAuthentication failed\u0000"
-  
+
     // ── handleLobbyCreated — host auto-add ───────────────────────────────────
 
     @Test
@@ -1951,7 +1949,7 @@ class OkHttpWebSocketClientTest {
         assertTrue(factory.socket.sentMessages.any { it.contains("destination:/queue/lobby-usersess-1") })
 
         // Disconnect clears session ID; reconnect with new session gets new subscription
-        factory.simulateFailure(java.io.IOException("drop"))
+        factory.simulateFailure(IOException("drop"))
         runCurrent()
         factory.simulateOpen()
         factory.socket.sentMessages.clear()
@@ -2318,7 +2316,7 @@ class OkHttpWebSocketClientTest {
         client.connect()
         factory.simulateOpen()
         factory.simulateText(connectedFrame())
-        factory.simulateText(gameStartedFrame(gameId = 42, activePlayerId = 1))
+        factory.simulateText(gameStartedFrame(gameId = 42))
         assertEquals(42, client.activeGameId.value)
         assertTrue(client.lobbyCode.value != null)
         client.sendGameStart()
@@ -2615,9 +2613,9 @@ class OkHttpWebSocketClientTest {
     private fun gameActionFrame(body: String): String =
         "MESSAGE\ndestination:/topic/public\ncontent-type:application/json\n\n$body\u0000"
 
-    private fun gameStartedFrame(gameId: Int, activePlayerId: Int): String =
+    private fun gameStartedFrame(gameId: Int): String =
         gameActionFrame(
-            """{"type":"GAME_STARTED","gameId":$gameId,"payload":{"activePlayerId":$activePlayerId,"game":{"id":$gameId,"lobbyCode":"ABC1234","turnPhase":"ROLL_DICE"},"players":[]}}"""
+            """{"type":"GAME_STARTED","gameId":$gameId,"payload":{"activePlayerId":1,"game":{"id":$gameId,"lobbyCode":"ABC1234","turnPhase":"ROLL_DICE"},"players":[]}}"""
         )
 
     private fun FakeWebSocket.rollDiceFrames(): List<StompFrame> =

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -425,6 +425,20 @@ class OkHttpWebSocketClientTest {
     }
 
     @Test
+    fun sendCreateLobbyDoesNotSetHostFlagBeforeServerHostIdArrives() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+
+        client.sendCreateLobby()
+
+        assertFalse(client.isLobbyHost.value)
+    }
+
+    @Test
     fun sendCreateLobbyWithoutConnectionIsIgnored() {
         val factory = FakeWebSocketFactory()
         val client = newClient(factory)
@@ -1285,13 +1299,47 @@ class OkHttpWebSocketClientTest {
     }
 
     @Test
-    fun lobbyCreatedTriggersAutoJoinWhenIsLobbyHost() {
+    fun lobbyCreatedSetsHostFlagWhenHostIdMatchesCurrentUser() {
         val factory = FakeWebSocketFactory()
         val client = newClient(factory)
         client.connect()
         factory.simulateOpen()
         factory.simulateText(connectedFrame())
-        client.sendCreateLobby() // sets isLobbyHost = true
+
+        factory.simulateText(
+            gameActionFrame(
+                """{"type":"LOBBY_CREATED","sender":"SERVER","payload":{"lobbyCode":"ABC123","hostId":$DEFAULT_USER_ID}}"""
+            )
+        )
+
+        assertTrue(client.isLobbyHost.value)
+    }
+
+    @Test
+    fun lobbyCreatedKeepsHostFlagFalseWhenHostIdDoesNotMatchCurrentUser() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+
+        factory.simulateText(
+            gameActionFrame(
+                """{"type":"LOBBY_CREATED","sender":"SERVER","payload":{"lobbyCode":"ABC123","host_id":999}}"""
+            )
+        )
+
+        assertFalse(client.isLobbyHost.value)
+    }
+
+    @Test
+    fun lobbyCreatedTriggersAutoJoinAfterCreateRequest() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        client.sendCreateLobby()
         factory.simulateText(
             gameActionFrame(
                 """{"type":"LOBBY_CREATED","sender":"SERVER","payload":{"lobbyCode":"ABC123"}}"""
@@ -1789,6 +1837,52 @@ class OkHttpWebSocketClientTest {
     }
 
     @Test
+    fun lobbyRosterSetsHostFlagWhenHostIdMatchesCurrentUser() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n ")
+
+        val rosterJson = """{"type":"LOBBY_ROSTER","sender":"SERVER","gameId":1,"payload":{"hostId":$DEFAULT_USER_ID,"players":[{"playerId":5,"userId":$DEFAULT_USER_ID,"username":"Alice","coins":3}]}}"""
+        factory.simulateText("MESSAGE\ndestination:/queue/lobby-user1\ncontent-type:application/json\n\n$rosterJson ")
+
+        assertTrue(client.isLobbyHost.value)
+    }
+
+    @Test
+    fun lobbyRosterUpdatesHostFlagWhenHostChanges() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n ")
+
+        val hostRoster = """{"type":"LOBBY_ROSTER","sender":"SERVER","gameId":1,"payload":{"host_id":$DEFAULT_USER_ID,"players":[{"playerId":5,"userId":$DEFAULT_USER_ID,"username":"Alice","coins":3},{"playerId":6,"userId":2,"username":"Bob","coins":3}]}}"""
+        factory.simulateText("MESSAGE\ndestination:/queue/lobby-user1\ncontent-type:application/json\n\n$hostRoster ")
+        assertTrue(client.isLobbyHost.value)
+
+        val guestRoster = """{"type":"LOBBY_ROSTER","sender":"SERVER","gameId":1,"payload":{"host_id":2,"players":[{"playerId":5,"userId":$DEFAULT_USER_ID,"username":"Alice","coins":3},{"playerId":6,"userId":2,"username":"Bob","coins":3}]}}"""
+        factory.simulateText("MESSAGE\ndestination:/queue/lobby-user1\ncontent-type:application/json\n\n$guestRoster ")
+
+        assertFalse(client.isLobbyHost.value)
+    }
+
+    @Test
+    fun lobbyRosterCanResolveHostFromHostPlayerEntryWhenNoHostIdFieldExists() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n ")
+
+        val rosterJson = """{"type":"LOBBY_ROSTER","sender":"SERVER","gameId":1,"payload":{"players":[{"playerId":5,"userId":$DEFAULT_USER_ID,"username":"Alice","coins":3,"isHost":true},{"playerId":6,"userId":2,"username":"Bob","coins":3}]}}"""
+        factory.simulateText("MESSAGE\ndestination:/queue/lobby-user1\ncontent-type:application/json\n\n$rosterJson ")
+
+        assertTrue(client.isLobbyHost.value)
+    }
+
+    @Test
     fun lobbyRosterWithEmptyArrayClearsPlayerList() {
         val factory = FakeWebSocketFactory()
         val client = newClient(factory)
@@ -2129,6 +2223,7 @@ class OkHttpWebSocketClientTest {
                 "type":"LOBBY_CREATED",
                 "payload":{
                     "lobbyCode":"ABC123",
+                    "hostId":$DEFAULT_USER_ID,
                     "gameId":42
                 }
             }"""
@@ -2162,11 +2257,10 @@ class OkHttpWebSocketClientTest {
         client.connect()
         factory.simulateOpen()
         factory.simulateText(connectedFrame())
-        client.sendCreateLobby() // sets isLobbyHost = true
         factory.socket.sentMessages.clear()
         factory.simulateText(
             gameActionFrame(
-                """{"type":"LOBBY_JOINED","gameId":10,"payload":{"username":"alice","playerId":1,"coins":3,"gameId":10}}"""
+                """{"type":"LOBBY_JOINED","gameId":10,"payload":{"username":"alice","playerId":1,"coins":3,"gameId":10,"hostId":$DEFAULT_USER_ID}}"""
             )
         )
         assertTrue(


### PR DESCRIPTION
Summary
Derive lobby host ownership from backend-provided host identifiers instead of setting isLobbyHost optimistically when creating a lobby.
Preserve the existing create-lobby auto-join handshake with a private pending-create flag that is independent from host authorization state.
Update host ownership reactively from lobby creation, lobby join, lobby roster, and game snapshot payloads.
Issue
Closes #119

Implementation Notes
sendCreateLobby() no longer marks the local user as host before server confirmation.
isLobbyHost is updated by comparing the current session userId with server host fields such as hostId, host_id, hostUserId, and host_user_id.
LOBBY_ROSTER can also resolve host ownership from roster entries marked with isHost or host.
The host flag is reset with lobby state cleanup to avoid leaking stale permissions across lobbies.
Verification
./gradlew testDebugUnitTest
Dependency Context
This frontend behavior expects the server to broadcast host ownership data in lobby state payloads, as described by the paired server work for host ID broadcast support.