### PR TITLE
Fix: Ready Sync in LobbyScreen

### DIFF
--- a/app/src/main/java/com/machikoro/client/domain/model/state/LobbyScreenState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/LobbyScreenState.kt
@@ -3,9 +3,11 @@ package com.machikoro.client.domain.model.state
 data class LobbyScreenState(
     val connectionStatus: ConnectionStatus,
     val lobbyStatus: LobbyStatus,
-    val playerList: List<String> = emptyList(),
+    val playerList: List<PlayerCoinState> = emptyList(),
     // TODO: Replace hardcoded maxPlayers once server provides lobby configuration.
-    val maxPlayers: Int = 4,    val isHost: Boolean = false,
+    val maxPlayers: Int = 4,
+    val isHost: Boolean = false,
+    // Mirrors the local player's ready state from the server roster
     val isReady: Boolean = false,
     val loggedInAs: String? = null,
 ) {

--- a/app/src/main/java/com/machikoro/client/domain/model/state/PlayerCoinState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/PlayerCoinState.kt
@@ -5,5 +5,6 @@ data class PlayerCoinState(
     val displayName: String,
     val coins: Int,
     val isCurrentPlayer: Boolean = false,
-    val isActivePlayer: Boolean = false
+    val isActivePlayer: Boolean = false,
+    val isReady: Boolean = false,
 )

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -278,6 +278,39 @@ class OkHttpWebSocketClient(
         }
     }
 
