### PR TITLE
fix: remove unused import in GameScreenSnapshotTest

### DIFF
--- a/app/src/androidTest/java/com/machikoro/client/ui/game/GameScreenSnapshotTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/game/GameScreenSnapshotTest.kt
@@ -17,7 +17,6 @@ import com.machikoro.client.domain.model.state.PlayerCardState
 import com.machikoro.client.domain.model.state.PlayerCoinState
 import com.machikoro.client.domain.model.state.PlayerLandmarkState
 import com.machikoro.client.domain.model.state.PurchaseState
-import com.machikoro.client.ui.game.ui.GameScreen
 import com.machikoro.client.ui.theme.ClientTheme
 import org.junit.Rule
 import org.junit.Test


### PR DESCRIPTION
## Summary

Closes #286.

- Removed the stale `GameScreen` import from `GameScreenSnapshotTest`.
- The test now resolves `GameScreen` from its own package, `com.machikoro.client.ui.game`.
