### PR TITLE
fix: update hasTrainStation logic to use active player's database ID

### DIFF
--- a/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
@@ -41,10 +41,13 @@ data class GameScreenState(
         get() = gamePhase == GamePhase.BUY_OR_BUILD
 
     val hasTrainStation: Boolean
-        get() = activePlayerId != null &&
-                playerLandmarks[activePlayerId]
-                    ?.any { it.landmarkType == LandmarkType.TRAIN_STATION && it.isBuilt }
-                ?: false
+        get() {
+            val activePlayerDatabaseId = players.firstOrNull { it.isActivePlayer }?.id?.toIntOrNull()
+                ?: return false
+            return playerLandmarks[activePlayerDatabaseId].orEmpty().any {
+                it.landmarkType == LandmarkType.TRAIN_STATION && it.isBuilt
+            }
+        }
 
     companion object {
         fun initial() = GameScreenState(

--- a/app/src/test/java/com/machikoro/client/domain/model/state/GameScreenStateTest.kt
+++ b/app/src/test/java/com/machikoro/client/domain/model/state/GameScreenStateTest.kt
@@ -72,6 +72,83 @@ class GameScreenStateTest {
         assertFalse(state.hasTrainStation)
     }
 
+    @Test
+    fun hasTrainStationIsFalseWhenNoPlayerIsMarkedActive() {
+        val state = GameScreenState.initial().copy(
+            activePlayerId = ACTIVE_USER_ID,
+            myUserId = ACTIVE_USER_ID,
+            players = listOf(
+                PlayerCoinState(
+                    id = ACTIVE_PLAYER_DATABASE_ID.toString(),
+                    displayName = "Waiting Player",
+                    coins = 4,
+                    isCurrentPlayer = true,
+                    isActivePlayer = false,
+                ),
+            ),
+            playerLandmarks = mapOf(
+                ACTIVE_PLAYER_DATABASE_ID to listOf(
+                    PlayerLandmarkState(
+                        landmarkType = LandmarkType.TRAIN_STATION,
+                        isBuilt = true,
+                    ),
+                ),
+            ),
+        )
+
+        assertFalse(state.hasTrainStation)
+    }
+
+    @Test
+    fun hasTrainStationIsFalseWhenActivePlayerIdCannotBeMappedToDatabaseId() {
+        val state = GameScreenState.initial().copy(
+            activePlayerId = ACTIVE_USER_ID,
+            myUserId = ACTIVE_USER_ID,
+            players = listOf(
+                PlayerCoinState(
+                    id = "player-$ACTIVE_PLAYER_DATABASE_ID",
+                    displayName = "Active Player",
+                    coins = 4,
+                    isCurrentPlayer = true,
+                    isActivePlayer = true,
+                ),
+            ),
+            playerLandmarks = mapOf(
+                ACTIVE_PLAYER_DATABASE_ID to listOf(
+                    PlayerLandmarkState(
+                        landmarkType = LandmarkType.TRAIN_STATION,
+                        isBuilt = true,
+                    ),
+                ),
+            ),
+        )
+
+        assertFalse(state.hasTrainStation)
+    }
+
+    @Test
+    fun hasTrainStationIsFalseWhenActivePlayerLandmarksAreMissing() {
+        val state = trainStationState(playerLandmarks = emptyMap())
+
+        assertFalse(state.hasTrainStation)
+    }
+
+    @Test
+    fun hasTrainStationIgnoresBuiltNonTrainStationLandmarks() {
+        val state = trainStationState(
+            playerLandmarks = mapOf(
+                ACTIVE_PLAYER_DATABASE_ID to listOf(
+                    PlayerLandmarkState(
+                        landmarkType = LandmarkType.SHOPPING_MALL,
+                        isBuilt = true,
+                    ),
+                ),
+            ),
+        )
+
+        assertFalse(state.hasTrainStation)
+    }
+
     private fun trainStationState(
         playerLandmarks: Map<Int, List<PlayerLandmarkState>>,
     ): GameScreenState =

--- a/app/src/test/java/com/machikoro/client/domain/model/state/GameScreenStateTest.kt
+++ b/app/src/test/java/com/machikoro/client/domain/model/state/GameScreenStateTest.kt
@@ -1,7 +1,10 @@
 package com.machikoro.client.domain.model.state
 
 import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.enums.LandmarkType
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class GameScreenStateTest {
@@ -29,5 +32,74 @@ class GameScreenStateTest {
         val state = GameScreenState.initial().copy(gamePhase = GamePhase.BUY_OR_BUILD)
 
         assertEquals(true, state.isBuyingPhase)
+    }
+
+    @Test
+    fun hasTrainStationUsesActivePlayersDatabasePlayerIdWhenUserIdDiffers() {
+        val state = trainStationState(
+            playerLandmarks = mapOf(
+                ACTIVE_PLAYER_DATABASE_ID to listOf(
+                    PlayerLandmarkState(
+                        landmarkType = LandmarkType.TRAIN_STATION,
+                        isBuilt = true,
+                    ),
+                ),
+            ),
+        )
+
+        assertTrue(state.hasTrainStation)
+    }
+
+    @Test
+    fun hasTrainStationIsFalseWhenActivePlayerHasNoBuiltTrainStation() {
+        val state = trainStationState(
+            playerLandmarks = mapOf(
+                ACTIVE_PLAYER_DATABASE_ID to listOf(
+                    PlayerLandmarkState(
+                        landmarkType = LandmarkType.TRAIN_STATION,
+                        isBuilt = false,
+                    ),
+                ),
+                ACTIVE_USER_ID to listOf(
+                    PlayerLandmarkState(
+                        landmarkType = LandmarkType.TRAIN_STATION,
+                        isBuilt = true,
+                    ),
+                ),
+            ),
+        )
+
+        assertFalse(state.hasTrainStation)
+    }
+
+    private fun trainStationState(
+        playerLandmarks: Map<Int, List<PlayerLandmarkState>>,
+    ): GameScreenState =
+        GameScreenState.initial().copy(
+            activePlayerId = ACTIVE_USER_ID,
+            myUserId = ACTIVE_USER_ID,
+            players = listOf(
+                PlayerCoinState(
+                    id = ACTIVE_PLAYER_DATABASE_ID.toString(),
+                    displayName = "Active Player",
+                    coins = 4,
+                    isCurrentPlayer = true,
+                    isActivePlayer = true,
+                ),
+                PlayerCoinState(
+                    id = OTHER_PLAYER_DATABASE_ID.toString(),
+                    displayName = "Waiting Player",
+                    coins = 3,
+                    isCurrentPlayer = false,
+                    isActivePlayer = false,
+                ),
+            ),
+            playerLandmarks = playerLandmarks,
+        )
+
+    private companion object {
+        const val ACTIVE_USER_ID = 202
+        const val ACTIVE_PLAYER_DATABASE_ID = 11
+        const val OTHER_PLAYER_DATABASE_ID = 22
     }
 }


### PR DESCRIPTION
## Summary
- Fixes Train Station detection in `GameScreenState.hasTrainStation`.
- Resolves the active player’s database player ID from `players.firstOrNull { it.isActivePlayer }?.id`.
- Keeps compatibility with current server `main`, where `activePlayerId` is a user ID and `playerLandmarks` is keyed by database player ID.

## Why
The UI previously indexed `playerLandmarks` with `activePlayerId`. This failed when `activePlayerId != playerId`, preventing the active local player from seeing the 1/2 dice selector after building Train Station.

## Testing
- Added unit coverage for mismatched `userId` and `playerId`.
- Verified `hasTrainStation == true` when the active player’s database player ID has a built Train Station.
- Verified `hasTrainStation == false` when the active player does not have a built Train Station.

## Verification
- `./gradlew test`
- `./gradlew build`

Closes #285