### PR TITLE
fix: separate current and active player coin identity

### DIFF
--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -1258,14 +1258,19 @@ class OkHttpWebSocketClient(
         val currentTurnUserId = payload.optJSONArray("turnOrder")
             ?.takeIf { currentTurnIndex != null && currentTurnIndex in 0 until it.length() }
             ?.let { turnOrder -> currentTurnIndex?.let(turnOrder::optInt) }
-        val currentUserId = activeUserId ?: currentTurnUserId
+        val resolvedActiveUserId = activeUserId ?: currentTurnUserId
+        val localUserId = sessionStateHolder.session.value?.userId
 
         return List(length()) { index ->
-            getJSONObject(index).toPlayerCoinState(currentUserId, playerUsernames)
+            getJSONObject(index).toPlayerCoinState(localUserId, resolvedActiveUserId, playerUsernames)
         }
     }
 
-    private fun JSONObject.toPlayerCoinState(currentUserId: Int?, playerUsernames: Map<Int, String> = emptyMap()): PlayerCoinState {
+    private fun JSONObject.toPlayerCoinState(
+        localUserId: Int?,
+        activeUserId: Int?,
+        playerUsernames: Map<Int, String> = emptyMap()
+    ): PlayerCoinState {
         val playerId = optInt("id")
         val userId = optIntOrNull("userId")
         val resolvedDisplayName =
@@ -1278,8 +1283,8 @@ class OkHttpWebSocketClient(
             id = playerId.toString(),
             displayName = resolvedDisplayName,
             coins = optInt("coins"),
-            isCurrentPlayer = userId != null && userId == currentUserId,
-            isActivePlayer = userId != null && userId == currentUserId,
+            isCurrentPlayer = userId != null && userId == localUserId,
+            isActivePlayer = userId != null && userId == activeUserId,
         )
     }
 

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -2762,7 +2762,18 @@ class OkHttpWebSocketClientTest {
         assertEquals(harness.playerA.activeGameId.value, harness.playerB.activeGameId.value)
         assertEquals(harness.playerA.gamePhase.value, harness.playerB.gamePhase.value)
         assertEquals(harness.playerA.activePlayerId.value, harness.playerB.activePlayerId.value)
-        assertEquals(harness.playerA.players.value, harness.playerB.players.value)
+        assertEquals(
+            harness.playerA.players.value.map { player ->
+                listOf(player.id, player.displayName, player.coins, player.isActivePlayer)
+            },
+            harness.playerB.players.value.map { player ->
+                listOf(player.id, player.displayName, player.coins, player.isActivePlayer)
+            }
+        )
+        assertEquals(true, harness.playerA.players.value.first { it.id == "11" }.isCurrentPlayer)
+        assertFalse(harness.playerA.players.value.first { it.id == "22" }.isCurrentPlayer)
+        assertFalse(harness.playerB.players.value.first { it.id == "11" }.isCurrentPlayer)
+        assertEquals(true, harness.playerB.players.value.first { it.id == "22" }.isCurrentPlayer)
         assertEquals(harness.playerA.marketplace.value, harness.playerB.marketplace.value)
         assertEquals(harness.playerA.playerLandmarks.value, harness.playerB.playerLandmarks.value)
         assertEquals(listOf(9), harness.playerB.diceResult.value)

--- a/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
@@ -115,7 +115,9 @@ class WebSocketClientTest {
             fixture.client.players.value.map { it.id to it.coins }
         )
         assertFalse(fixture.client.players.value.first { it.id == "11" }.isActivePlayer)
+        assertEquals(true, fixture.client.players.value.first { it.id == "11" }.isCurrentPlayer)
         assertEquals(true, fixture.client.players.value.first { it.id == "22" }.isActivePlayer)
+        assertFalse(fixture.client.players.value.first { it.id == "22" }.isCurrentPlayer)
         assertEquals(
             mapOf(11 to listOf(PlayerCardState(CardType.WHEAT_FIELD, 1))),
             fixture.client.playerCards.value
@@ -198,7 +200,9 @@ class WebSocketClientTest {
 
         assertEquals(202, fixture.client.activePlayerId.value)
         assertFalse(fixture.client.players.value.first { it.id == "202" }.isActivePlayer)
+        assertEquals(true, fixture.client.players.value.first { it.id == "202" }.isCurrentPlayer)
         assertEquals(true, fixture.client.players.value.first { it.id == "22" }.isActivePlayer)
+        assertFalse(fixture.client.players.value.first { it.id == "22" }.isCurrentPlayer)
     }
 
     @Test


### PR DESCRIPTION
Fixes player coin display mismatch between `PlayersTopBar` and the right-side player/coin UI after resolving effects and switching turns.

### **What Changed**

- Updated WebSocket game-state parsing so player identity flags are derived from the correct IDs:
  - `isCurrentPlayer` now uses the local session user ID.
  - `isActivePlayer` now uses the active turn user ID.
- Kept `PlayerCoinState.id` unchanged as the database/player ID, so existing coin, card, and landmark mappings continue to use the same identifier.
- Added regression test coverage for snapshots where:
  - the local user is not the active player,
  - player database IDs and user IDs can overlap,
  - multiple clients receive the same authoritative state but correctly keep different local `isCurrentPlayer` flags.

### **Why**

Previously, both `isCurrentPlayer` and `isActivePlayer` were derived from the active player ID. This caused the `"You"` marker and current-player display behavior to follow the active turn instead of staying attached to the logged-in user. As a result, the top bar could display/hide/highlight coin information for the wrong player after effects resolved or turns switched.

### **How It Works Now**

- Coin amounts still come from `player.coins`.
- `PlayerCoinState.id` still represents the player/database ID.
- Active turn highlighting follows `activeUserId`.
- Local player identity follows `sessionStateHolder.session.value?.userId`.