+    override fun sendReadyToggle(isReady: Boolean) {
+        val socket = synchronized(this) { webSocket }
+        if (socket == null) {
+            Log.w(TAG, "sendReadyToggle called but no active WebSocket connection")
+            return
+        }
+        val gameId = mutableActiveGameId.value
+        if (gameId == null) {
+            Log.w(TAG, "sendReadyToggle: no active game, dropping toggle")
+            return
+        }
+        val body = JSONObject()
+            .put("type", "LOBBY_ROSTER")
+            .put("sender", WebSocketContract.defaultSender)
+            .put("payload", JSONObject()
+                .put("gameId", gameId)
+                .put("isReady", isReady)
+            )
+            .toString()
+        val sent = socket.send(
+            StompFrame(
+                command = "SEND",
+                headers = mapOf(
+                    "destination" to WebSocketContract.readyToggleDestination,
+                    "content-type" to "application/json"
+                ),
+                body = body
+            ).serialize()
+        )
+        if (sent) Log.d(TAG, "Ready toggle sent: isReady=$isReady, gameId=$gameId")
+        else Log.w(TAG, "sendReadyToggle: failed to send frame")
+    }
+
     override fun sendLeaveLobby(gameId: Int) {
         val socket = synchronized(this) { webSocket }
         if (socket == null) {
@@ -677,6 +710,7 @@ class OkHttpWebSocketClient(
                 id = playerId,
                 displayName = username,
                 coins = entry.optInt("coins", 3),
+                isReady = entry.optBoolean("isReady", false),
             )
         }
         Log.d(TAG, "Lobby roster received: ${mutablePlayers.value.size} players, gameId=$gameId")

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -660,7 +660,8 @@ class OkHttpWebSocketClient(
         // Try both "playerId" and "id" since the server may use either field name
         val playerId = (payload.optIntOrNull("playerId") ?: payload.optIntOrNull("id"))?.toString() ?: return
         val coins = payload.optInt("coins", 3)
-        val newPlayer = PlayerCoinState(id = playerId, displayName = username, coins = coins)
+        val isReady = payload.optBoolean("isReady", false)
+        val newPlayer = PlayerCoinState(id = playerId, displayName = username, coins = coins, isReady = isReady)
         // Replace any existing entry with same id or name (e.g., temp host entry) then add
         mutablePlayers.value = mutablePlayers.value
             .filter { it.id != playerId && it.displayName != username } + newPlayer

--- a/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
@@ -61,6 +61,7 @@ interface WebSocketClient {
     fun sendCreateLobby()
     fun sendJoinLobby(lobbyCode: String)     // Sends a request to join an existing lobby by lobby code.
     fun sendLeaveLobby(gameId: Int)          // Notifies the server that this player is leaving the lobby.
+    fun sendReadyToggle(isReady: Boolean)    // Notifies the server of this player's ready state.
     fun clearLobbyCode()
     fun clearGameState()
     fun sendGameStart()

--- a/app/src/main/java/com/machikoro/client/network/websocket/WebSocketContract.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WebSocketContract.kt
@@ -18,6 +18,7 @@ object WebSocketContract {
     const val createLobbyDestination: String = "/app/lobby.create"
     const val joinLobbyDestination = "/app/lobby.join"
     const val leaveLobbyDestination = "/app/lobby.leave"
+    const val readyToggleDestination: String = "/app/lobby.ready"
     const val gameStartDestination: String = "/app/game.start"
     // Server PR #216 exposes PurchaseRequest at @MessageMapping("/game.purchase").
     const val purchaseDestination: String = "/app/game.purchase"

--- a/app/src/main/java/com/machikoro/client/ui/lobby/LobbyScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/lobby/LobbyScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.machikoro.client.R
 import com.machikoro.client.domain.model.state.LobbyScreenState
+import com.machikoro.client.domain.model.state.PlayerCoinState
 import com.machikoro.client.ui.theme.ButtonBeigeLight
 import com.machikoro.client.ui.theme.ButtonBlueDark
 import com.machikoro.client.ui.theme.ClientTheme
@@ -58,11 +59,11 @@ fun LobbyScreen(
     @SuppressLint("ModifierParameter") modifier: Modifier = Modifier
 ) {
     LobbyScreen(
-        playerNames = state.playerList,
+        players = state.playerList,
         maxPlayers = state.maxPlayers,
         currentUsername = state.loggedInAs,
-        // TODO: Replace first-player-as-host fallback once backend exposes host information.
-        hostUsername = state.playerList.firstOrNull(),
+        // First player in roster has lowest turnOrder, which is the host
+        hostUsername = state.playerList.firstOrNull()?.displayName,
         isHost = state.isHost,
         isReady = state.isReady,
         lobbyCode = lobbyCode,
@@ -77,7 +78,7 @@ fun LobbyScreen(
 
 @Composable
 fun LobbyScreen(
-    playerNames: List<String>,
+    players: List<PlayerCoinState>,
     maxPlayers: Int = 4,
     currentUsername: String? = null,
     hostUsername: String? = null,
@@ -89,9 +90,9 @@ fun LobbyScreen(
     onLeaveLobby: () -> Unit = {},
     onFillWithDummies: () -> Unit = {},
     onResetLobby: () -> Unit = {},
-    modifier: Modifier = Modifier
+    @SuppressLint("ModifierParameter") modifier: Modifier = Modifier
 ) {
-    val startEnabled = isHost && playerNames.size >= 2 && isReady
+    val startEnabled = isHost && players.size >= 2 && isReady
 
     Box(
         modifier = modifier
@@ -163,7 +164,8 @@ fun LobbyScreen(
             Spacer(modifier = Modifier.height(5.dp))
 
             repeat(maxPlayers) { index ->
-                val name = playerNames.getOrNull(index)
+                val player = players.getOrNull(index)
+                val name = player?.displayName
                 val isCurrentUser = name != null && name == currentUsername
                 val isHostPlayer = name != null && name == hostUsername
 
@@ -180,11 +182,11 @@ fun LobbyScreen(
                         isHost = isHostPlayer
                     )
 
-                    // TODO: Replace placeholder ready state once backend exposes readiness per player.
+                    // Ready state comes from the server roster per player
                     val statusText = when {
-                        name == null -> ""
-                        isCurrentUser && !isReady -> "not ready"
-                        else -> "ready"
+                        player == null -> ""
+                        player.isReady -> "ready"
+                        else -> "not ready"
                     }
 
                     StatusSlot(text = statusText)
@@ -209,7 +211,7 @@ fun LobbyScreen(
             }
 
             // Debug helper: fill remaining slots so the host can start without real players
-            if (isHost && playerNames.size < maxPlayers) {
+            if (isHost && players.size < maxPlayers) {
                 Spacer(modifier = Modifier.height(8.dp))
                 Button(
                     onClick = onFillWithDummies,
@@ -224,7 +226,7 @@ fun LobbyScreen(
             }
 
             // Debug helper: remove all non-host players so the host can start fresh
-            if (isHost && playerNames.size > 1) {
+            if (isHost && players.size > 1) {
                 Spacer(modifier = Modifier.height(4.dp))
                 Button(
                     onClick = onResetLobby,
@@ -478,9 +480,9 @@ private fun LeaveLobbyButton(
 private fun LobbyScreenPreview() {
     ClientTheme {
         LobbyScreen(
-            playerNames = listOf("Player1"),
+            players = listOf(PlayerCoinState(id = "1", displayName = "Player1", coins = 3)),
             currentUsername = "Player1",
-            hostUsername = "Player",
+            hostUsername = "Player1",
             isHost = true,
             isReady = false
         )
@@ -492,7 +494,12 @@ private fun LobbyScreenPreview() {
 private fun LobbyScreenFullPreview() {
     ClientTheme {
         LobbyScreen(
-            playerNames = listOf("Player1", "Player2", "Player3", "Player4"),
+            players = listOf(
+                PlayerCoinState(id = "1", displayName = "Player1", coins = 3, isReady = true),
+                PlayerCoinState(id = "2", displayName = "Player2", coins = 3, isReady = true),
+                PlayerCoinState(id = "3", displayName = "Player3", coins = 3, isReady = false),
+                PlayerCoinState(id = "4", displayName = "Player4", coins = 3, isReady = true),
+            ),
             currentUsername = "Player1",
             hostUsername = "Player1",
             isHost = true,

--- a/app/src/main/java/com/machikoro/client/ui/lobby/LobbyScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/lobby/LobbyScreen.kt
@@ -93,6 +93,8 @@ fun LobbyScreen(
     @SuppressLint("ModifierParameter") modifier: Modifier = Modifier
 ) {
     val startEnabled = isHost && players.size >= 2 && isReady
+    // True when any dummy player (filled via debug) is present in the roster
+    val hasDummies = players.any { it.displayName.startsWith("debug_player") }
 
     Box(
         modifier = modifier
@@ -209,36 +211,6 @@ fun LobbyScreen(
             ) {
                 Text("Start Game", color = TextWhite, style =  MaterialTheme.typography.labelLarge)
             }
-
-            // Debug helper: fill remaining slots so the host can start without real players
-            if (isHost && players.size < maxPlayers) {
-                Spacer(modifier = Modifier.height(8.dp))
-                Button(
-                    onClick = onFillWithDummies,
-                    modifier = Modifier
-                        .width(320.dp)
-                        .height(44.dp),
-                    shape = RoundedCornerShape(10.dp),
-                    colors = ButtonDefaults.buttonColors(containerColor = ButtonBeigeLight)
-                ) {
-                    Text("[Debug] Fill with dummies", color = TextBlueDark, style = MaterialTheme.typography.labelMedium)
-                }
-            }
-
-            // Debug helper: remove all non-host players so the host can start fresh
-            if (isHost && players.size > 1) {
-                Spacer(modifier = Modifier.height(4.dp))
-                Button(
-                    onClick = onResetLobby,
-                    modifier = Modifier
-                        .width(320.dp)
-                        .height(44.dp),
-                    shape = RoundedCornerShape(10.dp),
-                    colors = ButtonDefaults.buttonColors(containerColor = ButtonBeigeLight)
-                ) {
-                    Text("[Debug] Reset lobby", color = TextBlueDark, style = MaterialTheme.typography.labelMedium)
-                }
-            }
         }
 
         ReadyToggle(
@@ -256,6 +228,24 @@ fun LobbyScreen(
                     .align(Alignment.TopStart)
                     .padding(top = 180.dp, start = 95.dp)
             )
+        }
+
+        // Debug button: fill lobby with dummies, or reset once dummies are present
+        if (isHost) {
+            val debugLabel = if (hasDummies) "[Debug] Reset lobby" else "[Debug] Fill with dummies"
+            val debugAction = if (hasDummies) onResetLobby else onFillWithDummies
+            Button(
+                onClick = debugAction,
+                enabled = hasDummies || players.size < maxPlayers,
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(start = 20.dp, bottom = 20.dp)
+                    .height(34.dp),
+                shape = RoundedCornerShape(8.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = ButtonBeigeLight)
+            ) {
+                Text(debugLabel, color = TextBlueDark, style = MaterialTheme.typography.labelSmall)
+            }
         }
 
         LeaveLobbyButton(

--- a/app/src/main/java/com/machikoro/client/ui/lobby/LobbyScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/lobby/LobbyScreen.kt
@@ -92,7 +92,8 @@ fun LobbyScreen(
     onResetLobby: () -> Unit = {},
     @SuppressLint("ModifierParameter") modifier: Modifier = Modifier
 ) {
-    val startEnabled = isHost && players.size >= 2 && isReady
+    // All players must be ready, not just the host
+    val startEnabled = isHost && players.size >= 2 && players.all { it.isReady }
     // True when any dummy player (filled via debug) is present in the roster
     val hasDummies = players.any { it.displayName.startsWith("debug_player") }
 

--- a/app/src/main/java/com/machikoro/client/ui/lobby/LobbyScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/lobby/LobbyScreenViewModel.kt
@@ -57,10 +57,14 @@ class LobbyScreenViewModel(
         viewModelScope.launch {
             webSocketClient.players.collect { players ->
                 mutableState.update { current ->
-                    val playerNames = players.map { it.displayName }
-
+                    // Sync local ready state from the server roster for the current user
+                    val myReady = players
+                        .find { it.displayName == current.loggedInAs }
+                        ?.isReady
+                        ?: current.isReady
                     current.copy(
-                        playerList = playerNames,
+                        playerList = players,
+                        isReady = myReady,
                         lobbyStatus = if (players.size >= 2) {
                             LobbyStatus.READY
                         } else {
@@ -104,12 +108,10 @@ class LobbyScreenViewModel(
     }
 
     fun onReadyToggle() {
-        mutableState.update { current ->
-            current.copy(isReady = !current.isReady)
-        }
-
-        // TODO: send ready status to backend when supported.
-        // webSocketClient.sendReadyToggle()
+        // Optimistic local update so the toggle feels instant before the server responds
+        val newReady = !mutableState.value.isReady
+        mutableState.update { current -> current.copy(isReady = newReady) }
+        webSocketClient.sendReadyToggle(newReady)
     }
 
     fun onLeaveLobby() {

--- a/app/src/test/java/com/machikoro/client/network/websocket/FakeWebSocketClient.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/FakeWebSocketClient.kt
@@ -204,6 +204,13 @@ class FakeWebSocketClient : WebSocketClient {
         endedTurnGameId = gameId
     }
 
+    var lastReadyToggle: Boolean? = null
+        private set
+
+    override fun sendReadyToggle(isReady: Boolean) {
+        lastReadyToggle = isReady
+    }
+
     fun emitConnectionStatus(status: ConnectionStatus) {
         mutableConnectionStatus.value = status
     }

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -31,6 +31,7 @@ import okio.ByteString
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -1937,6 +1938,88 @@ class OkHttpWebSocketClientTest {
         val noPayload = """{"type":"LOBBY_ROSTER","sender":"SERVER","gameId":1}"""
         factory.simulateText("MESSAGE\ndestination:/queue/lobby-user1\ncontent-type:application/json\n\n$noPayload ")
         assertEquals(emptyList<PlayerCoinState>(), client.players.value)
+    }
+
+    // ── isReady field in LOBBY_ROSTER ───────────────────────────────────────────
+
+    @Test
+    fun lobbyRosterMessagePopulatesIsReadyField() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        // Player entry with isReady:true
+        val rosterJson = """{"type":"LOBBY_ROSTER","sender":"SERVER","gameId":1,"payload":{"players":[{"playerId":5,"userId":20,"username":"Alice","coins":3,"isReady":true}]}}"""
+        factory.simulateText(gameActionFrame(rosterJson))
+        assertTrue(client.players.value[0].isReady)
+    }
+
+    @Test
+    fun lobbyRosterMessageDefaultsIsReadyToFalseWhenAbsent() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        // Player entry without isReady field — should default to false
+        val rosterJson = """{"type":"LOBBY_ROSTER","sender":"SERVER","gameId":1,"payload":{"players":[{"playerId":5,"userId":20,"username":"Alice","coins":3}]}}"""
+        factory.simulateText(gameActionFrame(rosterJson))
+        assertFalse(client.players.value[0].isReady)
+    }
+
+    // ── sendReadyToggle ──────────────────────────────────────────────────────────
+
+    @Test
+    fun sendReadyToggleSendsStompFrameToReadyToggleDestination() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        // Lobby roster sets activeGameId so the toggle has a game to target
+        val rosterJson = """{"type":"LOBBY_ROSTER","sender":"SERVER","gameId":7,"payload":{"players":[{"playerId":1,"userId":1,"username":"Alice","coins":3}]}}"""
+        factory.simulateText(gameActionFrame(rosterJson))
+        factory.socket.sentMessages.clear()
+
+        client.sendReadyToggle(true)
+
+        val readyFrame = factory.socket.sentMessages.firstOrNull {
+            it.contains("destination:${WebSocketContract.readyToggleDestination}")
+        }
+        assertNotNull("expected a SEND frame to ${WebSocketContract.readyToggleDestination}", readyFrame)
+        assertTrue(readyFrame!!.contains("\"isReady\":true"))
+        assertTrue(readyFrame.contains("\"gameId\":7"))
+    }
+
+    @Test
+    fun sendReadyToggleWithoutActiveGameIdIsIgnored() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        // No roster → activeGameId stays null
+        factory.socket.sentMessages.clear()
+
+        client.sendReadyToggle(true)
+
+        assertFalse(
+            factory.socket.sentMessages.any {
+                it.contains("destination:${WebSocketContract.readyToggleDestination}")
+            }
+        )
+    }
+
+    @Test
+    fun sendReadyToggleWithoutConnectionIsIgnored() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        // Never connected — webSocket is null
+
+        client.sendReadyToggle(true)
+
+        assertTrue(factory.socket.sentMessages.isEmpty())
     }
 
     @Test

--- a/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
@@ -70,6 +70,7 @@ class DummyWebSocketClient : WebSocketClient {
     override fun resolveEffects(gameId: Int) {}
     override fun endTurn(gameId: Int) {}
     override fun sendLeaveLobby(gameId: Int) {}
+    override fun sendReadyToggle(isReady: Boolean) {}
     override fun sendPurchase(
         gameId: Int,
         purchaseType: PurchaseType,

--- a/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
@@ -222,6 +222,7 @@ class HomeScreenViewModelTest {
         override fun clearLobbyCode() { mutableLobbyCode.value = null }
         override fun clearGameState() = Unit
         override fun sendLeaveLobby(gameId: Int) {}
+        override fun sendReadyToggle(isReady: Boolean) = Unit
     }
 }
 

--- a/app/src/test/java/com/machikoro/client/ui/lobby/LobbyScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/lobby/LobbyScreenViewModelTest.kt
@@ -36,7 +36,7 @@ class LobbyScreenViewModelTest {
         advanceUntilIdle()
         assertEquals(ConnectionStatus.IDLE, viewModel.state.value.connectionStatus)
         assertEquals(LobbyStatus.WAITING_FOR_PLAYERS, viewModel.state.value.lobbyStatus)
-        assertEquals(emptyList<String>(), viewModel.state.value.playerList)
+        assertEquals(emptyList<PlayerCoinState>(), viewModel.state.value.playerList)
         assertEquals(4, viewModel.state.value.maxPlayers)
         assertFalse(viewModel.state.value.isHost)
         assertNull(viewModel.state.value.loggedInAs)
@@ -52,7 +52,13 @@ class LobbyScreenViewModelTest {
             PlayerCoinState(id = "2", displayName = "bob", coins = 5),
         ))
         advanceUntilIdle()
-        assertEquals(listOf("alice", "bob"), viewModel.state.value.playerList)
+        assertEquals(
+            listOf(
+                PlayerCoinState(id = "1", displayName = "alice", coins = 3),
+                PlayerCoinState(id = "2", displayName = "bob", coins = 5),
+            ),
+            viewModel.state.value.playerList
+        )
         assertEquals(LobbyStatus.READY, viewModel.state.value.lobbyStatus)
     }
 
@@ -62,7 +68,7 @@ class LobbyScreenViewModelTest {
         val viewModel = LobbyScreenViewModel(fakeClient, FakeSessionStateHolder(), FakeDebugApi())
         fakeClient.emitPlayers(listOf(PlayerCoinState(id = "1", displayName = "alice", coins = 3)))
         advanceUntilIdle()
-        assertEquals(listOf("alice"), viewModel.state.value.playerList)
+        assertEquals(listOf(PlayerCoinState(id = "1", displayName = "alice", coins = 3)), viewModel.state.value.playerList)
         assertEquals(LobbyStatus.WAITING_FOR_PLAYERS, viewModel.state.value.lobbyStatus)
     }
 
@@ -268,6 +274,56 @@ class LobbyScreenViewModelTest {
         viewModel.resetLobby()
         advanceUntilIdle()
         assertEquals(1, fakeDebugApi.resetLobbyCallCount)
+    }
+
+    // === ready-sync tests ===
+
+    @Test
+    fun isReadySyncedFromServerRosterWhenPlayersFlowUpdates() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val sessionHolder = FakeSessionStateHolder()
+        val viewModel = LobbyScreenViewModel(fakeClient, sessionHolder, FakeDebugApi())
+        sessionHolder.signIn(token = "t", username = "alice", userId = 1)
+        advanceUntilIdle()
+        // Server roster says alice is ready
+        fakeClient.emitPlayers(listOf(PlayerCoinState(id = "1", displayName = "alice", coins = 3, isReady = true)))
+        advanceUntilIdle()
+        assertTrue(viewModel.state.value.isReady)
+    }
+
+    @Test
+    fun isReadyNotOverriddenWhenCurrentUserNotInRoster() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val sessionHolder = FakeSessionStateHolder()
+        val viewModel = LobbyScreenViewModel(fakeClient, sessionHolder, FakeDebugApi())
+        sessionHolder.signIn(token = "t", username = "alice", userId = 1)
+        advanceUntilIdle()
+        // Alice toggled ready locally
+        viewModel.onReadyToggle()
+        advanceUntilIdle()
+        assertTrue(viewModel.state.value.isReady)
+        // Roster update that does not include alice — local state preserved
+        fakeClient.emitPlayers(listOf(PlayerCoinState(id = "2", displayName = "bob", coins = 3, isReady = false)))
+        advanceUntilIdle()
+        assertTrue(viewModel.state.value.isReady)
+    }
+
+    @Test
+    fun onReadyToggleSendsToggleViaWebSocketClient() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = LobbyScreenViewModel(fakeClient, FakeSessionStateHolder(), FakeDebugApi())
+        viewModel.onReadyToggle()
+        assertEquals(true, fakeClient.lastReadyToggle)
+    }
+
+    @Test
+    fun onReadyToggleSendsCorrectValueOnSubsequentToggles() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = LobbyScreenViewModel(fakeClient, FakeSessionStateHolder(), FakeDebugApi())
+        viewModel.onReadyToggle()
+        assertEquals(true, fakeClient.lastReadyToggle)
+        viewModel.onReadyToggle()
+        assertEquals(false, fakeClient.lastReadyToggle)
     }
 
     private class FakeDebugApi(private val shouldThrow: Boolean = false) : DebugApi {


### PR DESCRIPTION
The PR introduces a fix for the LobbyScreen, where other people can see the toggle between not ready and ready in real-time. This behaviour is now synced accordingly between multiple devices.
Also, a game can now only be started when all players are ready.
Debug Button was moved to the bottom left corner.