### PR TITLE
fix: centralize card definitions and activation sorting

### DIFF
--- a/app/src/main/java/com/machikoro/client/domain/cheat/InsiderTrading.kt
+++ b/app/src/main/java/com/machikoro/client/domain/cheat/InsiderTrading.kt
@@ -2,7 +2,7 @@ package com.machikoro.client.domain.cheat
 
 import com.machikoro.client.domain.enums.CardType
 import com.machikoro.client.domain.enums.LandmarkType
-import com.machikoro.client.domain.model.shop.ShopCatalog
+import com.machikoro.client.domain.model.shop.CardDefinitions
 import com.machikoro.client.domain.model.state.GameScreenState
 import com.machikoro.client.domain.model.state.PlayerCoinState
 import kotlin.math.sqrt
@@ -46,31 +46,27 @@ private sealed interface Payout {
     }
 }
 
-private data class Economics(val activationNumbers: Set<Int>, val payout: Payout)
+private data class Economics(val payout: Payout)
 
-/** Base-game establishment data, hardcoded because the server snapshot omits it. */
+/** Payout logic for the EV estimate; card metadata comes from [CardDefinitions]. */
 private val establishmentEconomics: Map<CardType, Economics> = mapOf(
-    CardType.WHEAT_FIELD to Economics(setOf(1), Payout.Fixed(1)),
-    CardType.RANCH to Economics(setOf(2), Payout.Fixed(1)),
-    CardType.BAKERY to Economics(setOf(2, 3), Payout.Fixed(1)),
-    CardType.CAFE to Economics(setOf(3), Payout.Fixed(1)),
-    CardType.CONVENIENCE_STORE to Economics(setOf(4), Payout.Fixed(3)),
-    CardType.FOREST to Economics(setOf(5), Payout.Fixed(1)),
-    CardType.CHEESE_FACTORY to Economics(setOf(7), Payout.PerOwnedIcon(3, setOf(CardType.RANCH))),
-    CardType.FURNITURE_FACTORY to Economics(
-        setOf(8),
-        Payout.PerOwnedIcon(3, setOf(CardType.FOREST, CardType.MINE)),
-    ),
-    CardType.MINE to Economics(setOf(9), Payout.Fixed(5)),
-    CardType.FAMILY_RESTAURANT to Economics(setOf(9, 10), Payout.Fixed(2)),
-    CardType.APPLE_ORCHARD to Economics(setOf(10), Payout.Fixed(3)),
+    CardType.WHEAT_FIELD to Economics(Payout.Fixed(1)),
+    CardType.RANCH to Economics(Payout.Fixed(1)),
+    CardType.BAKERY to Economics(Payout.Fixed(1)),
+    CardType.CAFE to Economics(Payout.Fixed(1)),
+    CardType.CONVENIENCE_STORE to Economics(Payout.Fixed(3)),
+    CardType.FOREST to Economics(Payout.Fixed(1)),
+    CardType.CHEESE_FACTORY to Economics(Payout.PerOwnedIcon(3, setOf(CardType.RANCH))),
+    CardType.FURNITURE_FACTORY to Economics(Payout.PerOwnedIcon(3, setOf(CardType.FOREST, CardType.MINE))),
+    CardType.MINE to Economics(Payout.Fixed(5)),
+    CardType.FAMILY_RESTAURANT to Economics(Payout.Fixed(2)),
+    CardType.APPLE_ORCHARD to Economics(Payout.Fixed(3)),
     CardType.FRUIT_AND_VEGETABLE_MARKET to Economics(
-        setOf(11, 12),
         Payout.PerOwnedIcon(2, setOf(CardType.WHEAT_FIELD, CardType.APPLE_ORCHARD)),
     ),
-    CardType.STADIUM to Economics(setOf(6), Payout.PerOpponent(2)),
-    CardType.TV_STATION to Economics(setOf(6), Payout.Fixed(5)),
-    CardType.BUSINESS_CENTER to Economics(setOf(6), Payout.Fixed(0)),
+    CardType.STADIUM to Economics(Payout.PerOpponent(2)),
+    CardType.TV_STATION to Economics(Payout.Fixed(5)),
+    CardType.BUSINESS_CENTER to Economics(Payout.Fixed(0)),
 )
 
 private val oneDieDistribution: Map<Int, Double> = (1..6).associateWith { 1.0 / 6.0 }
@@ -107,7 +103,8 @@ fun recommendBestBuy(state: GameScreenState, player: PlayerCoinState): CardType?
         .mapNotNull { (type, econ) ->
             val cost = costOf(type, state)
             if (cost > player.coins) return@mapNotNull null
-            val expectedValue = activationProbability(econ.activationNumbers, twoDice) *
+            val activationNumbers = activationNumbersOf(type, state)
+            val expectedValue = activationProbability(activationNumbers, twoDice) *
                 econ.payout.amount(ownedCounts, opponentCount)
             if (expectedValue <= 0.0) return@mapNotNull null
             Candidate(type, expectedValue, cost)
@@ -126,7 +123,12 @@ private data class Candidate(val type: CardType, val expectedValue: Double, val 
 /** Card cost from the server-provided shop items, falling back to the local catalog. */
 private fun costOf(type: CardType, state: GameScreenState): Int {
     state.shopItems.firstOrNull { it.type == type.name }?.cost?.let { return it }
-    return ShopCatalog.defaultItems.firstOrNull { it.type == type.name }?.cost ?: Int.MAX_VALUE
+    return CardDefinitions.forType(type)?.cost ?: Int.MAX_VALUE
+}
+
+private fun activationNumbersOf(type: CardType, state: GameScreenState): Set<Int> {
+    state.shopItems.firstOrNull { it.type == type.name }?.activationNumbers?.let { return it.toSet() }
+    return CardDefinitions.forType(type)?.activationNumbers.orEmpty().toSet()
 }
 
 private const val GRAVITY = 9.80665f

--- a/app/src/main/java/com/machikoro/client/domain/model/shop/ShopItem.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/shop/ShopItem.kt
@@ -18,232 +18,297 @@ data class ShopItem(
     val cost: Int,
     val color: ShopItemColor,
     val establishmentType: String,
-    val activationText: String,
+    val activationNumbers: List<Int>,
     val effectText: String,
     val imageKey: String,
     val isAvailable: Boolean = true
-)
+) {
+    val activationText: String
+        get() = activationNumbers.toActivationText() ?: "Permanent"
+}
 
-object ShopCatalog {
-    private const val ONE_COIN_ON_ANY_TURN = "Get 1 coin from the bank on anyone's turn."
+data class CardDefinition(
+    val cardType: CardType,
+    val displayName: String,
+    val cost: Int,
+    val color: ShopItemColor,
+    val establishmentType: String,
+    val activationNumbers: List<Int>,
+    val effectText: String,
+    val imageKey: String,
+) {
+    val activationText: String
+        get() = activationNumbers.toActivationText().orEmpty()
 
-    /**
-     * Temporary local catalog for issue #38.
-     *
-     * The server already owns the real card/landmark database. Until the client
-     * consumes server-provided shop definitions, this list gives the UI all
-     * current server enum values so every purchase button can send a valid
-     * request. Availability/error feedback stays with #39 and server #228.
-     */
-    val defaultItems = listOf(
+    fun toShopItem(isAvailable: Boolean = true): ShopItem =
         ShopItem(
             purchaseType = PurchaseType.ESTABLISHMENT,
-            type = CardType.WHEAT_FIELD.name,
+            type = cardType.name,
+            displayName = displayName,
+            cost = cost,
+            color = color,
+            establishmentType = establishmentType,
+            activationNumbers = activationNumbers,
+            effectText = effectText,
+            imageKey = imageKey,
+            isAvailable = isAvailable,
+        )
+}
+
+object CardDefinitions {
+    private const val ONE_COIN_ON_ANY_TURN = "Get 1 coin from the bank on anyone's turn."
+
+    val defaultCards = listOf(
+        CardDefinition(
+            cardType = CardType.WHEAT_FIELD,
             displayName = "Wheat Field",
             cost = 1,
             color = ShopItemColor.BLUE,
             establishmentType = "WHEAT",
-            activationText = "1",
+            activationNumbers = listOf(1),
             effectText = ONE_COIN_ON_ANY_TURN,
             imageKey = "card_wheat_field"
         ),
-        ShopItem(
-            purchaseType = PurchaseType.ESTABLISHMENT,
-            type = CardType.RANCH.name,
+        CardDefinition(
+            cardType = CardType.RANCH,
             displayName = "Ranch",
             cost = 1,
             color = ShopItemColor.BLUE,
             establishmentType = "COW",
-            activationText = "2",
+            activationNumbers = listOf(2),
             effectText = ONE_COIN_ON_ANY_TURN,
             imageKey = "card_ranch"
         ),
-        ShopItem(
-            purchaseType = PurchaseType.ESTABLISHMENT,
-            type = CardType.FOREST.name,
+        CardDefinition(
+            cardType = CardType.FOREST,
             displayName = "Forest",
             cost = 3,
             color = ShopItemColor.BLUE,
             establishmentType = "GEAR",
-            activationText = "5",
+            activationNumbers = listOf(5),
             effectText = ONE_COIN_ON_ANY_TURN,
             imageKey = "card_forest"
         ),
-        ShopItem(
-            purchaseType = PurchaseType.ESTABLISHMENT,
-            type = CardType.MINE.name,
+        CardDefinition(
+            cardType = CardType.MINE,
             displayName = "Mine",
             cost = 6,
             color = ShopItemColor.BLUE,
             establishmentType = "GEAR",
-            activationText = "9",
+            activationNumbers = listOf(9),
             effectText = "Get 5 coins from the bank on anyone's turn.",
             imageKey = "card_mine"
         ),
-        ShopItem(
-            purchaseType = PurchaseType.ESTABLISHMENT,
-            type = CardType.APPLE_ORCHARD.name,
+        CardDefinition(
+            cardType = CardType.APPLE_ORCHARD,
             displayName = "Apple Orchard",
             cost = 3,
             color = ShopItemColor.BLUE,
             establishmentType = "WHEAT",
-            activationText = "10",
+            activationNumbers = listOf(10),
             effectText = "Get 3 coins from the bank on anyone's turn.",
             imageKey = "card_apple_orchard"
         ),
-        ShopItem(
-            purchaseType = PurchaseType.ESTABLISHMENT,
-            type = CardType.BAKERY.name,
+        CardDefinition(
+            cardType = CardType.BAKERY,
             displayName = "Bakery",
             cost = 1,
             color = ShopItemColor.GREEN,
             establishmentType = "BREAD",
-            activationText = "2-3",
+            activationNumbers = listOf(2, 3),
             effectText = "Get 1 coin from the bank on your turn.",
             imageKey = "card_bakery"
         ),
-        ShopItem(
-            purchaseType = PurchaseType.ESTABLISHMENT,
-            type = CardType.CONVENIENCE_STORE.name,
+        CardDefinition(
+            cardType = CardType.CONVENIENCE_STORE,
             displayName = "Convenience Store",
             cost = 2,
             color = ShopItemColor.GREEN,
             establishmentType = "BREAD",
-            activationText = "4",
+            activationNumbers = listOf(4),
             effectText = "Get 3 coins from the bank on your turn.",
             imageKey = "card_convenience_store"
         ),
-        ShopItem(
-            purchaseType = PurchaseType.ESTABLISHMENT,
-            type = CardType.CHEESE_FACTORY.name,
+        CardDefinition(
+            cardType = CardType.CHEESE_FACTORY,
             displayName = "Cheese Factory",
             cost = 5,
             color = ShopItemColor.GREEN,
             establishmentType = "FACTORY",
-            activationText = "7",
+            activationNumbers = listOf(7),
             effectText = "Get 3 coins from the bank for each cow establishment you own.",
             imageKey = "card_cheese_factory"
         ),
-        ShopItem(
-            purchaseType = PurchaseType.ESTABLISHMENT,
-            type = CardType.FURNITURE_FACTORY.name,
+        CardDefinition(
+            cardType = CardType.FURNITURE_FACTORY,
             displayName = "Furniture Factory",
             cost = 3,
             color = ShopItemColor.GREEN,
             establishmentType = "FACTORY",
-            activationText = "8",
+            activationNumbers = listOf(8),
             effectText = "Get 3 coins from the bank for each gear establishment you own.",
             imageKey = "card_furniture_factory"
         ),
-        ShopItem(
-            purchaseType = PurchaseType.ESTABLISHMENT,
-            type = CardType.FRUIT_AND_VEGETABLE_MARKET.name,
+        CardDefinition(
+            cardType = CardType.FRUIT_AND_VEGETABLE_MARKET,
             displayName = "Fruit and Vegetable Market",
             cost = 2,
             color = ShopItemColor.GREEN,
             establishmentType = "FRUIT",
-            activationText = "11-12",
+            activationNumbers = listOf(11, 12),
             effectText = "Get 2 coins from the bank for each wheat establishment you own.",
             imageKey = "card_fruit_and_vegetable_market"
         ),
-        ShopItem(
-            purchaseType = PurchaseType.ESTABLISHMENT,
-            type = CardType.CAFE.name,
+        CardDefinition(
+            cardType = CardType.CAFE,
             displayName = "Cafe",
             cost = 2,
             color = ShopItemColor.RED,
             establishmentType = "CUP",
-            activationText = "3",
+            activationNumbers = listOf(3),
             effectText = "Take 1 coin from the player who rolled the dice.",
             imageKey = "card_cafe"
         ),
-        ShopItem(
-            purchaseType = PurchaseType.ESTABLISHMENT,
-            type = CardType.FAMILY_RESTAURANT.name,
+        CardDefinition(
+            cardType = CardType.FAMILY_RESTAURANT,
             displayName = "Family Restaurant",
             cost = 3,
             color = ShopItemColor.RED,
             establishmentType = "CUP",
-            activationText = "9-10",
+            activationNumbers = listOf(9, 10),
             effectText = "Take 2 coins from the player who rolled the dice.",
             imageKey = "card_family_restaurant"
         ),
-        ShopItem(
-            purchaseType = PurchaseType.ESTABLISHMENT,
-            type = CardType.STADIUM.name,
+        CardDefinition(
+            cardType = CardType.STADIUM,
             displayName = "Stadium",
             cost = 6,
             color = ShopItemColor.PURPLE,
             establishmentType = "MAJOR",
-            activationText = "6",
+            activationNumbers = listOf(6),
             effectText = "Take 2 coins from every opponent on your turn.",
             imageKey = "card_stadium"
         ),
-        ShopItem(
-            purchaseType = PurchaseType.ESTABLISHMENT,
-            type = CardType.TV_STATION.name,
+        CardDefinition(
+            cardType = CardType.TV_STATION,
             displayName = "TV Station",
             cost = 7,
             color = ShopItemColor.PURPLE,
             establishmentType = "MAJOR",
-            activationText = "6",
+            activationNumbers = listOf(6),
             effectText = "Take 5 coins from one opponent on your turn.",
             imageKey = "card_tv_station"
         ),
-        ShopItem(
-            purchaseType = PurchaseType.ESTABLISHMENT,
-            type = CardType.BUSINESS_CENTER.name,
+        CardDefinition(
+            cardType = CardType.BUSINESS_CENTER,
             displayName = "Business Center",
             cost = 8,
             color = ShopItemColor.PURPLE,
             establishmentType = "MAJOR",
-            activationText = "6",
+            activationNumbers = listOf(6),
             effectText = "Exchange one non-major establishment with an opponent.",
             imageKey = "card_business_center"
         ),
-        ShopItem(
-            purchaseType = PurchaseType.LANDMARK,
-            type = LandmarkType.TRAIN_STATION.name,
-            displayName = "Train Station",
-            cost = 4,
-            color = ShopItemColor.LANDMARK,
-            establishmentType = "LANDMARK",
-            activationText = "Permanent",
-            effectText = "You may roll one or two dice.",
-            imageKey = "landmark_train_station"
-        ),
-        ShopItem(
-            purchaseType = PurchaseType.LANDMARK,
-            type = LandmarkType.SHOPPING_MALL.name,
-            displayName = "Shopping Mall",
-            cost = 10,
-            color = ShopItemColor.LANDMARK,
-            establishmentType = "LANDMARK",
-            activationText = "Permanent",
-            effectText = "Your cup and bread establishments earn 1 extra coin.",
-            imageKey = "landmark_shopping_mall"
-        ),
-        ShopItem(
-            purchaseType = PurchaseType.LANDMARK,
-            type = LandmarkType.AMUSEMENT_PARK.name,
-            displayName = "Amusement Park",
-            cost = 16,
-            color = ShopItemColor.LANDMARK,
-            establishmentType = "LANDMARK",
-            activationText = "Permanent",
-            effectText = "If you roll doubles, take another turn after this one.",
-            imageKey = "landmark_amusement_park"
-        ),
-        ShopItem(
-            purchaseType = PurchaseType.LANDMARK,
-            type = LandmarkType.RADIO_TOWER.name,
-            displayName = "Radio Tower",
-            cost = 22,
-            color = ShopItemColor.LANDMARK,
-            establishmentType = "LANDMARK",
-            activationText = "Permanent",
-            effectText = "Once every turn, you can reroll your dice.",
-            imageKey = "landmark_radio_tower"
-        )
     )
+
+    private val byType = defaultCards.associateBy { it.cardType }
+
+    fun forType(cardType: CardType): CardDefinition? = byType[cardType]
+
+    fun sortShopItemsByActivation(items: List<ShopItem>): List<ShopItem> =
+        items.sortedWith(
+            compareBy<ShopItem> { it.activationSortStart }
+                .thenBy { it.activationSortEnd }
+                .thenBy { it.cost }
+                .thenBy { it.displayName },
+        )
+
+    fun sortCardTypesByActivation(types: Iterable<CardType>): List<CardType> =
+        types.sortedWith(
+            compareBy<CardType> { forType(it)?.activationNumbers?.firstOrNull() ?: Int.MAX_VALUE }
+                .thenBy { forType(it)?.activationNumbers?.lastOrNull() ?: Int.MAX_VALUE }
+                .thenBy { forType(it)?.cost ?: Int.MAX_VALUE }
+                .thenBy { forType(it)?.displayName ?: it.name },
+        )
+}
+
+object ShopCatalog {
+    /** Local fallback catalog used until a snapshot supplies server definitions. */
+    val defaultItems = listOf(
+        CardDefinitions.defaultCards.map { it.toShopItem() },
+        listOf(
+            ShopItem(
+                purchaseType = PurchaseType.LANDMARK,
+                type = LandmarkType.TRAIN_STATION.name,
+                displayName = "Train Station",
+                cost = 4,
+                color = ShopItemColor.LANDMARK,
+                establishmentType = "LANDMARK",
+                activationNumbers = emptyList(),
+                effectText = "You may roll one or two dice.",
+                imageKey = "landmark_train_station"
+            ),
+            ShopItem(
+                purchaseType = PurchaseType.LANDMARK,
+                type = LandmarkType.SHOPPING_MALL.name,
+                displayName = "Shopping Mall",
+                cost = 10,
+                color = ShopItemColor.LANDMARK,
+                establishmentType = "LANDMARK",
+                activationNumbers = emptyList(),
+                effectText = "Your cup and bread establishments earn 1 extra coin.",
+                imageKey = "landmark_shopping_mall"
+            ),
+            ShopItem(
+                purchaseType = PurchaseType.LANDMARK,
+                type = LandmarkType.AMUSEMENT_PARK.name,
+                displayName = "Amusement Park",
+                cost = 16,
+                color = ShopItemColor.LANDMARK,
+                establishmentType = "LANDMARK",
+                activationNumbers = emptyList(),
+                effectText = "If you roll doubles, take another turn after this one.",
+                imageKey = "landmark_amusement_park"
+            ),
+            ShopItem(
+                purchaseType = PurchaseType.LANDMARK,
+                type = LandmarkType.RADIO_TOWER.name,
+                displayName = "Radio Tower",
+                cost = 22,
+                color = ShopItemColor.LANDMARK,
+                establishmentType = "LANDMARK",
+                activationNumbers = emptyList(),
+                effectText = "Once every turn, you can reroll your dice.",
+                imageKey = "landmark_radio_tower"
+            )
+        )
+    ).flatten()
+}
+
+private val ShopItem.activationSortStart: Int
+    get() = activationNumbers.firstOrNull() ?: Int.MAX_VALUE
+
+private val ShopItem.activationSortEnd: Int
+    get() = activationNumbers.lastOrNull() ?: Int.MAX_VALUE
+
+fun List<Int>.toActivationText(): String? {
+    val numbers = distinct().sorted()
+    if (numbers.isEmpty()) return null
+    return if (numbers.size == 1) {
+        numbers.first().toString()
+    } else {
+        "${numbers.first()}-${numbers.last()}"
+    }
+}
+
+fun String.toActivationNumbers(): List<Int> {
+    val trimmed = trim()
+    if (trimmed.isBlank() || trimmed.equals("Permanent", ignoreCase = true)) return emptyList()
+    val rangeParts = trimmed.split("-", limit = 2).map { it.trim().toIntOrNull() }
+    if (rangeParts.size == 2 && rangeParts.all { it != null }) {
+        val start = rangeParts[0] ?: return emptyList()
+        val end = rangeParts[1] ?: return emptyList()
+        return (minOf(start, end)..maxOf(start, end)).toList()
+    }
+    return Regex("\\d+").findAll(trimmed).map { it.value.toInt() }.toList().distinct().sorted()
 }

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -7,9 +7,12 @@ import com.machikoro.client.domain.enums.PurchaseType
 import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.enums.LandmarkType
 import com.machikoro.client.domain.enums.ShopItemColor
+import com.machikoro.client.domain.model.shop.CardDefinition
+import com.machikoro.client.domain.model.shop.CardDefinitions
 import com.machikoro.client.domain.model.shop.PurchaseEvent
 import com.machikoro.client.domain.model.shop.ShopCatalog
 import com.machikoro.client.domain.model.shop.ShopItem
+import com.machikoro.client.domain.model.shop.toActivationNumbers
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.PlayerCardState
 import com.machikoro.client.domain.model.state.PlayerCoinState
@@ -863,18 +866,8 @@ class OkHttpWebSocketClient(
             val definition = array.optJSONObject(index) ?: return@mapNotNull null
             val cardType = runCatching { CardType.valueOf(definition.optString("cardType")) }
                 .getOrNull() ?: return@mapNotNull null
-            ShopItem(
-                purchaseType = PurchaseType.ESTABLISHMENT,
-                type = cardType.name,
-                displayName = cardType.displayName(),
-                cost = definition.optInt("cost"),
-                color = definition.optString("color").toShopItemColor(),
-                establishmentType = definition.optString("establishmentType"),
-                activationText = definition.activationText(cardType),
-                effectText = definition.effectText(cardType),
-                imageKey = "card_${cardType.name.lowercase()}",
-                isAvailable = (marketplace[cardType] ?: 0) > 0
-            )
+            definition.toCardDefinition(cardType)
+                .toShopItem(isAvailable = (marketplace[cardType] ?: 0) > 0)
         }
     }
 
@@ -892,7 +885,7 @@ class OkHttpWebSocketClient(
                 cost = definition.optInt("cost"),
                 color = ShopItemColor.LANDMARK,
                 establishmentType = "LANDMARK",
-                activationText = "Permanent",
+                activationNumbers = emptyList(),
                 effectText = definition.effectText(landmarkType),
                 imageKey = "landmark_${landmarkType.name.lowercase()}",
                 isAvailable = true
@@ -900,11 +893,32 @@ class OkHttpWebSocketClient(
         }
     }
 
-    private fun JSONObject.activationText(cardType: CardType): String =
-        optString("activationText")
-            .ifBlank { optString("activationRange") }
-            .ifBlank { optJSONArray("activationNumbers")?.toRangeText().orEmpty() }
-            .ifBlank { defaultShopItem(cardType.name)?.activationText.orEmpty() }
+    private fun JSONObject.toCardDefinition(cardType: CardType): CardDefinition {
+        val fallback = CardDefinitions.forType(cardType)
+        return CardDefinition(
+            cardType = cardType,
+            displayName = optString("displayName").ifBlank {
+                fallback?.displayName ?: cardType.displayName()
+            },
+            cost = optIntOrNull("cost") ?: fallback?.cost ?: 0,
+            color = optString("color").toShopItemColor(fallback?.color),
+            establishmentType = optString("establishmentType").ifBlank {
+                fallback?.establishmentType.orEmpty()
+            },
+            activationNumbers = activationNumbers().ifEmpty {
+                fallback?.activationNumbers.orEmpty()
+            },
+            effectText = effectText(cardType),
+            imageKey = optString("imageKey").ifBlank {
+                fallback?.imageKey ?: "card_${cardType.name.lowercase()}"
+            },
+        )
+    }
+
+    private fun JSONObject.activationNumbers(): List<Int> =
+        optJSONArray("activationNumbers")?.toActivationNumbers().orEmpty()
+            .ifEmpty { optString("activationRange").toActivationNumbers() }
+            .ifEmpty { optString("activationText").toActivationNumbers() }
 
     private fun JSONObject.effectText(cardType: CardType): String =
         optString("effectText")
@@ -918,20 +932,13 @@ class OkHttpWebSocketClient(
             .ifBlank { optString("description") }
             .ifBlank { defaultShopItem(landmarkType.name)?.effectText.orEmpty() }
 
-    private fun JSONArray.toRangeText(): String {
-        val numbers = (0 until length()).mapNotNull { index ->
+    private fun JSONArray.toActivationNumbers(): List<Int> =
+        (0 until length()).mapNotNull { index ->
             runCatching { getInt(index) }.getOrNull()
-        }.sorted()
-        if (numbers.isEmpty()) return ""
-        return if (numbers.size == 1) {
-            numbers.first().toString()
-        } else {
-            "${numbers.first()}-${numbers.last()}"
-        }
-    }
+        }.distinct().sorted()
 
-    private fun String.toShopItemColor(): ShopItemColor =
-        runCatching { ShopItemColor.valueOf(this) }.getOrDefault(ShopItemColor.BLUE)
+    private fun String.toShopItemColor(fallback: ShopItemColor? = null): ShopItemColor =
+        runCatching { ShopItemColor.valueOf(this) }.getOrDefault(fallback ?: ShopItemColor.BLUE)
 
     private fun CardType.displayName(): String = name.toDisplayName()
 

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Marketplace.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Marketplace.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.machikoro.client.R
 import com.machikoro.client.domain.enums.CardType
+import com.machikoro.client.domain.model.shop.CardDefinitions
 import com.machikoro.client.domain.model.state.toDisplayText
 import com.machikoro.client.ui.theme.White
 
@@ -40,7 +41,7 @@ fun MarketplaceSection(
     recommendedCardType: CardType? = null,
     modifier: Modifier = Modifier
 ) {
-    val entries = CardType.entries.mapNotNull { type ->
+    val entries = CardDefinitions.sortCardTypesByActivation(CardType.entries).mapNotNull { type ->
         marketplace[type]?.let { count -> type to count }
     }
     Surface(
@@ -136,4 +137,3 @@ fun MarketplaceButton(
         }
     }
 }
-

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/PlayersTopBar.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/PlayersTopBar.kt
@@ -58,6 +58,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.machikoro.client.R
 import com.machikoro.client.domain.enums.CardType
 import com.machikoro.client.domain.enums.LandmarkType
+import com.machikoro.client.domain.model.shop.CardDefinitions
 import com.machikoro.client.domain.model.state.PlayerCardState
 import com.machikoro.client.domain.model.state.PlayerCoinState
 import com.machikoro.client.domain.model.state.PlayerLandmarkState
@@ -528,7 +529,7 @@ private fun <T> TwoColumnGrid(
 
 private fun List<PlayerCardState>.visibleInDisplayOrder(): List<PlayerCardState> {
     val cardsByType = filter { it.quantity > 0 }.associateBy { it.cardType }
-    return CardType.entries.mapNotNull { cardsByType[it] }
+    return CardDefinitions.sortCardTypesByActivation(cardsByType.keys).mapNotNull { cardsByType[it] }
 }
 
 private fun PlayerCoinState.snapshotId(): Int? = id.toIntOrNull()

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
@@ -46,6 +46,7 @@ import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.enums.LandmarkType
 import com.machikoro.client.domain.enums.PurchaseType
+import com.machikoro.client.domain.model.shop.CardDefinitions
 import com.machikoro.client.domain.model.shop.ShopItem
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.GameScreenState
@@ -82,9 +83,9 @@ internal fun BuyingPhaseShop(
     }
 
     val establishments = remember(items) {
-        items
-            .filter { it.purchaseType == PurchaseType.ESTABLISHMENT }
-            .sortedWith(compareBy<ShopItem> { it.cost }.thenBy { it.activationText }.thenBy { it.displayName })
+        CardDefinitions.sortShopItemsByActivation(
+            items.filter { it.purchaseType == PurchaseType.ESTABLISHMENT }
+        )
     }
 
     var selectedTab by remember {

--- a/app/src/test/java/com/machikoro/client/domain/model/shop/CardDefinitionsTest.kt
+++ b/app/src/test/java/com/machikoro/client/domain/model/shop/CardDefinitionsTest.kt
@@ -1,0 +1,62 @@
+package com.machikoro.client.domain.model.shop
+
+import com.machikoro.client.domain.enums.CardType
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class CardDefinitionsTest {
+    @Test
+    fun activationTextIsDerivedFromNumericActivationNumbers() {
+        val bakery = CardDefinitions.forType(CardType.BAKERY)
+
+        assertEquals(listOf(2, 3), bakery?.activationNumbers)
+        assertEquals("2-3", bakery?.activationText)
+    }
+
+    @Test
+    fun sortShopItemsByActivationUsesNumericActivationOrder() {
+        val items = listOf(
+            CardDefinitions.forType(CardType.FRUIT_AND_VEGETABLE_MARKET)!!.toShopItem(),
+            CardDefinitions.forType(CardType.CAFE)!!.toShopItem(),
+            CardDefinitions.forType(CardType.BAKERY)!!.toShopItem(),
+            CardDefinitions.forType(CardType.WHEAT_FIELD)!!.toShopItem(),
+        )
+
+        assertEquals(
+            listOf(
+                CardType.WHEAT_FIELD.name,
+                CardType.BAKERY.name,
+                CardType.CAFE.name,
+                CardType.FRUIT_AND_VEGETABLE_MARKET.name,
+            ),
+            CardDefinitions.sortShopItemsByActivation(items).map { it.type },
+        )
+    }
+
+    @Test
+    fun sortCardTypesByActivationUsesNumericActivationOrder() {
+        assertEquals(
+            listOf(
+                CardType.WHEAT_FIELD,
+                CardType.BAKERY,
+                CardType.CAFE,
+                CardType.FRUIT_AND_VEGETABLE_MARKET,
+            ),
+            CardDefinitions.sortCardTypesByActivation(
+                listOf(
+                    CardType.FRUIT_AND_VEGETABLE_MARKET,
+                    CardType.CAFE,
+                    CardType.BAKERY,
+                    CardType.WHEAT_FIELD,
+                )
+            ),
+        )
+    }
+
+    @Test
+    fun activationNumbersCanBeParsedFromLegacyDisplayText() {
+        assertEquals(listOf(9, 10), "9-10".toActivationNumbers())
+        assertEquals(listOf(11, 12), "11, 12".toActivationNumbers())
+        assertEquals(emptyList<Int>(), "Permanent".toActivationNumbers())
+    }
+}

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -2559,6 +2559,31 @@ class OkHttpWebSocketClientTest {
     }
 
     @Test
+    fun parseCardDefinitionsStoresNumericActivationNumbersAndDerivesText() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        factory.simulateText(
+            syncFrame(
+                """{"type":"SYNC","sender":"server","gameId":1,"payload":{"targetUserId":1,"state":{""" +
+                    """"game":{"id":1,"status":"IN_PROGRESS","turnPhase":"ROLL_DICE","currentTurnIndex":0},""" +
+                    """"players":[],"playerLandmarks":{},"marketplace":{"BAKERY":4},""" +
+                    """"cardDefinitions":[{"cardType":"BAKERY","cost":1,"color":"GREEN",""" +
+                    """"establishmentType":"BREAD","activationNumbers":[2,3],""" +
+                    """"effectText":"Get 1 coin from the bank on your turn."}],""" +
+                    """"landmarkDefinitions":[],"turnOrder":[]}}}"""
+            )
+        )
+
+        val bakery = client.shopItems.value.single { it.type == CardType.BAKERY.name }
+        assertEquals(listOf(2, 3), bakery.activationNumbers)
+        assertEquals("2-3", bakery.activationText)
+        assertTrue(bakery.isAvailable)
+    }
+
+    @Test
     fun parseLandmarkDefinitionsSkipsEntriesWithUnknownLandmarkType() {
         val factory = FakeWebSocketFactory()
         val client = newClient(factory)

--- a/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
@@ -829,7 +829,7 @@ class GameScreenViewModelTest {
                 color = ShopItemColor.GREEN,
                 imageKey = "bakery",
                 establishmentType = "Bakery",
-                activationText = "2-3",
+                activationNumbers = listOf(2, 3),
                 effectText = "Get 1 coin from the bank on your turn.",
             ),
             ShopItem(
@@ -840,7 +840,7 @@ class GameScreenViewModelTest {
                 color = ShopItemColor.RED,
                 imageKey = "cafe",
                 establishmentType = "Cafe",
-                activationText = "3",
+                activationNumbers = listOf(3),
                 effectText = "Take 1 coin from the active player.",
             ),
         )
@@ -879,7 +879,7 @@ class GameScreenViewModelTest {
                 color = ShopItemColor.GREEN,
                 imageKey = "bakery",
                 establishmentType = "Bakery",
-                activationText = "2-3",
+                activationNumbers = listOf(2, 3),
                 effectText = "Get 1 coin from the bank on your turn.",
             ),
         )


### PR DESCRIPTION
## Summary
- Centralize establishment card metadata into a shared client-side `CardDefinition` model.
- Store activation values as numeric `activationNumbers` and derive `activationText` for display.
- Parse websocket/server `cardDefinitions` into the same canonical model.
- Update shop, marketplace, player-card inventory, and cheat recommendation ordering/metadata usage to rely on numeric card definitions.
- Purchase flows still use server enum names via `CardType.name`.
