### PR TITLE
118 optional card library

### DIFF
--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -110,7 +110,7 @@ fun GameScreen(
             text = {
                 Text(
                     "Bet that ${accuseTarget.displayName} used the Insider Trading cheat. " +
-                            "If you're wrong, you lose a coin."
+                        "If you're wrong, you lose a coin."
                 )
             },
             confirmButton = {
@@ -149,8 +149,6 @@ fun GameScreen(
         when {
             showOwnCards -> 10
             showMarketplace -> 10
-            state.isBuyingPhase -> 30
-            state.gamePhase == GamePhase.ROLL_DICE -> 20
             else -> 0
         }
 

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -81,6 +81,7 @@ fun GameScreen(
     onPurchaseClick: (String) -> Unit = {},
     onBuySelectedClick: () -> Unit = {},
     onRollDice: (diceCount: Int) -> Unit = {},
+    onReroll: (diceCount: Int) -> Unit = {},
     onTurnFlowAction: () -> Unit = {},
     onLeaveGame: () -> Unit = {},
     onEndGame: () -> Unit = {},
@@ -88,6 +89,9 @@ fun GameScreen(
     onShake: () -> Unit = {},
     onAccuse: (accusedPlayerId: Int) -> Unit = {},
     canAccuse: Boolean = true,
+    // Radio Tower reroll budget (#326): false once the active player has rerolled
+    // this turn. Combined with [GameScreenState.canReroll] to show the button.
+    canReroll: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     ShakeDetector(
@@ -371,7 +375,6 @@ fun GameScreen(
                                 .fillMaxSize(),
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
-
                             Image(
                                 painter = painterResource(id = R.drawable.rotated_arrow),
                                 contentDescription = "Arrow",
@@ -466,7 +469,31 @@ fun GameScreen(
                         }
                     }
                 }
-            },
+
+                // Radio Tower reroll (#326): only the active player who built a
+                // Radio Tower may reroll, once, during RESOLVE_EFFECTS.
+                else if (state.canReroll && canReroll) {
+                    Row(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(bottom = 32.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        state.diceResult?.let { DiceResultDisplay(dice = it) }
+                        ActionButton(
+                            onClick = { onReroll(state.diceResult?.size ?: 1) },
+                            enabled = !state.isRolling,
+                            label = "Nochmal würfeln",
+                            leftIcon = R.drawable.game_dice_perspective,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Nochmal würfeln"
+                            }
+                        )
+                    }
+                }
+            }
+        },
 // =====================================
 // RIGHT
 // =====================================

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -85,8 +85,6 @@ fun GameScreen(
     onEndGame: () -> Unit = {},
     cheatRecommendation: CardType? = null,
     onShake: () -> Unit = {},
-    onAccuse: (accusedPlayerId: Int) -> Unit = {},
-    canAccuse: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     ShakeDetector(
@@ -94,55 +92,15 @@ fun GameScreen(
         onShake = onShake,
     )
 
-    // Cheating accusation (#280): the Accuse action in the player-inspection
-    // dialog opens this confirmation. Accusing wrongly costs a coin, so we
-    // always confirm first.
-    var accuseTargetId by remember { mutableStateOf<String?>(null) }
-    val accuseTarget = accuseTargetId?.let { id -> state.players.firstOrNull { it.id == id } }
-    if (accuseTarget != null) {
-        AlertDialog(
-            onDismissRequest = { accuseTargetId = null },
-            title = { Text("Accuse ${accuseTarget.displayName}?") },
-            text = {
-                Text(
-                    "Bet that ${accuseTarget.displayName} used the Insider Trading cheat. " +
-                            "If you're wrong, you lose a coin."
-                )
-            },
-            confirmButton = {
-                TextButton(
-                    onClick = {
-                        accuseTarget.id.toIntOrNull()?.let(onAccuse)
-                        accuseTargetId = null
-                    }
-                ) {
-                    Text("Accuse")
-                }
-            },
-            dismissButton = {
-                TextButton(onClick = { accuseTargetId = null }) {
-                    Text("Cancel")
-                }
-            },
-        )
-    }
-
     var showLeaveDialog by remember { mutableStateOf(false) }
     var showOwnCards by remember { mutableStateOf(false) }
     var showMarketplace by remember { mutableStateOf(false) }
-
-    val phaseTimerTime =
-        when {
-            state.isBuyingPhase -> 30
-            state.gamePhase == GamePhase.ROLL_DICE -> 20
-            state.gamePhase == GamePhase.RESOLVE_EFFECTS -> 25
-            else -> 0
-        }
-
-    val cardsTimerTime =
+    val timerTime =
         when {
             showOwnCards -> 10
             showMarketplace -> 10
+            state.isBuyingPhase -> 30
+            state.gamePhase == GamePhase.ROLL_DICE -> 20
             else -> 0
         }
 
@@ -245,289 +203,266 @@ fun GameScreen(
     Box {
 
 
-        GameScreenLayout(
-            // =====================================
-            // TOP BAR
-            // =====================================
-            topBar = {
-                Column(
+    GameScreenLayout(
+        // =====================================
+        // TOP BAR
+        // =====================================
+        topBar = {
+            Column(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Box(
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    Box(
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
 
-                        SecondaryActionButton(
-                            label = "Leave",
-                            modifier = Modifier.align(
-                                Alignment.CenterStart
-                            ),
-                            onClick = {
-                                showLeaveDialog = true
-                            }
-                        )
-
-                        PlayersTopBar(
-                            players = state.players,
-                            playerLandmarks =
-                                state.playerLandmarks,
-                            playerCards = state.playerCards,
-                            onAccusePlayer = { accuseTargetId = it },
-                            canAccuse = canAccuse,
-                            modifier = Modifier.align(
-                                Alignment.Center
-                            ),
-                        )
-
-                        state.roundNumber?.let { round ->
-                            RoundIndicator(
-                                round = round,
-                                modifier = Modifier.align(
-                                    Alignment.CenterEnd
-                                )
-                            )
+                    SecondaryActionButton(
+                        label = "Leave",
+                        modifier = Modifier.align(
+                            Alignment.CenterStart
+                        ),
+                        onClick = {
+                            showLeaveDialog = true
                         }
-                    }
+                    )
 
-                    Spacer(modifier = Modifier.height(8.dp))
+                    PlayersTopBar(
+                        players = state.players,
+                        playerLandmarks =
+                            state.playerLandmarks,
+                        playerCards = state.playerCards,
+                        modifier = Modifier.align(
+                            Alignment.Center
+                        ),
+                    )
 
-                    Column(
-                        modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .width(IntrinsicSize.Max),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-
-                        GamePhaseBanner(
-                            phase = state.gamePhase,
-                            text = state.customDisplayText
+                    state.roundNumber?.let { round ->
+                        RoundIndicator(
+                            round = round,
+                            modifier = Modifier.align(
+                                Alignment.CenterEnd
+                            )
                         )
-                        Box(
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .width(IntrinsicSize.Max),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+
+                    GamePhaseBanner(
+                        phase = state.gamePhase,
+                        text = state.customDisplayText
+                    )
+
+                    if (timerTime > 0) {
+                        DecreasingLineTimer(
+                            timerTime,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(top = 4.dp)
-                        ) {
-
-                            // phase timer stays alive
-                            if (phaseTimerTime > 0) {
-                                Box(
-                                    modifier = Modifier.alpha(
-                                        if (cardsTimerTime > 0) 0f else 1f
-                                    )
-                                ) {
-                                    DecreasingLineTimer(phaseTimerTime)
-                                }
-                            }
-
-                            // cards timer overlay
-                            if (cardsTimerTime > 0) {
-                                DecreasingLineTimer(cardsTimerTime)
-                            }
-                        }
-                    }
-                }
-            },
-
-            // =====================================
-            // LEFT
-            // =====================================
-            leftContent = {
-                Box(modifier = Modifier.fillMaxHeight()) {
-
-                    Box(modifier = Modifier.align(Alignment.Center)
-                    ) {
-                        if(state.gamePhase != GamePhase.ROLL_DICE) {
-                            state.diceResult?.let { DiceResultDisplay(dice = it) }
-                        }
-                    }
-
-                    Box(modifier = Modifier.align(Alignment.BottomCenter)) {
-                        MarketplaceButton(
-                            onClick = {
-                                showMarketplace = !showMarketplace
-                            },
-                            enabled = isCardViewPossible
                         )
-
                     }
                 }
-            },
+            }
+        },
 
-            // =====================================
-            // CENTER
-            // =====================================
-            centerContent = {
+        // =====================================
+        // LEFT
+        // =====================================
+        leftContent = {
+            Box(modifier = Modifier.fillMaxHeight()) {
 
-                Box(modifier = Modifier.align(Alignment.Center)) {
-                    if(
-                        showOwnCards
-                        && isCardViewPossible
-                        && !showMarketplace
-                    ) {
-                        Column(
-                            modifier = Modifier
-                                .align(Alignment.Center)
-                                .fillMaxSize(),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-
-                            Image(
-                                painter = painterResource(id = R.drawable.rotated_arrow),
-                                contentDescription = "Arrow",
-                                modifier = Modifier
-                                    .clickable {
-                                        showOwnCards = false
-                                    }
-                                    .size(35.dp)
-                            )
-                            BigPlayerCardsDisplay(
-                                state
-                            )
-                        }
-                    }
-
-                    else if(
-                        showMarketplace
-                        && isCardViewPossible
-                        && !showOwnCards
-                    ) {
-                        Column(
-                            modifier = Modifier
-                                .align(Alignment.Center)
-                                .fillMaxSize(),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-
-                            MarketplaceSection(state.marketplace)
-                        }
-                    }
-
-                    else if (state.isBuyingPhase) {
-                        if(state.isActivePlayer) {
-                            BuyingPhaseShop(
-                                state = state,
-                                items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
-                                onPurchaseClick = onPurchaseClick,
-                                recommendedCardType = cheatRecommendation,
-                                modifier = Modifier.align(Alignment.Center)
-                            )
-                        } else BasicText("Waiting for purchase")
-                    }
-
-                    else if (state.gamePhase == GamePhase.ROLL_DICE) {
-                        Row(
-                            modifier = Modifier
-                                .align(Alignment.Center)
-                                .padding(bottom = 32.dp),
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            when {
-                                state.isRolling -> DiceAnimationDisplay()
-                                state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
-                            }
-
-                            if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
-                                var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
-
-                                if (state.hasTrainStation) {
-                                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                        listOf(1, 2).forEach { count ->
-                                            Button(
-                                                onClick = { selectedDiceCount = count },
-                                                colors = ButtonDefaults.buttonColors(
-                                                    containerColor = if (selectedDiceCount == count)
-                                                        MaterialTheme.colorScheme.primary
-                                                    else
-                                                        MaterialTheme.colorScheme.surfaceVariant,
-                                                    contentColor = if (selectedDiceCount == count)
-                                                        MaterialTheme.colorScheme.onPrimary
-                                                    else
-                                                        MaterialTheme.colorScheme.onSurfaceVariant
-                                                )
-                                            ) {
-                                                Text("$count 🎲")
-                                            }
-                                        }
-                                    }
-                                }
-
-                                ActionButton(
-                                    onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
-                                    enabled = !state.isRolling,
-                                    label = if (state.diceResult == null) "Würfeln" else "Nochmal würfeln",
-                                    leftIcon = R.drawable.game_dice_perspective,
-                                    modifier = Modifier.semantics {
-                                        contentDescription = "Würfeln"
-                                    }
-                                )
-                            }
-                        }
-                    }
-                }
-            },
-// =====================================
-// RIGHT
-// =====================================
-            rightContent = {
-                Box(modifier = Modifier
-                    .fillMaxHeight()
-                    .width(140.dp)
+                Box(modifier = Modifier.align(Alignment.Center)
                 ) {
+                    if(state.gamePhase != GamePhase.ROLL_DICE) {
+                        state.diceResult?.let { DiceResultDisplay(dice = it) }
+                    }
+                }
 
-                    PlayerCoinField(
-                        state = state,
+                Box(modifier = Modifier.align(Alignment.BottomCenter)) {
+                      MarketplaceButton(
+                          onClick = {
+                              showMarketplace = !showMarketplace
+                          },
+                          enabled = isCardViewPossible
+                      )
+
+                }
+            }
+        },
+
+        // =====================================
+        // CENTER
+        // =====================================
+        centerContent = {
+
+            Box(modifier = Modifier.align(Alignment.Center)) {
+                if(
+                    showOwnCards
+                    && isCardViewPossible
+                    && !showMarketplace
+                ) {
+                    Column(
+                        modifier = Modifier.align(Alignment.Center)
+                            .fillMaxSize(),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+
+                        Image(
+                            painter = painterResource(id = R.drawable.rotated_arrow),
+                            contentDescription = "Arrow",
+                            modifier = Modifier.clickable {
+                                showOwnCards = false
+                            }
+                                .size(35.dp)
+                            )
+                        BigPlayerCardsDisplay(
+                            state
+                        )
+                    }
+                }
+
+                else if(
+                    showMarketplace
+                    && isCardViewPossible
+                    && !showOwnCards
+                ) {
+                    Column(
+                        modifier = Modifier.align(Alignment.Center)
+                            .fillMaxSize(),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+
+                        MarketplaceSection(state.marketplace)
+                    }
+                }
+
+                else if (state.isBuyingPhase) {
+                    if(state.isActivePlayer) {
+                        BuyingPhaseShop(
+                            state = state,
+                            items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
+                            onPurchaseClick = onPurchaseClick,
+                            recommendedCardType = cheatRecommendation,
+                            modifier = Modifier.align(Alignment.Center)
+                        )
+                    } else BasicText("Waiting for purchase")
+                }
+
+                else if (state.gamePhase == GamePhase.ROLL_DICE) {
+                    Row(
                         modifier = Modifier
                             .align(Alignment.Center)
-                            .offset(y = 45.dp)
-                    )
-
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                        modifier = modifier.align(Alignment.BottomCenter)
+                            .padding(bottom = 32.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
-                        val turnFlowLabel = state.turnFlowActionLabel()
-                        if (
-                            state.isActivePlayer &&
-                            state.gameStatus == GameStatus.IN_PROGRESS
-                        ) {
-                            turnFlowLabel?.let {
-                                ActionButton(
-                                    onClick = if (state.isBuyingPhase) onBuySelectedClick else onTurnFlowAction,
-                                    enabled = !state.isBuyingPhase || state.canConfirmSelectedPurchase(),
-                                    modifier = Modifier
-                                        .semantics {
-                                            contentDescription = turnFlowLabel
+                        when {
+                            state.isRolling -> DiceAnimationDisplay()
+                            state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
+                        }
+
+                        if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
+                            var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
+
+                            if (state.hasTrainStation) {
+                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    listOf(1, 2).forEach { count ->
+                                        Button(
+                                            onClick = { selectedDiceCount = count },
+                                            colors = ButtonDefaults.buttonColors(
+                                                containerColor = if (selectedDiceCount == count)
+                                                    MaterialTheme.colorScheme.primary
+                                                else
+                                                    MaterialTheme.colorScheme.surfaceVariant,
+                                                contentColor = if (selectedDiceCount == count)
+                                                    MaterialTheme.colorScheme.onPrimary
+                                                else
+                                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        ) {
+                                            Text("$count 🎲")
                                         }
-                                        .fillMaxWidth(),
-                                    label = turnFlowLabel,
-                                )
+                                    }
+                                }
                             }
 
-                            if (state.isBuyingPhase) {
-                                SecondaryActionButton(
-                                    onClick = onTurnFlowAction,
-                                    enabled = state.purchaseState != PurchaseState.PENDING,
-                                    modifier = Modifier
-                                        .semantics {
-                                            contentDescription = "Skip"
-                                        }
-                                        .fillMaxWidth(),
-                                    label = "Skip",
-                                )
-                            }
+                            ActionButton(
+                                onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
+                                enabled = !state.isRolling,
+                                label = if (state.diceResult == null) "Würfeln" else "Nochmal würfeln",
+                                leftIcon = R.drawable.game_dice_perspective,
+                                modifier = Modifier.semantics {
+                                    contentDescription = "Würfeln"
+                                }
+                            )
                         }
                     }
                 }
             }
-        )
+        },
+// =====================================
+// RIGHT
+// =====================================
+        rightContent = {
+            Box(modifier = Modifier.fillMaxHeight()
+                .width(140.dp)
+            ) {
+
+            PlayerCoinField(
+               state = state,
+                modifier = Modifier.align(Alignment.Center)
+                    .offset(y = 45.dp)
+            )
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = modifier.align(Alignment.BottomCenter)
+            ) {
+                val turnFlowLabel = state.turnFlowActionLabel()
+                if (
+                    state.isActivePlayer &&
+                    state.gameStatus == GameStatus.IN_PROGRESS
+                ) {
+                    turnFlowLabel?.let {
+                            ActionButton(
+                                onClick = if (state.isBuyingPhase) onBuySelectedClick else onTurnFlowAction,
+                                enabled = !state.isBuyingPhase || state.canConfirmSelectedPurchase(),
+                                modifier = Modifier.semantics {
+                                    contentDescription = turnFlowLabel
+                                }
+                                    .fillMaxWidth(),
+                                label = turnFlowLabel,
+                            )
+                    }
+
+                            if (state.isBuyingPhase) {
+                               SecondaryActionButton(
+                                   onClick = onTurnFlowAction,
+                                   enabled = state.purchaseState != PurchaseState.PENDING,
+                                   modifier = Modifier.semantics {
+                                       contentDescription = "Skip"
+                                   }
+                                       .fillMaxWidth(),
+                                   label = "Skip",
+                           )
+                        }
+                    }
+                }
+            }
+        }
+    )
 
         //Small own cards at the button
         if(isCardViewPossible && !showOwnCards && !showMarketplace) {
             Column(
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
+                modifier = Modifier.align(Alignment.BottomCenter)
                     .offset(y = 90.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
 
@@ -535,13 +470,12 @@ fun GameScreen(
                 Image(
                     painter = painterResource(id = R.drawable.arrow_button),
                     contentDescription = "Arrow",
-                    modifier = Modifier
-                        .clickable {
-                            showOwnCards = true
-                        }
+                    modifier = Modifier.clickable {
+                        showOwnCards = true
+                    }
                         .size(35.dp),
 
-                    )
+                )
                 Spacer(modifier = Modifier.height(4.dp))
                 PlayerCardsDisplay(
                     state,
@@ -550,26 +484,25 @@ fun GameScreen(
             }
         }
     }
-    InitializationLoadingOverlay(
-        connectionStatus = state.connectionStatus,
-        gameStatus = state.gameStatus
-    )
-}
+        InitializationLoadingOverlay(
+            connectionStatus = state.connectionStatus,
+            gameStatus = state.gameStatus
+        )
+    }
 
 
 private fun GameScreenState.turnFlowActionLabel(): String? = when (gamePhase) {
+    GamePhase.RESOLVE_EFFECTS -> "Resolve effects"
     GamePhase.BUY_OR_BUILD -> "Buy card"
-    // RESOLVE_EFFECTS auto-advances now (#302) — no manual "Resolve effects" button.
     GamePhase.NONE,
     GamePhase.ROLL_DICE,
-    GamePhase.RESOLVE_EFFECTS,
     GamePhase.END_TURN -> null
 }
 
 private fun GameScreenState.canConfirmSelectedPurchase(): Boolean =
     selectedPurchaseItemType != null &&
-            purchaseState != PurchaseState.PENDING &&
-            purchaseState != PurchaseState.SUCCESS
+        purchaseState != PurchaseState.PENDING &&
+        purchaseState != PurchaseState.SUCCESS
 
 // === PREVIEWS ===
 

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -137,8 +137,6 @@ fun GameScreen(
 
     val phaseTimerTime =
         when {
-            showOwnCards -> 10
-            showMarketplace -> 10
             state.isBuyingPhase -> 30
             state.gamePhase == GamePhase.ROLL_DICE -> 20
             state.gamePhase == GamePhase.RESOLVE_EFFECTS -> 25

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
@@ -138,6 +137,8 @@ fun GameScreen(
 
     val phaseTimerTime =
         when {
+            showOwnCards -> 10
+            showMarketplace -> 10
             state.isBuyingPhase -> 30
             state.gamePhase == GamePhase.ROLL_DICE -> 20
             state.gamePhase == GamePhase.RESOLVE_EFFECTS -> 25

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
@@ -130,12 +131,17 @@ fun GameScreen(
     var showLeaveDialog by remember { mutableStateOf(false) }
     var showOwnCards by remember { mutableStateOf(false) }
     var showMarketplace by remember { mutableStateOf(false) }
-    val timerTime =
+    val phaseTimerTime =
+        when {
+            state.isBuyingPhase -> 30
+            state.gamePhase == GamePhase.ROLL_DICE -> 20
+            else -> 0
+        }
+
+    val cardsTimerTime =
         when {
             showOwnCards -> 10
             showMarketplace -> 10
-            state.isBuyingPhase -> 30
-            state.gamePhase == GamePhase.ROLL_DICE -> 20
             else -> 0
         }
 
@@ -295,14 +301,27 @@ fun GameScreen(
                         phase = state.gamePhase,
                         text = state.customDisplayText
                     )
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 4.dp)
+                    ) {
 
-                    if (timerTime > 0) {
-                        DecreasingLineTimer(
-                            timerTime,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(top = 4.dp)
-                        )
+                        // phase timer stays alive
+                        if (phaseTimerTime > 0) {
+                            Box(
+                                modifier = Modifier.alpha(
+                                    if (cardsTimerTime > 0) 0f else 1f
+                                )
+                            ) {
+                                DecreasingLineTimer(phaseTimerTime)
+                            }
+                        }
+
+                        // cards timer overlay
+                        if (cardsTimerTime > 0) {
+                            DecreasingLineTimer(cardsTimerTime)
+                        }
                     }
                 }
             }
@@ -345,7 +364,8 @@ fun GameScreen(
                     && !showMarketplace
                 ) {
                     Column(
-                        modifier = Modifier.align(Alignment.Center)
+                        modifier = Modifier
+                            .align(Alignment.Center)
                             .fillMaxSize(),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
@@ -353,9 +373,10 @@ fun GameScreen(
                         Image(
                             painter = painterResource(id = R.drawable.rotated_arrow),
                             contentDescription = "Arrow",
-                            modifier = Modifier.clickable {
-                                showOwnCards = false
-                            }
+                            modifier = Modifier
+                                .clickable {
+                                    showOwnCards = false
+                                }
                                 .size(35.dp)
                             )
                         BigPlayerCardsDisplay(
@@ -370,7 +391,8 @@ fun GameScreen(
                     && !showOwnCards
                 ) {
                     Column(
-                        modifier = Modifier.align(Alignment.Center)
+                        modifier = Modifier
+                            .align(Alignment.Center)
                             .fillMaxSize(),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
@@ -447,13 +469,15 @@ fun GameScreen(
 // RIGHT
 // =====================================
         rightContent = {
-            Box(modifier = Modifier.fillMaxHeight()
+            Box(modifier = Modifier
+                .fillMaxHeight()
                 .width(140.dp)
             ) {
 
             PlayerCoinField(
                state = state,
-                modifier = Modifier.align(Alignment.Center)
+                modifier = Modifier
+                    .align(Alignment.Center)
                     .offset(y = 45.dp)
             )
 
@@ -471,9 +495,10 @@ fun GameScreen(
                             ActionButton(
                                 onClick = if (state.isBuyingPhase) onBuySelectedClick else onTurnFlowAction,
                                 enabled = !state.isBuyingPhase || state.canConfirmSelectedPurchase(),
-                                modifier = Modifier.semantics {
-                                    contentDescription = turnFlowLabel
-                                }
+                                modifier = Modifier
+                                    .semantics {
+                                        contentDescription = turnFlowLabel
+                                    }
                                     .fillMaxWidth(),
                                 label = turnFlowLabel,
                             )
@@ -483,9 +508,10 @@ fun GameScreen(
                                SecondaryActionButton(
                                    onClick = onTurnFlowAction,
                                    enabled = state.purchaseState != PurchaseState.PENDING,
-                                   modifier = Modifier.semantics {
-                                       contentDescription = "Skip"
-                                   }
+                                   modifier = Modifier
+                                       .semantics {
+                                           contentDescription = "Skip"
+                                       }
                                        .fillMaxWidth(),
                                    label = "Skip",
                            )
@@ -499,7 +525,8 @@ fun GameScreen(
         //Small own cards at the button
         if(isCardViewPossible && !showOwnCards && !showMarketplace) {
             Column(
-                modifier = Modifier.align(Alignment.BottomCenter)
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
                     .offset(y = 90.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
 
@@ -507,9 +534,10 @@ fun GameScreen(
                 Image(
                     painter = painterResource(id = R.drawable.arrow_button),
                     contentDescription = "Arrow",
-                    modifier = Modifier.clickable {
-                        showOwnCards = true
-                    }
+                    modifier = Modifier
+                        .clickable {
+                            showOwnCards = true
+                        }
                         .size(35.dp),
 
                 )

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
@@ -131,10 +130,14 @@ fun GameScreen(
     var showLeaveDialog by remember { mutableStateOf(false) }
     var showOwnCards by remember { mutableStateOf(false) }
     var showMarketplace by remember { mutableStateOf(false) }
+
     val phaseTimerTime =
         when {
+            showOwnCards -> 10
+            showMarketplace -> 10
             state.isBuyingPhase -> 30
             state.gamePhase == GamePhase.ROLL_DICE -> 20
+            state.gamePhase == GamePhase.RESOLVE_EFFECTS -> 25
             else -> 0
         }
 

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -15,7 +16,6 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -71,7 +71,8 @@ import com.machikoro.client.ui.shared.SecondaryActionButton
 import com.machikoro.client.ui.theme.ClientTheme
 import kotlinx.coroutines.delay
 
-private val SIDE_CENTER_CONTENT_OFFSET = (-35).dp
+private val OWN_CARDS_VIEW_DELAY = 10000L
+private val MARKETPLACE_VIEW_DELAY = 10000L
 
 @Composable
 fun GameScreen(
@@ -93,18 +94,39 @@ fun GameScreen(
 
     var showLeaveDialog by remember { mutableStateOf(false) }
     var showOwnCards by remember { mutableStateOf(false) }
+    var showMarketplace by remember { mutableStateOf(false) }
+    val timerTime =
+        when {
+            showOwnCards -> 10
+            showMarketplace -> 10
+            state.isBuyingPhase -> 30
+            state.gamePhase == GamePhase.ROLL_DICE -> 20
+            else -> 0
+        }
 
-
-    var isOwnCardsDisplayPermitted = ((state.gamePhase == GamePhase.ROLL_DICE || state.gamePhase == GamePhase.BUY_OR_BUILD )
+    val isCardViewPossible = ((state.gamePhase == GamePhase.ROLL_DICE || state.gamePhase == GamePhase.BUY_OR_BUILD )
             && !state.isActivePlayer)
 
-    LaunchedEffect(isOwnCardsDisplayPermitted) {
-        if (!isOwnCardsDisplayPermitted) {
+    LaunchedEffect(showOwnCards) {
+        if (showOwnCards) {
+            showMarketplace = false
+            delay(OWN_CARDS_VIEW_DELAY)
             showOwnCards = false
         }
     }
-
-
+    LaunchedEffect(showMarketplace) {
+        if (showMarketplace) {
+            showOwnCards = false
+            delay(MARKETPLACE_VIEW_DELAY)
+            showMarketplace = false
+        }
+    }
+    LaunchedEffect(isCardViewPossible) {
+        if (!isCardViewPossible) {
+            showOwnCards = false
+            showMarketplace = false
+        }
+    }
 
     if (showLeaveDialog) {
         AlertDialog(
@@ -225,11 +247,27 @@ fun GameScreen(
 
                 Spacer(modifier = Modifier.height(8.dp))
 
-                GamePhaseBanner(
-                    phase = state.gamePhase,
-                    modifier = Modifier.align(Alignment.CenterHorizontally),
-                    text = state.customDisplayText
-                )
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .width(IntrinsicSize.Max),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+
+                    GamePhaseBanner(
+                        phase = state.gamePhase,
+                        text = state.customDisplayText
+                    )
+
+                    if (timerTime > 0) {
+                        DecreasingLineTimer(
+                            timerTime,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 4.dp)
+                        )
+                    }
+                }
             }
         },
 
@@ -240,7 +278,6 @@ fun GameScreen(
             Box(modifier = Modifier.fillMaxHeight()) {
 
                 Box(modifier = Modifier.align(Alignment.Center)
-                    .offset(y = SIDE_CENTER_CONTENT_OFFSET)
                 ) {
                     if(state.gamePhase != GamePhase.ROLL_DICE) {
                         state.diceResult?.let { DiceResultDisplay(dice = it) }
@@ -248,7 +285,13 @@ fun GameScreen(
                 }
 
                 Box(modifier = Modifier.align(Alignment.BottomCenter)) {
-                    MarketplaceButton()
+                      MarketplaceButton(
+                          onClick = {
+                              showMarketplace = !showMarketplace
+                          },
+                          enabled = isCardViewPossible
+                      )
+
                 }
             }
         },
@@ -259,18 +302,17 @@ fun GameScreen(
         centerContent = {
 
             Box(modifier = Modifier.align(Alignment.Center)) {
-
-                if(showOwnCards && isOwnCardsDisplayPermitted) {
-                    LaunchedEffect(Unit) {
-                        delay(10000)
-                        showOwnCards = false
-                    }
+                if(
+                    showOwnCards
+                    && isCardViewPossible
+                    && !showMarketplace
+                ) {
                     Column(
                         modifier = Modifier.align(Alignment.Center)
                             .fillMaxSize(),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
-                        DecreasingLineTimer(10)
+
                         Image(
                             painter = painterResource(id = R.drawable.rotated_arrow),
                             contentDescription = "Arrow",
@@ -285,12 +327,19 @@ fun GameScreen(
                     }
                 }
 
-                else if (false) {
-                    MarketplaceSection(
-                        marketplace = state.marketplace,
-                        recommendedCardType = cheatRecommendation,
-                        modifier = Modifier.widthIn(max = 260.dp)
-                    )
+                else if(
+                    showMarketplace
+                    && isCardViewPossible
+                    && !showOwnCards
+                ) {
+                    Column(
+                        modifier = Modifier.align(Alignment.Center)
+                            .fillMaxSize(),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+
+                        MarketplaceSection(state.marketplace)
+                    }
                 }
 
                 else if (state.isBuyingPhase) {
@@ -367,8 +416,8 @@ fun GameScreen(
 
             PlayerCoinField(
                state = state,
-                modifier = Modifier.align(Alignment.CenterEnd)
-                    .offset(y = SIDE_CENTER_CONTENT_OFFSET)
+                modifier = Modifier.align(Alignment.Center)
+                    .offset(y = 45.dp)
             )
 
             Column(
@@ -410,7 +459,8 @@ fun GameScreen(
         }
     )
 
-        if(isOwnCardsDisplayPermitted && !showOwnCards) {
+        //Small own cards at the button
+        if(isCardViewPossible && !showOwnCards && !showMarketplace) {
             Column(
                 modifier = Modifier.align(Alignment.BottomCenter)
                     .offset(y = 90.dp),

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
@@ -148,6 +147,8 @@ fun GameScreen(
         when {
             showOwnCards -> 10
             showMarketplace -> 10
+            state.isBuyingPhase -> 30
+            state.gamePhase == GamePhase.ROLL_DICE -> 20
             else -> 0
         }
 

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -107,7 +107,7 @@ fun GameScreen(
             text = {
                 Text(
                     "Bet that ${accuseTarget.displayName} used the Insider Trading cheat. " +
-                        "If you're wrong, you lose a coin."
+                            "If you're wrong, you lose a coin."
                 )
             },
             confirmButton = {
@@ -134,8 +134,6 @@ fun GameScreen(
 
     val phaseTimerTime =
         when {
-            showOwnCards -> 10
-            showMarketplace -> 10
             state.isBuyingPhase -> 30
             state.gamePhase == GamePhase.ROLL_DICE -> 20
             state.gamePhase == GamePhase.RESOLVE_EFFECTS -> 25
@@ -248,283 +246,283 @@ fun GameScreen(
     Box {
 
 
-    GameScreenLayout(
-        // =====================================
-        // TOP BAR
-        // =====================================
-        topBar = {
-            Column(
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Box(
+        GameScreenLayout(
+            // =====================================
+            // TOP BAR
+            // =====================================
+            topBar = {
+                Column(
                     modifier = Modifier.fillMaxWidth()
                 ) {
-
-                    SecondaryActionButton(
-                        label = "Leave",
-                        modifier = Modifier.align(
-                            Alignment.CenterStart
-                        ),
-                        onClick = {
-                            showLeaveDialog = true
-                        }
-                    )
-
-                    PlayersTopBar(
-                        players = state.players,
-                        playerLandmarks =
-                            state.playerLandmarks,
-                        playerCards = state.playerCards,
-                        onAccusePlayer = { accuseTargetId = it },
-                        canAccuse = canAccuse,
-                        modifier = Modifier.align(
-                            Alignment.Center
-                        ),
-                    )
-
-                    state.roundNumber?.let { round ->
-                        RoundIndicator(
-                            round = round,
-                            modifier = Modifier.align(
-                                Alignment.CenterEnd
-                            )
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                Column(
-                    modifier = Modifier
-                        .align(Alignment.CenterHorizontally)
-                        .width(IntrinsicSize.Max),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-
-                    GamePhaseBanner(
-                        phase = state.gamePhase,
-                        text = state.customDisplayText
-                    )
                     Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 4.dp)
+                        modifier = Modifier.fillMaxWidth()
                     ) {
 
-                        // phase timer stays alive
-                        if (phaseTimerTime > 0) {
-                            Box(
-                                modifier = Modifier.alpha(
-                                    if (cardsTimerTime > 0) 0f else 1f
+                        SecondaryActionButton(
+                            label = "Leave",
+                            modifier = Modifier.align(
+                                Alignment.CenterStart
+                            ),
+                            onClick = {
+                                showLeaveDialog = true
+                            }
+                        )
+
+                        PlayersTopBar(
+                            players = state.players,
+                            playerLandmarks =
+                                state.playerLandmarks,
+                            playerCards = state.playerCards,
+                            onAccusePlayer = { accuseTargetId = it },
+                            canAccuse = canAccuse,
+                            modifier = Modifier.align(
+                                Alignment.Center
+                            ),
+                        )
+
+                        state.roundNumber?.let { round ->
+                            RoundIndicator(
+                                round = round,
+                                modifier = Modifier.align(
+                                    Alignment.CenterEnd
                                 )
-                            ) {
-                                DecreasingLineTimer(phaseTimerTime)
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .width(IntrinsicSize.Max),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+
+                        GamePhaseBanner(
+                            phase = state.gamePhase,
+                            text = state.customDisplayText
+                        )
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 4.dp)
+                        ) {
+
+                            // phase timer stays alive
+                            if (phaseTimerTime > 0) {
+                                Box(
+                                    modifier = Modifier.alpha(
+                                        if (cardsTimerTime > 0) 0f else 1f
+                                    )
+                                ) {
+                                    DecreasingLineTimer(phaseTimerTime)
+                                }
+                            }
+
+                            // cards timer overlay
+                            if (cardsTimerTime > 0) {
+                                DecreasingLineTimer(cardsTimerTime)
                             }
                         }
+                    }
+                }
+            },
 
-                        // cards timer overlay
-                        if (cardsTimerTime > 0) {
-                            DecreasingLineTimer(cardsTimerTime)
+            // =====================================
+            // LEFT
+            // =====================================
+            leftContent = {
+                Box(modifier = Modifier.fillMaxHeight()) {
+
+                    Box(modifier = Modifier.align(Alignment.Center)
+                    ) {
+                        if(state.gamePhase != GamePhase.ROLL_DICE) {
+                            state.diceResult?.let { DiceResultDisplay(dice = it) }
                         }
                     }
-                }
-            }
-        },
 
-        // =====================================
-        // LEFT
-        // =====================================
-        leftContent = {
-            Box(modifier = Modifier.fillMaxHeight()) {
+                    Box(modifier = Modifier.align(Alignment.BottomCenter)) {
+                        MarketplaceButton(
+                            onClick = {
+                                showMarketplace = !showMarketplace
+                            },
+                            enabled = isCardViewPossible
+                        )
 
-                Box(modifier = Modifier.align(Alignment.Center)
-                ) {
-                    if(state.gamePhase != GamePhase.ROLL_DICE) {
-                        state.diceResult?.let { DiceResultDisplay(dice = it) }
                     }
                 }
+            },
 
-                Box(modifier = Modifier.align(Alignment.BottomCenter)) {
-                      MarketplaceButton(
-                          onClick = {
-                              showMarketplace = !showMarketplace
-                          },
-                          enabled = isCardViewPossible
-                      )
+            // =====================================
+            // CENTER
+            // =====================================
+            centerContent = {
 
-                }
-            }
-        },
-
-        // =====================================
-        // CENTER
-        // =====================================
-        centerContent = {
-
-            Box(modifier = Modifier.align(Alignment.Center)) {
-                if(
-                    showOwnCards
-                    && isCardViewPossible
-                    && !showMarketplace
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .fillMaxSize(),
-                        horizontalAlignment = Alignment.CenterHorizontally
+                Box(modifier = Modifier.align(Alignment.Center)) {
+                    if(
+                        showOwnCards
+                        && isCardViewPossible
+                        && !showMarketplace
                     ) {
-
-                        Image(
-                            painter = painterResource(id = R.drawable.rotated_arrow),
-                            contentDescription = "Arrow",
+                        Column(
                             modifier = Modifier
-                                .clickable {
-                                    showOwnCards = false
-                                }
-                                .size(35.dp)
+                                .align(Alignment.Center)
+                                .fillMaxSize(),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+
+                            Image(
+                                painter = painterResource(id = R.drawable.rotated_arrow),
+                                contentDescription = "Arrow",
+                                modifier = Modifier
+                                    .clickable {
+                                        showOwnCards = false
+                                    }
+                                    .size(35.dp)
                             )
-                        BigPlayerCardsDisplay(
-                            state
-                        )
-                    }
-                }
-
-                else if(
-                    showMarketplace
-                    && isCardViewPossible
-                    && !showOwnCards
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .fillMaxSize(),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-
-                        MarketplaceSection(state.marketplace)
-                    }
-                }
-
-                else if (state.isBuyingPhase) {
-                    if(state.isActivePlayer) {
-                        BuyingPhaseShop(
-                            state = state,
-                            items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
-                            onPurchaseClick = onPurchaseClick,
-                            recommendedCardType = cheatRecommendation,
-                            modifier = Modifier.align(Alignment.Center)
-                        )
-                    } else BasicText("Waiting for purchase")
-                }
-
-                else if (state.gamePhase == GamePhase.ROLL_DICE) {
-                    Row(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .padding(bottom = 32.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        when {
-                            state.isRolling -> DiceAnimationDisplay()
-                            state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
+                            BigPlayerCardsDisplay(
+                                state
+                            )
                         }
+                    }
 
-                        if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
-                            var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
+                    else if(
+                        showMarketplace
+                        && isCardViewPossible
+                        && !showOwnCards
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .fillMaxSize(),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
 
-                            if (state.hasTrainStation) {
-                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                    listOf(1, 2).forEach { count ->
-                                        Button(
-                                            onClick = { selectedDiceCount = count },
-                                            colors = ButtonDefaults.buttonColors(
-                                                containerColor = if (selectedDiceCount == count)
-                                                    MaterialTheme.colorScheme.primary
-                                                else
-                                                    MaterialTheme.colorScheme.surfaceVariant,
-                                                contentColor = if (selectedDiceCount == count)
-                                                    MaterialTheme.colorScheme.onPrimary
-                                                else
-                                                    MaterialTheme.colorScheme.onSurfaceVariant
-                                            )
-                                        ) {
-                                            Text("$count 🎲")
+                            MarketplaceSection(state.marketplace)
+                        }
+                    }
+
+                    else if (state.isBuyingPhase) {
+                        if(state.isActivePlayer) {
+                            BuyingPhaseShop(
+                                state = state,
+                                items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
+                                onPurchaseClick = onPurchaseClick,
+                                recommendedCardType = cheatRecommendation,
+                                modifier = Modifier.align(Alignment.Center)
+                            )
+                        } else BasicText("Waiting for purchase")
+                    }
+
+                    else if (state.gamePhase == GamePhase.ROLL_DICE) {
+                        Row(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .padding(bottom = 32.dp),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            when {
+                                state.isRolling -> DiceAnimationDisplay()
+                                state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
+                            }
+
+                            if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
+                                var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
+
+                                if (state.hasTrainStation) {
+                                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                        listOf(1, 2).forEach { count ->
+                                            Button(
+                                                onClick = { selectedDiceCount = count },
+                                                colors = ButtonDefaults.buttonColors(
+                                                    containerColor = if (selectedDiceCount == count)
+                                                        MaterialTheme.colorScheme.primary
+                                                    else
+                                                        MaterialTheme.colorScheme.surfaceVariant,
+                                                    contentColor = if (selectedDiceCount == count)
+                                                        MaterialTheme.colorScheme.onPrimary
+                                                    else
+                                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                                )
+                                            ) {
+                                                Text("$count 🎲")
+                                            }
                                         }
                                     }
                                 }
-                            }
 
-                            ActionButton(
-                                onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
-                                enabled = !state.isRolling,
-                                label = if (state.diceResult == null) "Würfeln" else "Nochmal würfeln",
-                                leftIcon = R.drawable.game_dice_perspective,
-                                modifier = Modifier.semantics {
-                                    contentDescription = "Würfeln"
-                                }
-                            )
+                                ActionButton(
+                                    onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
+                                    enabled = !state.isRolling,
+                                    label = if (state.diceResult == null) "Würfeln" else "Nochmal würfeln",
+                                    leftIcon = R.drawable.game_dice_perspective,
+                                    modifier = Modifier.semantics {
+                                        contentDescription = "Würfeln"
+                                    }
+                                )
+                            }
                         }
                     }
                 }
-            }
-        },
+            },
 // =====================================
 // RIGHT
 // =====================================
-        rightContent = {
-            Box(modifier = Modifier
-                .fillMaxHeight()
-                .width(140.dp)
-            ) {
-
-            PlayerCoinField(
-               state = state,
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .offset(y = 45.dp)
-            )
-
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = modifier.align(Alignment.BottomCenter)
-            ) {
-                val turnFlowLabel = state.turnFlowActionLabel()
-                if (
-                    state.isActivePlayer &&
-                    state.gameStatus == GameStatus.IN_PROGRESS
+            rightContent = {
+                Box(modifier = Modifier
+                    .fillMaxHeight()
+                    .width(140.dp)
                 ) {
-                    turnFlowLabel?.let {
-                            ActionButton(
-                                onClick = if (state.isBuyingPhase) onBuySelectedClick else onTurnFlowAction,
-                                enabled = !state.isBuyingPhase || state.canConfirmSelectedPurchase(),
-                                modifier = Modifier
-                                    .semantics {
-                                        contentDescription = turnFlowLabel
-                                    }
-                                    .fillMaxWidth(),
-                                label = turnFlowLabel,
-                            )
-                    }
+
+                    PlayerCoinField(
+                        state = state,
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .offset(y = 45.dp)
+                    )
+
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = modifier.align(Alignment.BottomCenter)
+                    ) {
+                        val turnFlowLabel = state.turnFlowActionLabel()
+                        if (
+                            state.isActivePlayer &&
+                            state.gameStatus == GameStatus.IN_PROGRESS
+                        ) {
+                            turnFlowLabel?.let {
+                                ActionButton(
+                                    onClick = if (state.isBuyingPhase) onBuySelectedClick else onTurnFlowAction,
+                                    enabled = !state.isBuyingPhase || state.canConfirmSelectedPurchase(),
+                                    modifier = Modifier
+                                        .semantics {
+                                            contentDescription = turnFlowLabel
+                                        }
+                                        .fillMaxWidth(),
+                                    label = turnFlowLabel,
+                                )
+                            }
 
                             if (state.isBuyingPhase) {
-                               SecondaryActionButton(
-                                   onClick = onTurnFlowAction,
-                                   enabled = state.purchaseState != PurchaseState.PENDING,
-                                   modifier = Modifier
-                                       .semantics {
-                                           contentDescription = "Skip"
-                                       }
-                                       .fillMaxWidth(),
-                                   label = "Skip",
-                           )
+                                SecondaryActionButton(
+                                    onClick = onTurnFlowAction,
+                                    enabled = state.purchaseState != PurchaseState.PENDING,
+                                    modifier = Modifier
+                                        .semantics {
+                                            contentDescription = "Skip"
+                                        }
+                                        .fillMaxWidth(),
+                                    label = "Skip",
+                                )
+                            }
                         }
                     }
                 }
             }
-        }
-    )
+        )
 
         //Small own cards at the button
         if(isCardViewPossible && !showOwnCards && !showMarketplace) {
@@ -544,7 +542,7 @@ fun GameScreen(
                         }
                         .size(35.dp),
 
-                )
+                    )
                 Spacer(modifier = Modifier.height(4.dp))
                 PlayerCardsDisplay(
                     state,
@@ -553,11 +551,11 @@ fun GameScreen(
             }
         }
     }
-        InitializationLoadingOverlay(
-            connectionStatus = state.connectionStatus,
-            gameStatus = state.gameStatus
-        )
-    }
+    InitializationLoadingOverlay(
+        connectionStatus = state.connectionStatus,
+        gameStatus = state.gameStatus
+    )
+}
 
 
 private fun GameScreenState.turnFlowActionLabel(): String? = when (gamePhase) {
@@ -571,8 +569,8 @@ private fun GameScreenState.turnFlowActionLabel(): String? = when (gamePhase) {
 
 private fun GameScreenState.canConfirmSelectedPurchase(): Boolean =
     selectedPurchaseItemType != null &&
-        purchaseState != PurchaseState.PENDING &&
-        purchaseState != PurchaseState.SUCCESS
+            purchaseState != PurchaseState.PENDING &&
+            purchaseState != PurchaseState.SUCCESS
 
 // === PREVIEWS ===
 

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -250,222 +250,221 @@ fun GameScreen(
     Box {
 
 
-        GameScreenLayout(
-            // =====================================
-            // TOP BAR
-            // =====================================
-            topBar = {
-                Column(
+    GameScreenLayout(
+        // =====================================
+        // TOP BAR
+        // =====================================
+        topBar = {
+            Column(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Box(
                     modifier = Modifier.fillMaxWidth()
                 ) {
+
+                    SecondaryActionButton(
+                        label = "Leave",
+                        modifier = Modifier.align(
+                            Alignment.CenterStart
+                        ),
+                        onClick = {
+                            showLeaveDialog = true
+                        }
+                    )
+
+                    PlayersTopBar(
+                        players = state.players,
+                        playerLandmarks =
+                            state.playerLandmarks,
+                        playerCards = state.playerCards,
+                        onAccusePlayer = { accuseTargetId = it },
+                        canAccuse = canAccuse,
+                        modifier = Modifier.align(
+                            Alignment.Center
+                        ),
+                    )
+
+                    state.roundNumber?.let { round ->
+                        RoundIndicator(
+                            round = round,
+                            modifier = Modifier.align(
+                                Alignment.CenterEnd
+                            )
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .width(IntrinsicSize.Max),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+
+                    GamePhaseBanner(
+                        phase = state.gamePhase,
+                        text = state.customDisplayText
+                    )
                     Box(
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 4.dp)
                     ) {
 
-                        SecondaryActionButton(
-                            label = "Leave",
-                            modifier = Modifier.align(
-                                Alignment.CenterStart
-                            ),
-                            onClick = {
-                                showLeaveDialog = true
-                            }
-                        )
-
-                        PlayersTopBar(
-                            players = state.players,
-                            playerLandmarks =
-                                state.playerLandmarks,
-                            playerCards = state.playerCards,
-                            onAccusePlayer = { accuseTargetId = it },
-                            canAccuse = canAccuse,
-                            modifier = Modifier.align(
-                                Alignment.Center
-                            ),
-                        )
-
-                        state.roundNumber?.let { round ->
-                            RoundIndicator(
-                                round = round,
-                                modifier = Modifier.align(
-                                    Alignment.CenterEnd
+                        // phase timer stays alive
+                        if (phaseTimerTime > 0) {
+                            Box(
+                                modifier = Modifier.alpha(
+                                    if (cardsTimerTime > 0) 0f else 1f
                                 )
-                            )
+                            ) {
+                                DecreasingLineTimer(phaseTimerTime)
+                            }
+                        }
+
+                        // cards timer overlay
+                        if (cardsTimerTime > 0) {
+                            DecreasingLineTimer(cardsTimerTime)
                         }
                     }
+                }
+            }
+        },
 
-                    Spacer(modifier = Modifier.height(8.dp))
+        // =====================================
+        // LEFT
+        // =====================================
+        leftContent = {
+            Box(modifier = Modifier.fillMaxHeight()) {
 
+                Box(modifier = Modifier.align(Alignment.Center)
+                ) {
+                    if(state.gamePhase != GamePhase.ROLL_DICE) {
+                        state.diceResult?.let { DiceResultDisplay(dice = it) }
+                    }
+                }
+
+                Box(modifier = Modifier.align(Alignment.BottomCenter)) {
+                      MarketplaceButton(
+                          onClick = {
+                              showMarketplace = !showMarketplace
+                          },
+                          enabled = isCardViewPossible
+                      )
+
+                }
+            }
+        },
+
+        // =====================================
+        // CENTER
+        // =====================================
+        centerContent = {
+
+            Box(modifier = Modifier.align(Alignment.Center)) {
+                if(
+                    showOwnCards
+                    && isCardViewPossible
+                    && !showMarketplace
+                ) {
                     Column(
                         modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .width(IntrinsicSize.Max),
+                            .align(Alignment.Center)
+                            .fillMaxSize(),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Image(
+                            painter = painterResource(id = R.drawable.rotated_arrow),
+                            contentDescription = "Arrow",
+                            modifier = Modifier
+                                .clickable {
+                                    showOwnCards = false
+                                }
+                                .size(35.dp)
+                            )
+                        BigPlayerCardsDisplay(
+                            state
+                        )
+                    }
+                }
+
+                else if(
+                    showMarketplace
+                    && isCardViewPossible
+                    && !showOwnCards
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .fillMaxSize(),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
 
-                        GamePhaseBanner(
-                            phase = state.gamePhase,
-                            text = state.customDisplayText
-                        )
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(top = 4.dp)
-                        ) {
-
-                            // phase timer stays alive
-                            if (phaseTimerTime > 0) {
-                                Box(
-                                    modifier = Modifier.alpha(
-                                        if (cardsTimerTime > 0) 0f else 1f
-                                    )
-                                ) {
-                                    DecreasingLineTimer(phaseTimerTime)
-                                }
-                            }
-
-                            // cards timer overlay
-                            if (cardsTimerTime > 0) {
-                                DecreasingLineTimer(cardsTimerTime)
-                            }
-                        }
+                        MarketplaceSection(state.marketplace)
                     }
                 }
-            },
 
-            // =====================================
-            // LEFT
-            // =====================================
-            leftContent = {
-                Box(modifier = Modifier.fillMaxHeight()) {
-
-                    Box(modifier = Modifier.align(Alignment.Center)
-                    ) {
-                        if(state.gamePhase != GamePhase.ROLL_DICE) {
-                            state.diceResult?.let { DiceResultDisplay(dice = it) }
-                        }
-                    }
-
-                    Box(modifier = Modifier.align(Alignment.BottomCenter)) {
-                        MarketplaceButton(
-                            onClick = {
-                                showMarketplace = !showMarketplace
-                            },
-                            enabled = isCardViewPossible
+                else if (state.isBuyingPhase) {
+                    if(state.isActivePlayer) {
+                        BuyingPhaseShop(
+                            state = state,
+                            items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
+                            onPurchaseClick = onPurchaseClick,
+                            recommendedCardType = cheatRecommendation,
+                            modifier = Modifier.align(Alignment.Center)
                         )
-
-                    }
+                    } else BasicText("Waiting for purchase")
                 }
-            },
 
-            // =====================================
-            // CENTER
-            // =====================================
-            centerContent = {
-
-                Box(modifier = Modifier.align(Alignment.Center)) {
-                    if(
-                        showOwnCards
-                        && isCardViewPossible
-                        && !showMarketplace
+                else if (state.gamePhase == GamePhase.ROLL_DICE) {
+                    Row(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(bottom = 32.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Column(
-                            modifier = Modifier
-                                .align(Alignment.Center)
-                                .fillMaxSize(),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            Image(
-                                painter = painterResource(id = R.drawable.rotated_arrow),
-                                contentDescription = "Arrow",
-                                modifier = Modifier
-                                    .clickable {
-                                        showOwnCards = false
-                                    }
-                                    .size(35.dp)
-                            )
-                            BigPlayerCardsDisplay(
-                                state
-                            )
+                        when {
+                            state.isRolling -> DiceAnimationDisplay()
+                            state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
                         }
-                    }
 
-                    else if(
-                        showMarketplace
-                        && isCardViewPossible
-                        && !showOwnCards
-                    ) {
-                        Column(
-                            modifier = Modifier
-                                .align(Alignment.Center)
-                                .fillMaxSize(),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
+                        if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
+                            var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
 
-                            MarketplaceSection(state.marketplace)
-                        }
-                    }
-
-                    else if (state.isBuyingPhase) {
-                        if(state.isActivePlayer) {
-                            BuyingPhaseShop(
-                                state = state,
-                                items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
-                                onPurchaseClick = onPurchaseClick,
-                                recommendedCardType = cheatRecommendation,
-                                modifier = Modifier.align(Alignment.Center)
-                            )
-                        } else BasicText("Waiting for purchase")
-                    }
-
-                    else if (state.gamePhase == GamePhase.ROLL_DICE) {
-                        Row(
-                            modifier = Modifier
-                                .align(Alignment.Center)
-                                .padding(bottom = 32.dp),
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            when {
-                                state.isRolling -> DiceAnimationDisplay()
-                                state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
-                            }
-
-                            if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
-                                var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
-
-                                if (state.hasTrainStation) {
-                                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                        listOf(1, 2).forEach { count ->
-                                            Button(
-                                                onClick = { selectedDiceCount = count },
-                                                colors = ButtonDefaults.buttonColors(
-                                                    containerColor = if (selectedDiceCount == count)
-                                                        MaterialTheme.colorScheme.primary
-                                                    else
-                                                        MaterialTheme.colorScheme.surfaceVariant,
-                                                    contentColor = if (selectedDiceCount == count)
-                                                        MaterialTheme.colorScheme.onPrimary
-                                                    else
-                                                        MaterialTheme.colorScheme.onSurfaceVariant
-                                                )
-                                            ) {
-                                                Text("$count 🎲")
-                                            }
+                            if (state.hasTrainStation) {
+                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    listOf(1, 2).forEach { count ->
+                                        Button(
+                                            onClick = { selectedDiceCount = count },
+                                            colors = ButtonDefaults.buttonColors(
+                                                containerColor = if (selectedDiceCount == count)
+                                                    MaterialTheme.colorScheme.primary
+                                                else
+                                                    MaterialTheme.colorScheme.surfaceVariant,
+                                                contentColor = if (selectedDiceCount == count)
+                                                    MaterialTheme.colorScheme.onPrimary
+                                                else
+                                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        ) {
+                                            Text("$count 🎲")
                                         }
                                     }
                                 }
-
-                                ActionButton(
-                                    onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
-                                    enabled = !state.isRolling,
-                                    label = if (state.diceResult == null) "Würfeln" else "Nochmal würfeln",
-                                    leftIcon = R.drawable.game_dice_perspective,
-                                    modifier = Modifier.semantics {
-                                        contentDescription = "Würfeln"
-                                    }
-                                )
                             }
+
+                            ActionButton(
+                                onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
+                                enabled = !state.isRolling,
+                                label = if (state.diceResult == null) "Würfeln" else "Nochmal würfeln",
+                                leftIcon = R.drawable.game_dice_perspective,
+                                modifier = Modifier.semantics {
+                                    contentDescription = "Würfeln"
+                                }
+                            )
                         }
                     }
                 }
@@ -497,59 +496,59 @@ fun GameScreen(
 // =====================================
 // RIGHT
 // =====================================
-            rightContent = {
-                Box(modifier = Modifier
-                    .fillMaxHeight()
-                    .width(140.dp)
+        rightContent = {
+            Box(modifier = Modifier
+                .fillMaxHeight()
+                .width(140.dp)
+            ) {
+
+            PlayerCoinField(
+               state = state,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .offset(y = 45.dp)
+            )
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = modifier.align(Alignment.BottomCenter)
+            ) {
+                val turnFlowLabel = state.turnFlowActionLabel()
+                if (
+                    state.isActivePlayer &&
+                    state.gameStatus == GameStatus.IN_PROGRESS
                 ) {
-
-                    PlayerCoinField(
-                        state = state,
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .offset(y = 45.dp)
-                    )
-
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                        modifier = modifier.align(Alignment.BottomCenter)
-                    ) {
-                        val turnFlowLabel = state.turnFlowActionLabel()
-                        if (
-                            state.isActivePlayer &&
-                            state.gameStatus == GameStatus.IN_PROGRESS
-                        ) {
-                            turnFlowLabel?.let {
-                                ActionButton(
-                                    onClick = if (state.isBuyingPhase) onBuySelectedClick else onTurnFlowAction,
-                                    enabled = !state.isBuyingPhase || state.canConfirmSelectedPurchase(),
-                                    modifier = Modifier
-                                        .semantics {
-                                            contentDescription = turnFlowLabel
-                                        }
-                                        .fillMaxWidth(),
-                                    label = turnFlowLabel,
-                                )
-                            }
+                    turnFlowLabel?.let {
+                            ActionButton(
+                                onClick = if (state.isBuyingPhase) onBuySelectedClick else onTurnFlowAction,
+                                enabled = !state.isBuyingPhase || state.canConfirmSelectedPurchase(),
+                                modifier = Modifier
+                                    .semantics {
+                                        contentDescription = turnFlowLabel
+                                    }
+                                    .fillMaxWidth(),
+                                label = turnFlowLabel,
+                            )
+                    }
 
                             if (state.isBuyingPhase) {
-                                SecondaryActionButton(
-                                    onClick = onTurnFlowAction,
-                                    enabled = state.purchaseState != PurchaseState.PENDING,
-                                    modifier = Modifier
-                                        .semantics {
-                                            contentDescription = "Skip"
-                                        }
-                                        .fillMaxWidth(),
-                                    label = "Skip",
-                                )
-                            }
+                               SecondaryActionButton(
+                                   onClick = onTurnFlowAction,
+                                   enabled = state.purchaseState != PurchaseState.PENDING,
+                                   modifier = Modifier
+                                       .semantics {
+                                           contentDescription = "Skip"
+                                       }
+                                       .fillMaxWidth(),
+                                   label = "Skip",
+                           )
                         }
                     }
                 }
             }
-        )
+        }
+    )
 
         //Small own cards at the button
         if(isCardViewPossible && !showOwnCards && !showMarketplace) {
@@ -569,7 +568,7 @@ fun GameScreen(
                         }
                         .size(35.dp),
 
-                    )
+                )
                 Spacer(modifier = Modifier.height(4.dp))
                 PlayerCardsDisplay(
                     state,
@@ -578,11 +577,11 @@ fun GameScreen(
             }
         }
     }
-    InitializationLoadingOverlay(
-        connectionStatus = state.connectionStatus,
-        gameStatus = state.gameStatus
-    )
-}
+        InitializationLoadingOverlay(
+            connectionStatus = state.connectionStatus,
+            gameStatus = state.gameStatus
+        )
+    }
 
 
 private fun GameScreenState.turnFlowActionLabel(): String? = when (gamePhase) {
@@ -596,8 +595,8 @@ private fun GameScreenState.turnFlowActionLabel(): String? = when (gamePhase) {
 
 private fun GameScreenState.canConfirmSelectedPurchase(): Boolean =
     selectedPurchaseItemType != null &&
-            purchaseState != PurchaseState.PENDING &&
-            purchaseState != PurchaseState.SUCCESS
+        purchaseState != PurchaseState.PENDING &&
+        purchaseState != PurchaseState.SUCCESS
 
 // === PREVIEWS ===
 

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -250,223 +250,221 @@ fun GameScreen(
     Box {
 
 
-        GameScreenLayout(
-            // =====================================
-            // TOP BAR
-            // =====================================
-            topBar = {
-                Column(
+    GameScreenLayout(
+        // =====================================
+        // TOP BAR
+        // =====================================
+        topBar = {
+            Column(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Box(
                     modifier = Modifier.fillMaxWidth()
                 ) {
+
+                    SecondaryActionButton(
+                        label = "Leave",
+                        modifier = Modifier.align(
+                            Alignment.CenterStart
+                        ),
+                        onClick = {
+                            showLeaveDialog = true
+                        }
+                    )
+
+                    PlayersTopBar(
+                        players = state.players,
+                        playerLandmarks =
+                            state.playerLandmarks,
+                        playerCards = state.playerCards,
+                        onAccusePlayer = { accuseTargetId = it },
+                        canAccuse = canAccuse,
+                        modifier = Modifier.align(
+                            Alignment.Center
+                        ),
+                    )
+
+                    state.roundNumber?.let { round ->
+                        RoundIndicator(
+                            round = round,
+                            modifier = Modifier.align(
+                                Alignment.CenterEnd
+                            )
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .width(IntrinsicSize.Max),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+
+                    GamePhaseBanner(
+                        phase = state.gamePhase,
+                        text = state.customDisplayText
+                    )
                     Box(
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 4.dp)
                     ) {
 
-                        SecondaryActionButton(
-                            label = "Leave",
-                            modifier = Modifier.align(
-                                Alignment.CenterStart
-                            ),
-                            onClick = {
-                                showLeaveDialog = true
-                            }
-                        )
-
-                        PlayersTopBar(
-                            players = state.players,
-                            playerLandmarks =
-                                state.playerLandmarks,
-                            playerCards = state.playerCards,
-                            onAccusePlayer = { accuseTargetId = it },
-                            canAccuse = canAccuse,
-                            modifier = Modifier.align(
-                                Alignment.Center
-                            ),
-                        )
-
-                        state.roundNumber?.let { round ->
-                            RoundIndicator(
-                                round = round,
-                                modifier = Modifier.align(
-                                    Alignment.CenterEnd
+                        // phase timer stays alive
+                        if (phaseTimerTime > 0) {
+                            Box(
+                                modifier = Modifier.alpha(
+                                    if (cardsTimerTime > 0) 0f else 1f
                                 )
-                            )
+                            ) {
+                                DecreasingLineTimer(phaseTimerTime)
+                            }
+                        }
+
+                        // cards timer overlay
+                        if (cardsTimerTime > 0) {
+                            DecreasingLineTimer(cardsTimerTime)
                         }
                     }
+                }
+            }
+        },
 
-                    Spacer(modifier = Modifier.height(8.dp))
+        // =====================================
+        // LEFT
+        // =====================================
+        leftContent = {
+            Box(modifier = Modifier.fillMaxHeight()) {
 
+                Box(modifier = Modifier.align(Alignment.Center)
+                ) {
+                    if(state.gamePhase != GamePhase.ROLL_DICE) {
+                        state.diceResult?.let { DiceResultDisplay(dice = it) }
+                    }
+                }
+
+                Box(modifier = Modifier.align(Alignment.BottomCenter)) {
+                      MarketplaceButton(
+                          onClick = {
+                              showMarketplace = !showMarketplace
+                          },
+                          enabled = isCardViewPossible
+                      )
+
+                }
+            }
+        },
+
+        // =====================================
+        // CENTER
+        // =====================================
+        centerContent = {
+
+            Box(modifier = Modifier.align(Alignment.Center)) {
+                if(
+                    showOwnCards
+                    && isCardViewPossible
+                    && !showMarketplace
+                ) {
                     Column(
                         modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .width(IntrinsicSize.Max),
+                            .align(Alignment.Center)
+                            .fillMaxSize(),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Image(
+                            painter = painterResource(id = R.drawable.rotated_arrow),
+                            contentDescription = "Arrow",
+                            modifier = Modifier
+                                .clickable {
+                                    showOwnCards = false
+                                }
+                                .size(35.dp)
+                            )
+                        BigPlayerCardsDisplay(
+                            state
+                        )
+                    }
+                }
+
+                else if(
+                    showMarketplace
+                    && isCardViewPossible
+                    && !showOwnCards
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .fillMaxSize(),
                         horizontalAlignment = Alignment.CenterHorizontally
                     ) {
 
-                        GamePhaseBanner(
-                            phase = state.gamePhase,
-                            text = state.customDisplayText
-                        )
-                        Box(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(top = 4.dp)
-                        ) {
-
-                            // phase timer stays alive
-                            if (phaseTimerTime > 0) {
-                                Box(
-                                    modifier = Modifier.alpha(
-                                        if (cardsTimerTime > 0) 0f else 1f
-                                    )
-                                ) {
-                                    DecreasingLineTimer(phaseTimerTime)
-                                }
-                            }
-
-                            // cards timer overlay
-                            if (cardsTimerTime > 0) {
-                                DecreasingLineTimer(cardsTimerTime)
-                            }
-                        }
+                        MarketplaceSection(state.marketplace)
                     }
                 }
-            },
 
-            // =====================================
-            // LEFT
-            // =====================================
-            leftContent = {
-                Box(modifier = Modifier.fillMaxHeight()) {
-
-                    Box(modifier = Modifier.align(Alignment.Center)
-                    ) {
-                        if(state.gamePhase != GamePhase.ROLL_DICE) {
-                            state.diceResult?.let { DiceResultDisplay(dice = it) }
-                        }
-                    }
-
-                    Box(modifier = Modifier.align(Alignment.BottomCenter)) {
-                        MarketplaceButton(
-                            onClick = {
-                                showMarketplace = !showMarketplace
-                            },
-                            enabled = isCardViewPossible
+                else if (state.isBuyingPhase) {
+                    if(state.isActivePlayer) {
+                        BuyingPhaseShop(
+                            state = state,
+                            items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
+                            onPurchaseClick = onPurchaseClick,
+                            recommendedCardType = cheatRecommendation,
+                            modifier = Modifier.align(Alignment.Center)
                         )
-
-                    }
+                    } else BasicText("Waiting for purchase")
                 }
-            },
 
-            // =====================================
-            // CENTER
-            // =====================================
-            centerContent = {
-
-                Box(modifier = Modifier.align(Alignment.Center)) {
-                    if(
-                        showOwnCards
-                        && isCardViewPossible
-                        && !showMarketplace
+                else if (state.gamePhase == GamePhase.ROLL_DICE) {
+                    Row(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(bottom = 32.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Column(
-                            modifier = Modifier
-                                .align(Alignment.Center)
-                                .fillMaxSize(),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-
-                            Image(
-                                painter = painterResource(id = R.drawable.rotated_arrow),
-                                contentDescription = "Arrow",
-                                modifier = Modifier
-                                    .clickable {
-                                        showOwnCards = false
-                                    }
-                                    .size(35.dp)
-                            )
-                            BigPlayerCardsDisplay(
-                                state
-                            )
+                        when {
+                            state.isRolling -> DiceAnimationDisplay()
+                            state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
                         }
-                    }
 
-                    else if(
-                        showMarketplace
-                        && isCardViewPossible
-                        && !showOwnCards
-                    ) {
-                        Column(
-                            modifier = Modifier
-                                .align(Alignment.Center)
-                                .fillMaxSize(),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
+                        if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
+                            var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
 
-                            MarketplaceSection(state.marketplace)
-                        }
-                    }
-
-                    else if (state.isBuyingPhase) {
-                        if(state.isActivePlayer) {
-                            BuyingPhaseShop(
-                                state = state,
-                                items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
-                                onPurchaseClick = onPurchaseClick,
-                                recommendedCardType = cheatRecommendation,
-                                modifier = Modifier.align(Alignment.Center)
-                            )
-                        } else BasicText("Waiting for purchase")
-                    }
-
-                    else if (state.gamePhase == GamePhase.ROLL_DICE) {
-                        Row(
-                            modifier = Modifier
-                                .align(Alignment.Center)
-                                .padding(bottom = 32.dp),
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            when {
-                                state.isRolling -> DiceAnimationDisplay()
-                                state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
-                            }
-
-                            if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
-                                var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
-
-                                if (state.hasTrainStation) {
-                                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                        listOf(1, 2).forEach { count ->
-                                            Button(
-                                                onClick = { selectedDiceCount = count },
-                                                colors = ButtonDefaults.buttonColors(
-                                                    containerColor = if (selectedDiceCount == count)
-                                                        MaterialTheme.colorScheme.primary
-                                                    else
-                                                        MaterialTheme.colorScheme.surfaceVariant,
-                                                    contentColor = if (selectedDiceCount == count)
-                                                        MaterialTheme.colorScheme.onPrimary
-                                                    else
-                                                        MaterialTheme.colorScheme.onSurfaceVariant
-                                                )
-                                            ) {
-                                                Text("$count 🎲")
-                                            }
+                            if (state.hasTrainStation) {
+                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    listOf(1, 2).forEach { count ->
+                                        Button(
+                                            onClick = { selectedDiceCount = count },
+                                            colors = ButtonDefaults.buttonColors(
+                                                containerColor = if (selectedDiceCount == count)
+                                                    MaterialTheme.colorScheme.primary
+                                                else
+                                                    MaterialTheme.colorScheme.surfaceVariant,
+                                                contentColor = if (selectedDiceCount == count)
+                                                    MaterialTheme.colorScheme.onPrimary
+                                                else
+                                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        ) {
+                                            Text("$count 🎲")
                                         }
                                     }
                                 }
-
-                                ActionButton(
-                                    onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
-                                    enabled = !state.isRolling,
-                                    label = if (state.diceResult == null) "Würfeln" else "Nochmal würfeln",
-                                    leftIcon = R.drawable.game_dice_perspective,
-                                    modifier = Modifier.semantics {
-                                        contentDescription = "Würfeln"
-                                    }
-                                )
                             }
+
+                            ActionButton(
+                                onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
+                                enabled = !state.isRolling,
+                                label = if (state.diceResult == null) "Würfeln" else "Nochmal würfeln",
+                                leftIcon = R.drawable.game_dice_perspective,
+                                modifier = Modifier.semantics {
+                                    contentDescription = "Würfeln"
+                                }
+                            )
                         }
                     }
                 }
@@ -498,59 +496,59 @@ fun GameScreen(
 // =====================================
 // RIGHT
 // =====================================
-            rightContent = {
-                Box(modifier = Modifier
-                    .fillMaxHeight()
-                    .width(140.dp)
+        rightContent = {
+            Box(modifier = Modifier
+                .fillMaxHeight()
+                .width(140.dp)
+            ) {
+
+            PlayerCoinField(
+               state = state,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .offset(y = 45.dp)
+            )
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = modifier.align(Alignment.BottomCenter)
+            ) {
+                val turnFlowLabel = state.turnFlowActionLabel()
+                if (
+                    state.isActivePlayer &&
+                    state.gameStatus == GameStatus.IN_PROGRESS
                 ) {
-
-                    PlayerCoinField(
-                        state = state,
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .offset(y = 45.dp)
-                    )
-
-                    Column(
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                        modifier = modifier.align(Alignment.BottomCenter)
-                    ) {
-                        val turnFlowLabel = state.turnFlowActionLabel()
-                        if (
-                            state.isActivePlayer &&
-                            state.gameStatus == GameStatus.IN_PROGRESS
-                        ) {
-                            turnFlowLabel?.let {
-                                ActionButton(
-                                    onClick = if (state.isBuyingPhase) onBuySelectedClick else onTurnFlowAction,
-                                    enabled = !state.isBuyingPhase || state.canConfirmSelectedPurchase(),
-                                    modifier = Modifier
-                                        .semantics {
-                                            contentDescription = turnFlowLabel
-                                        }
-                                        .fillMaxWidth(),
-                                    label = turnFlowLabel,
-                                )
-                            }
+                    turnFlowLabel?.let {
+                            ActionButton(
+                                onClick = if (state.isBuyingPhase) onBuySelectedClick else onTurnFlowAction,
+                                enabled = !state.isBuyingPhase || state.canConfirmSelectedPurchase(),
+                                modifier = Modifier
+                                    .semantics {
+                                        contentDescription = turnFlowLabel
+                                    }
+                                    .fillMaxWidth(),
+                                label = turnFlowLabel,
+                            )
+                    }
 
                             if (state.isBuyingPhase) {
-                                SecondaryActionButton(
-                                    onClick = onTurnFlowAction,
-                                    enabled = state.purchaseState != PurchaseState.PENDING,
-                                    modifier = Modifier
-                                        .semantics {
-                                            contentDescription = "Skip"
-                                        }
-                                        .fillMaxWidth(),
-                                    label = "Skip",
-                                )
-                            }
+                               SecondaryActionButton(
+                                   onClick = onTurnFlowAction,
+                                   enabled = state.purchaseState != PurchaseState.PENDING,
+                                   modifier = Modifier
+                                       .semantics {
+                                           contentDescription = "Skip"
+                                       }
+                                       .fillMaxWidth(),
+                                   label = "Skip",
+                           )
                         }
                     }
                 }
             }
-        )
+        }
+    )
 
         //Small own cards at the button
         if(isCardViewPossible && !showOwnCards && !showMarketplace) {
@@ -570,7 +568,7 @@ fun GameScreen(
                         }
                         .size(35.dp),
 
-                    )
+                )
                 Spacer(modifier = Modifier.height(4.dp))
                 PlayerCardsDisplay(
                     state,
@@ -579,11 +577,11 @@ fun GameScreen(
             }
         }
     }
-    InitializationLoadingOverlay(
-        connectionStatus = state.connectionStatus,
-        gameStatus = state.gameStatus
-    )
-}
+        InitializationLoadingOverlay(
+            connectionStatus = state.connectionStatus,
+            gameStatus = state.gameStatus
+        )
+    }
 
 
 private fun GameScreenState.turnFlowActionLabel(): String? = when (gamePhase) {
@@ -597,8 +595,8 @@ private fun GameScreenState.turnFlowActionLabel(): String? = when (gamePhase) {
 
 private fun GameScreenState.canConfirmSelectedPurchase(): Boolean =
     selectedPurchaseItemType != null &&
-            purchaseState != PurchaseState.PENDING &&
-            purchaseState != PurchaseState.SUCCESS
+        purchaseState != PurchaseState.PENDING &&
+        purchaseState != PurchaseState.SUCCESS
 
 // === PREVIEWS ===
 

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -250,211 +250,212 @@ fun GameScreen(
     Box {
 
 
-    GameScreenLayout(
-        // =====================================
-        // TOP BAR
-        // =====================================
-        topBar = {
-            Column(
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Box(
+        GameScreenLayout(
+            // =====================================
+            // TOP BAR
+            // =====================================
+            topBar = {
+                Column(
                     modifier = Modifier.fillMaxWidth()
                 ) {
-
-                    SecondaryActionButton(
-                        label = "Leave",
-                        modifier = Modifier.align(
-                            Alignment.CenterStart
-                        ),
-                        onClick = {
-                            showLeaveDialog = true
-                        }
-                    )
-
-                    PlayersTopBar(
-                        players = state.players,
-                        playerLandmarks =
-                            state.playerLandmarks,
-                        playerCards = state.playerCards,
-                        onAccusePlayer = { accuseTargetId = it },
-                        canAccuse = canAccuse,
-                        modifier = Modifier.align(
-                            Alignment.Center
-                        ),
-                    )
-
-                    state.roundNumber?.let { round ->
-                        RoundIndicator(
-                            round = round,
-                            modifier = Modifier.align(
-                                Alignment.CenterEnd
-                            )
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                Column(
-                    modifier = Modifier
-                        .align(Alignment.CenterHorizontally)
-                        .width(IntrinsicSize.Max),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-
-                    GamePhaseBanner(
-                        phase = state.gamePhase,
-                        text = state.customDisplayText
-                    )
                     Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 4.dp)
+                        modifier = Modifier.fillMaxWidth()
                     ) {
 
-                        // phase timer stays alive
-                        if (phaseTimerTime > 0) {
-                            Box(
-                                modifier = Modifier.alpha(
-                                    if (cardsTimerTime > 0) 0f else 1f
+                        SecondaryActionButton(
+                            label = "Leave",
+                            modifier = Modifier.align(
+                                Alignment.CenterStart
+                            ),
+                            onClick = {
+                                showLeaveDialog = true
+                            }
+                        )
+
+                        PlayersTopBar(
+                            players = state.players,
+                            playerLandmarks =
+                                state.playerLandmarks,
+                            playerCards = state.playerCards,
+                            onAccusePlayer = { accuseTargetId = it },
+                            canAccuse = canAccuse,
+                            modifier = Modifier.align(
+                                Alignment.Center
+                            ),
+                        )
+
+                        state.roundNumber?.let { round ->
+                            RoundIndicator(
+                                round = round,
+                                modifier = Modifier.align(
+                                    Alignment.CenterEnd
                                 )
-                            ) {
-                                DecreasingLineTimer(phaseTimerTime)
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .width(IntrinsicSize.Max),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+
+                        GamePhaseBanner(
+                            phase = state.gamePhase,
+                            text = state.customDisplayText
+                        )
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 4.dp)
+                        ) {
+
+                            // phase timer stays alive
+                            if (phaseTimerTime > 0) {
+                                Box(
+                                    modifier = Modifier.alpha(
+                                        if (cardsTimerTime > 0) 0f else 1f
+                                    )
+                                ) {
+                                    DecreasingLineTimer(phaseTimerTime)
+                                }
+                            }
+
+                            // cards timer overlay
+                            if (cardsTimerTime > 0) {
+                                DecreasingLineTimer(cardsTimerTime)
                             }
                         }
+                    }
+                }
+            },
 
-                        // cards timer overlay
-                        if (cardsTimerTime > 0) {
-                            DecreasingLineTimer(cardsTimerTime)
+            // =====================================
+            // LEFT
+            // =====================================
+            leftContent = {
+                Box(modifier = Modifier.fillMaxHeight()) {
+
+                    Box(modifier = Modifier.align(Alignment.Center)
+                    ) {
+                        if(state.gamePhase != GamePhase.ROLL_DICE) {
+                            state.diceResult?.let { DiceResultDisplay(dice = it) }
                         }
                     }
-                }
-            }
-        },
 
-        // =====================================
-        // LEFT
-        // =====================================
-        leftContent = {
-            Box(modifier = Modifier.fillMaxHeight()) {
+                    Box(modifier = Modifier.align(Alignment.BottomCenter)) {
+                        MarketplaceButton(
+                            onClick = {
+                                showMarketplace = !showMarketplace
+                            },
+                            enabled = isCardViewPossible
+                        )
 
-                Box(modifier = Modifier.align(Alignment.Center)
-                ) {
-                    if(state.gamePhase != GamePhase.ROLL_DICE) {
-                        state.diceResult?.let { DiceResultDisplay(dice = it) }
                     }
                 }
+            },
 
-                Box(modifier = Modifier.align(Alignment.BottomCenter)) {
-                      MarketplaceButton(
-                          onClick = {
-                              showMarketplace = !showMarketplace
-                          },
-                          enabled = isCardViewPossible
-                      )
+            // =====================================
+            // CENTER
+            // =====================================
+            centerContent = {
 
-                }
-            }
-        },
-
-        // =====================================
-        // CENTER
-        // =====================================
-        centerContent = {
-
-            Box(modifier = Modifier.align(Alignment.Center)) {
-                if(
-                    showOwnCards
-                    && isCardViewPossible
-                    && !showMarketplace
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .fillMaxSize(),
-                        horizontalAlignment = Alignment.CenterHorizontally
+                Box(modifier = Modifier.align(Alignment.Center)) {
+                    if(
+                        showOwnCards
+                        && isCardViewPossible
+                        && !showMarketplace
                     ) {
-                        Image(
-                            painter = painterResource(id = R.drawable.rotated_arrow),
-                            contentDescription = "Arrow",
+                        Column(
                             modifier = Modifier
-                                .clickable {
-                                    showOwnCards = false
-                                }
-                                .size(35.dp)
+                                .align(Alignment.Center)
+                                .fillMaxSize(),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+
+                            Image(
+                                painter = painterResource(id = R.drawable.rotated_arrow),
+                                contentDescription = "Arrow",
+                                modifier = Modifier
+                                    .clickable {
+                                        showOwnCards = false
+                                    }
+                                    .size(35.dp)
                             )
-                        BigPlayerCardsDisplay(
-                            state
-                        )
-                    }
-                }
-
-                else if(
-                    showMarketplace
-                    && isCardViewPossible
-                    && !showOwnCards
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .fillMaxSize(),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-
-                        MarketplaceSection(state.marketplace)
-                    }
-                }
-
-                else if (state.isBuyingPhase) {
-                    if(state.isActivePlayer) {
-                        BuyingPhaseShop(
-                            state = state,
-                            items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
-                            onPurchaseClick = onPurchaseClick,
-                            recommendedCardType = cheatRecommendation,
-                            modifier = Modifier.align(Alignment.Center)
-                        )
-                    } else BasicText("Waiting for purchase")
-                }
-
-                else if (state.gamePhase == GamePhase.ROLL_DICE) {
-                    Row(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .padding(bottom = 32.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        when {
-                            state.isRolling -> DiceAnimationDisplay()
-                            state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
+                            BigPlayerCardsDisplay(
+                                state
+                            )
                         }
+                    }
 
-                        if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
-                            var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
+                    else if(
+                        showMarketplace
+                        && isCardViewPossible
+                        && !showOwnCards
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .fillMaxSize(),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
 
-                            if (state.hasTrainStation) {
-                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                    listOf(1, 2).forEach { count ->
-                                        Button(
-                                            onClick = { selectedDiceCount = count },
-                                            colors = ButtonDefaults.buttonColors(
-                                                containerColor = if (selectedDiceCount == count)
-                                                    MaterialTheme.colorScheme.primary
-                                                else
-                                                    MaterialTheme.colorScheme.surfaceVariant,
-                                                contentColor = if (selectedDiceCount == count)
-                                                    MaterialTheme.colorScheme.onPrimary
-                                                else
-                                                    MaterialTheme.colorScheme.onSurfaceVariant
-                                            )
-                                        ) {
-                                            Text("$count 🎲")
+                            MarketplaceSection(state.marketplace)
+                        }
+                    }
+
+                    else if (state.isBuyingPhase) {
+                        if(state.isActivePlayer) {
+                            BuyingPhaseShop(
+                                state = state,
+                                items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
+                                onPurchaseClick = onPurchaseClick,
+                                recommendedCardType = cheatRecommendation,
+                                modifier = Modifier.align(Alignment.Center)
+                            )
+                        } else BasicText("Waiting for purchase")
+                    }
+
+                    else if (state.gamePhase == GamePhase.ROLL_DICE) {
+                        Row(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .padding(bottom = 32.dp),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            when {
+                                state.isRolling -> DiceAnimationDisplay()
+                                state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
+                            }
+
+                            if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
+                                var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
+
+                                if (state.hasTrainStation) {
+                                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                        listOf(1, 2).forEach { count ->
+                                            Button(
+                                                onClick = { selectedDiceCount = count },
+                                                colors = ButtonDefaults.buttonColors(
+                                                    containerColor = if (selectedDiceCount == count)
+                                                        MaterialTheme.colorScheme.primary
+                                                    else
+                                                        MaterialTheme.colorScheme.surfaceVariant,
+                                                    contentColor = if (selectedDiceCount == count)
+                                                        MaterialTheme.colorScheme.onPrimary
+                                                    else
+                                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                                )
+                                            ) {
+                                                Text("$count 🎲")
+                                            }
                                         }
                                     }
                                 }
-                            }
 
                             ActionButton(
                                 onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
@@ -496,59 +497,59 @@ fun GameScreen(
 // =====================================
 // RIGHT
 // =====================================
-        rightContent = {
-            Box(modifier = Modifier
-                .fillMaxHeight()
-                .width(140.dp)
-            ) {
-
-            PlayerCoinField(
-               state = state,
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .offset(y = 45.dp)
-            )
-
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = modifier.align(Alignment.BottomCenter)
-            ) {
-                val turnFlowLabel = state.turnFlowActionLabel()
-                if (
-                    state.isActivePlayer &&
-                    state.gameStatus == GameStatus.IN_PROGRESS
+            rightContent = {
+                Box(modifier = Modifier
+                    .fillMaxHeight()
+                    .width(140.dp)
                 ) {
-                    turnFlowLabel?.let {
-                            ActionButton(
-                                onClick = if (state.isBuyingPhase) onBuySelectedClick else onTurnFlowAction,
-                                enabled = !state.isBuyingPhase || state.canConfirmSelectedPurchase(),
-                                modifier = Modifier
-                                    .semantics {
-                                        contentDescription = turnFlowLabel
-                                    }
-                                    .fillMaxWidth(),
-                                label = turnFlowLabel,
-                            )
-                    }
+
+                    PlayerCoinField(
+                        state = state,
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .offset(y = 45.dp)
+                    )
+
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = modifier.align(Alignment.BottomCenter)
+                    ) {
+                        val turnFlowLabel = state.turnFlowActionLabel()
+                        if (
+                            state.isActivePlayer &&
+                            state.gameStatus == GameStatus.IN_PROGRESS
+                        ) {
+                            turnFlowLabel?.let {
+                                ActionButton(
+                                    onClick = if (state.isBuyingPhase) onBuySelectedClick else onTurnFlowAction,
+                                    enabled = !state.isBuyingPhase || state.canConfirmSelectedPurchase(),
+                                    modifier = Modifier
+                                        .semantics {
+                                            contentDescription = turnFlowLabel
+                                        }
+                                        .fillMaxWidth(),
+                                    label = turnFlowLabel,
+                                )
+                            }
 
                             if (state.isBuyingPhase) {
-                               SecondaryActionButton(
-                                   onClick = onTurnFlowAction,
-                                   enabled = state.purchaseState != PurchaseState.PENDING,
-                                   modifier = Modifier
-                                       .semantics {
-                                           contentDescription = "Skip"
-                                       }
-                                       .fillMaxWidth(),
-                                   label = "Skip",
-                           )
+                                SecondaryActionButton(
+                                    onClick = onTurnFlowAction,
+                                    enabled = state.purchaseState != PurchaseState.PENDING,
+                                    modifier = Modifier
+                                        .semantics {
+                                            contentDescription = "Skip"
+                                        }
+                                        .fillMaxWidth(),
+                                    label = "Skip",
+                                )
+                            }
                         }
                     }
                 }
             }
-        }
-    )
+        )
 
         //Small own cards at the button
         if(isCardViewPossible && !showOwnCards && !showMarketplace) {
@@ -568,7 +569,7 @@ fun GameScreen(
                         }
                         .size(35.dp),
 
-                )
+                    )
                 Spacer(modifier = Modifier.height(4.dp))
                 PlayerCardsDisplay(
                     state,
@@ -577,11 +578,11 @@ fun GameScreen(
             }
         }
     }
-        InitializationLoadingOverlay(
-            connectionStatus = state.connectionStatus,
-            gameStatus = state.gameStatus
-        )
-    }
+    InitializationLoadingOverlay(
+        connectionStatus = state.connectionStatus,
+        gameStatus = state.gameStatus
+    )
+}
 
 
 private fun GameScreenState.turnFlowActionLabel(): String? = when (gamePhase) {
@@ -595,8 +596,8 @@ private fun GameScreenState.turnFlowActionLabel(): String? = when (gamePhase) {
 
 private fun GameScreenState.canConfirmSelectedPurchase(): Boolean =
     selectedPurchaseItemType != null &&
-        purchaseState != PurchaseState.PENDING &&
-        purchaseState != PurchaseState.SUCCESS
+            purchaseState != PurchaseState.PENDING &&
+            purchaseState != PurchaseState.SUCCESS
 
 // === PREVIEWS ===
 

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -137,6 +137,8 @@ fun GameScreen(
 
     val phaseTimerTime =
         when {
+            showOwnCards -> 10
+            showMarketplace -> 10
             state.isBuyingPhase -> 30
             state.gamePhase == GamePhase.ROLL_DICE -> 20
             state.gamePhase == GamePhase.RESOLVE_EFFECTS -> 25

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.contentDescription
@@ -85,6 +86,8 @@ fun GameScreen(
     onEndGame: () -> Unit = {},
     cheatRecommendation: CardType? = null,
     onShake: () -> Unit = {},
+    onAccuse: (accusedPlayerId: Int) -> Unit = {},
+    canAccuse: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     ShakeDetector(
@@ -92,15 +95,55 @@ fun GameScreen(
         onShake = onShake,
     )
 
+    // Cheating accusation (#280): the Accuse action in the player-inspection
+    // dialog opens this confirmation. Accusing wrongly costs a coin, so we
+    // always confirm first.
+    var accuseTargetId by remember { mutableStateOf<String?>(null) }
+    val accuseTarget = accuseTargetId?.let { id -> state.players.firstOrNull { it.id == id } }
+    if (accuseTarget != null) {
+        AlertDialog(
+            onDismissRequest = { accuseTargetId = null },
+            title = { Text("Accuse ${accuseTarget.displayName}?") },
+            text = {
+                Text(
+                    "Bet that ${accuseTarget.displayName} used the Insider Trading cheat. " +
+                            "If you're wrong, you lose a coin."
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        accuseTarget.id.toIntOrNull()?.let(onAccuse)
+                        accuseTargetId = null
+                    }
+                ) {
+                    Text("Accuse")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { accuseTargetId = null }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+
     var showLeaveDialog by remember { mutableStateOf(false) }
     var showOwnCards by remember { mutableStateOf(false) }
     var showMarketplace by remember { mutableStateOf(false) }
-    val timerTime =
+
+    val phaseTimerTime =
+        when {
+            state.isBuyingPhase -> 30
+            state.gamePhase == GamePhase.ROLL_DICE -> 20
+            state.gamePhase == GamePhase.RESOLVE_EFFECTS -> 25
+            else -> 0
+        }
+
+    val cardsTimerTime =
         when {
             showOwnCards -> 10
             showMarketplace -> 10
-            state.isBuyingPhase -> 30
-            state.gamePhase == GamePhase.ROLL_DICE -> 20
             else -> 0
         }
 
@@ -203,266 +246,289 @@ fun GameScreen(
     Box {
 
 
-    GameScreenLayout(
-        // =====================================
-        // TOP BAR
-        // =====================================
-        topBar = {
-            Column(
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Box(
+        GameScreenLayout(
+            // =====================================
+            // TOP BAR
+            // =====================================
+            topBar = {
+                Column(
                     modifier = Modifier.fillMaxWidth()
                 ) {
+                    Box(
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
 
-                    SecondaryActionButton(
-                        label = "Leave",
-                        modifier = Modifier.align(
-                            Alignment.CenterStart
-                        ),
-                        onClick = {
-                            showLeaveDialog = true
-                        }
-                    )
-
-                    PlayersTopBar(
-                        players = state.players,
-                        playerLandmarks =
-                            state.playerLandmarks,
-                        playerCards = state.playerCards,
-                        modifier = Modifier.align(
-                            Alignment.Center
-                        ),
-                    )
-
-                    state.roundNumber?.let { round ->
-                        RoundIndicator(
-                            round = round,
+                        SecondaryActionButton(
+                            label = "Leave",
                             modifier = Modifier.align(
-                                Alignment.CenterEnd
-                            )
+                                Alignment.CenterStart
+                            ),
+                            onClick = {
+                                showLeaveDialog = true
+                            }
                         )
+
+                        PlayersTopBar(
+                            players = state.players,
+                            playerLandmarks =
+                                state.playerLandmarks,
+                            playerCards = state.playerCards,
+                            onAccusePlayer = { accuseTargetId = it },
+                            canAccuse = canAccuse,
+                            modifier = Modifier.align(
+                                Alignment.Center
+                            ),
+                        )
+
+                        state.roundNumber?.let { round ->
+                            RoundIndicator(
+                                round = round,
+                                modifier = Modifier.align(
+                                    Alignment.CenterEnd
+                                )
+                            )
+                        }
                     }
-                }
 
-                Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(8.dp))
 
-                Column(
-                    modifier = Modifier
-                        .align(Alignment.CenterHorizontally)
-                        .width(IntrinsicSize.Max),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .width(IntrinsicSize.Max),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
 
-                    GamePhaseBanner(
-                        phase = state.gamePhase,
-                        text = state.customDisplayText
-                    )
-
-                    if (timerTime > 0) {
-                        DecreasingLineTimer(
-                            timerTime,
+                        GamePhaseBanner(
+                            phase = state.gamePhase,
+                            text = state.customDisplayText
+                        )
+                        Box(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(top = 4.dp)
-                        )
-                    }
-                }
-            }
-        },
+                        ) {
 
-        // =====================================
-        // LEFT
-        // =====================================
-        leftContent = {
-            Box(modifier = Modifier.fillMaxHeight()) {
-
-                Box(modifier = Modifier.align(Alignment.Center)
-                ) {
-                    if(state.gamePhase != GamePhase.ROLL_DICE) {
-                        state.diceResult?.let { DiceResultDisplay(dice = it) }
-                    }
-                }
-
-                Box(modifier = Modifier.align(Alignment.BottomCenter)) {
-                      MarketplaceButton(
-                          onClick = {
-                              showMarketplace = !showMarketplace
-                          },
-                          enabled = isCardViewPossible
-                      )
-
-                }
-            }
-        },
-
-        // =====================================
-        // CENTER
-        // =====================================
-        centerContent = {
-
-            Box(modifier = Modifier.align(Alignment.Center)) {
-                if(
-                    showOwnCards
-                    && isCardViewPossible
-                    && !showMarketplace
-                ) {
-                    Column(
-                        modifier = Modifier.align(Alignment.Center)
-                            .fillMaxSize(),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-
-                        Image(
-                            painter = painterResource(id = R.drawable.rotated_arrow),
-                            contentDescription = "Arrow",
-                            modifier = Modifier.clickable {
-                                showOwnCards = false
+                            // phase timer stays alive
+                            if (phaseTimerTime > 0) {
+                                Box(
+                                    modifier = Modifier.alpha(
+                                        if (cardsTimerTime > 0) 0f else 1f
+                                    )
+                                ) {
+                                    DecreasingLineTimer(phaseTimerTime)
+                                }
                             }
-                                .size(35.dp)
-                            )
-                        BigPlayerCardsDisplay(
-                            state
-                        )
-                    }
-                }
 
-                else if(
-                    showMarketplace
-                    && isCardViewPossible
-                    && !showOwnCards
-                ) {
-                    Column(
-                        modifier = Modifier.align(Alignment.Center)
-                            .fillMaxSize(),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-
-                        MarketplaceSection(state.marketplace)
-                    }
-                }
-
-                else if (state.isBuyingPhase) {
-                    if(state.isActivePlayer) {
-                        BuyingPhaseShop(
-                            state = state,
-                            items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
-                            onPurchaseClick = onPurchaseClick,
-                            recommendedCardType = cheatRecommendation,
-                            modifier = Modifier.align(Alignment.Center)
-                        )
-                    } else BasicText("Waiting for purchase")
-                }
-
-                else if (state.gamePhase == GamePhase.ROLL_DICE) {
-                    Row(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .padding(bottom = 32.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        when {
-                            state.isRolling -> DiceAnimationDisplay()
-                            state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
+                            // cards timer overlay
+                            if (cardsTimerTime > 0) {
+                                DecreasingLineTimer(cardsTimerTime)
+                            }
                         }
+                    }
+                }
+            },
 
-                        if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
-                            var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
+            // =====================================
+            // LEFT
+            // =====================================
+            leftContent = {
+                Box(modifier = Modifier.fillMaxHeight()) {
 
-                            if (state.hasTrainStation) {
-                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                    listOf(1, 2).forEach { count ->
-                                        Button(
-                                            onClick = { selectedDiceCount = count },
-                                            colors = ButtonDefaults.buttonColors(
-                                                containerColor = if (selectedDiceCount == count)
-                                                    MaterialTheme.colorScheme.primary
-                                                else
-                                                    MaterialTheme.colorScheme.surfaceVariant,
-                                                contentColor = if (selectedDiceCount == count)
-                                                    MaterialTheme.colorScheme.onPrimary
-                                                else
-                                                    MaterialTheme.colorScheme.onSurfaceVariant
-                                            )
-                                        ) {
-                                            Text("$count 🎲")
+                    Box(modifier = Modifier.align(Alignment.Center)
+                    ) {
+                        if(state.gamePhase != GamePhase.ROLL_DICE) {
+                            state.diceResult?.let { DiceResultDisplay(dice = it) }
+                        }
+                    }
+
+                    Box(modifier = Modifier.align(Alignment.BottomCenter)) {
+                        MarketplaceButton(
+                            onClick = {
+                                showMarketplace = !showMarketplace
+                            },
+                            enabled = isCardViewPossible
+                        )
+
+                    }
+                }
+            },
+
+            // =====================================
+            // CENTER
+            // =====================================
+            centerContent = {
+
+                Box(modifier = Modifier.align(Alignment.Center)) {
+                    if(
+                        showOwnCards
+                        && isCardViewPossible
+                        && !showMarketplace
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .fillMaxSize(),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+
+                            Image(
+                                painter = painterResource(id = R.drawable.rotated_arrow),
+                                contentDescription = "Arrow",
+                                modifier = Modifier
+                                    .clickable {
+                                        showOwnCards = false
+                                    }
+                                    .size(35.dp)
+                            )
+                            BigPlayerCardsDisplay(
+                                state
+                            )
+                        }
+                    }
+
+                    else if(
+                        showMarketplace
+                        && isCardViewPossible
+                        && !showOwnCards
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .fillMaxSize(),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+
+                            MarketplaceSection(state.marketplace)
+                        }
+                    }
+
+                    else if (state.isBuyingPhase) {
+                        if(state.isActivePlayer) {
+                            BuyingPhaseShop(
+                                state = state,
+                                items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
+                                onPurchaseClick = onPurchaseClick,
+                                recommendedCardType = cheatRecommendation,
+                                modifier = Modifier.align(Alignment.Center)
+                            )
+                        } else BasicText("Waiting for purchase")
+                    }
+
+                    else if (state.gamePhase == GamePhase.ROLL_DICE) {
+                        Row(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .padding(bottom = 32.dp),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            when {
+                                state.isRolling -> DiceAnimationDisplay()
+                                state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
+                            }
+
+                            if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
+                                var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
+
+                                if (state.hasTrainStation) {
+                                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                        listOf(1, 2).forEach { count ->
+                                            Button(
+                                                onClick = { selectedDiceCount = count },
+                                                colors = ButtonDefaults.buttonColors(
+                                                    containerColor = if (selectedDiceCount == count)
+                                                        MaterialTheme.colorScheme.primary
+                                                    else
+                                                        MaterialTheme.colorScheme.surfaceVariant,
+                                                    contentColor = if (selectedDiceCount == count)
+                                                        MaterialTheme.colorScheme.onPrimary
+                                                    else
+                                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                                )
+                                            ) {
+                                                Text("$count 🎲")
+                                            }
                                         }
                                     }
                                 }
-                            }
 
-                            ActionButton(
-                                onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
-                                enabled = !state.isRolling,
-                                label = if (state.diceResult == null) "Würfeln" else "Nochmal würfeln",
-                                leftIcon = R.drawable.game_dice_perspective,
-                                modifier = Modifier.semantics {
-                                    contentDescription = "Würfeln"
-                                }
-                            )
+                                ActionButton(
+                                    onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
+                                    enabled = !state.isRolling,
+                                    label = if (state.diceResult == null) "Würfeln" else "Nochmal würfeln",
+                                    leftIcon = R.drawable.game_dice_perspective,
+                                    modifier = Modifier.semantics {
+                                        contentDescription = "Würfeln"
+                                    }
+                                )
+                            }
                         }
                     }
                 }
-            }
-        },
+            },
 // =====================================
 // RIGHT
 // =====================================
-        rightContent = {
-            Box(modifier = Modifier.fillMaxHeight()
-                .width(140.dp)
-            ) {
-
-            PlayerCoinField(
-               state = state,
-                modifier = Modifier.align(Alignment.Center)
-                    .offset(y = 45.dp)
-            )
-
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = modifier.align(Alignment.BottomCenter)
-            ) {
-                val turnFlowLabel = state.turnFlowActionLabel()
-                if (
-                    state.isActivePlayer &&
-                    state.gameStatus == GameStatus.IN_PROGRESS
+            rightContent = {
+                Box(modifier = Modifier
+                    .fillMaxHeight()
+                    .width(140.dp)
                 ) {
-                    turnFlowLabel?.let {
-                            ActionButton(
-                                onClick = if (state.isBuyingPhase) onBuySelectedClick else onTurnFlowAction,
-                                enabled = !state.isBuyingPhase || state.canConfirmSelectedPurchase(),
-                                modifier = Modifier.semantics {
-                                    contentDescription = turnFlowLabel
-                                }
-                                    .fillMaxWidth(),
-                                label = turnFlowLabel,
-                            )
-                    }
+
+                    PlayerCoinField(
+                        state = state,
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .offset(y = 45.dp)
+                    )
+
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = modifier.align(Alignment.BottomCenter)
+                    ) {
+                        val turnFlowLabel = state.turnFlowActionLabel()
+                        if (
+                            state.isActivePlayer &&
+                            state.gameStatus == GameStatus.IN_PROGRESS
+                        ) {
+                            turnFlowLabel?.let {
+                                ActionButton(
+                                    onClick = if (state.isBuyingPhase) onBuySelectedClick else onTurnFlowAction,
+                                    enabled = !state.isBuyingPhase || state.canConfirmSelectedPurchase(),
+                                    modifier = Modifier
+                                        .semantics {
+                                            contentDescription = turnFlowLabel
+                                        }
+                                        .fillMaxWidth(),
+                                    label = turnFlowLabel,
+                                )
+                            }
 
                             if (state.isBuyingPhase) {
-                               SecondaryActionButton(
-                                   onClick = onTurnFlowAction,
-                                   enabled = state.purchaseState != PurchaseState.PENDING,
-                                   modifier = Modifier.semantics {
-                                       contentDescription = "Skip"
-                                   }
-                                       .fillMaxWidth(),
-                                   label = "Skip",
-                           )
+                                SecondaryActionButton(
+                                    onClick = onTurnFlowAction,
+                                    enabled = state.purchaseState != PurchaseState.PENDING,
+                                    modifier = Modifier
+                                        .semantics {
+                                            contentDescription = "Skip"
+                                        }
+                                        .fillMaxWidth(),
+                                    label = "Skip",
+                                )
+                            }
                         }
                     }
                 }
             }
-        }
-    )
+        )
 
         //Small own cards at the button
         if(isCardViewPossible && !showOwnCards && !showMarketplace) {
             Column(
-                modifier = Modifier.align(Alignment.BottomCenter)
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
                     .offset(y = 90.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
 
@@ -470,12 +536,13 @@ fun GameScreen(
                 Image(
                     painter = painterResource(id = R.drawable.arrow_button),
                     contentDescription = "Arrow",
-                    modifier = Modifier.clickable {
-                        showOwnCards = true
-                    }
+                    modifier = Modifier
+                        .clickable {
+                            showOwnCards = true
+                        }
                         .size(35.dp),
 
-                )
+                    )
                 Spacer(modifier = Modifier.height(4.dp))
                 PlayerCardsDisplay(
                     state,
@@ -484,25 +551,26 @@ fun GameScreen(
             }
         }
     }
-        InitializationLoadingOverlay(
-            connectionStatus = state.connectionStatus,
-            gameStatus = state.gameStatus
-        )
-    }
+    InitializationLoadingOverlay(
+        connectionStatus = state.connectionStatus,
+        gameStatus = state.gameStatus
+    )
+}
 
 
 private fun GameScreenState.turnFlowActionLabel(): String? = when (gamePhase) {
-    GamePhase.RESOLVE_EFFECTS -> "Resolve effects"
     GamePhase.BUY_OR_BUILD -> "Buy card"
+    // RESOLVE_EFFECTS auto-advances now (#302) — no manual "Resolve effects" button.
     GamePhase.NONE,
     GamePhase.ROLL_DICE,
+    GamePhase.RESOLVE_EFFECTS,
     GamePhase.END_TURN -> null
 }
 
 private fun GameScreenState.canConfirmSelectedPurchase(): Boolean =
     selectedPurchaseItemType != null &&
-        purchaseState != PurchaseState.PENDING &&
-        purchaseState != PurchaseState.SUCCESS
+            purchaseState != PurchaseState.PENDING &&
+            purchaseState != PurchaseState.SUCCESS
 
 // === PREVIEWS ===
 

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -80,7 +80,6 @@ fun GameScreen(
     onPurchaseClick: (String) -> Unit = {},
     onBuySelectedClick: () -> Unit = {},
     onRollDice: (diceCount: Int) -> Unit = {},
-    onReroll: (diceCount: Int) -> Unit = {},
     onTurnFlowAction: () -> Unit = {},
     onLeaveGame: () -> Unit = {},
     onEndGame: () -> Unit = {},
@@ -88,9 +87,6 @@ fun GameScreen(
     onShake: () -> Unit = {},
     onAccuse: (accusedPlayerId: Int) -> Unit = {},
     canAccuse: Boolean = true,
-    // Radio Tower reroll budget (#326): false once the active player has rerolled
-    // this turn. Combined with [GameScreenState.canReroll] to show the button.
-    canReroll: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     ShakeDetector(
@@ -110,7 +106,7 @@ fun GameScreen(
             text = {
                 Text(
                     "Bet that ${accuseTarget.displayName} used the Insider Trading cheat. " +
-                        "If you're wrong, you lose a coin."
+                            "If you're wrong, you lose a coin."
                 )
             },
             confirmButton = {
@@ -137,8 +133,6 @@ fun GameScreen(
 
     val phaseTimerTime =
         when {
-            showOwnCards -> 10
-            showMarketplace -> 10
             state.isBuyingPhase -> 30
             state.gamePhase == GamePhase.ROLL_DICE -> 20
             state.gamePhase == GamePhase.RESOLVE_EFFECTS -> 25
@@ -251,305 +245,283 @@ fun GameScreen(
     Box {
 
 
-    GameScreenLayout(
-        // =====================================
-        // TOP BAR
-        // =====================================
-        topBar = {
-            Column(
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Box(
+        GameScreenLayout(
+            // =====================================
+            // TOP BAR
+            // =====================================
+            topBar = {
+                Column(
                     modifier = Modifier.fillMaxWidth()
                 ) {
-
-                    SecondaryActionButton(
-                        label = "Leave",
-                        modifier = Modifier.align(
-                            Alignment.CenterStart
-                        ),
-                        onClick = {
-                            showLeaveDialog = true
-                        }
-                    )
-
-                    PlayersTopBar(
-                        players = state.players,
-                        playerLandmarks =
-                            state.playerLandmarks,
-                        playerCards = state.playerCards,
-                        onAccusePlayer = { accuseTargetId = it },
-                        canAccuse = canAccuse,
-                        modifier = Modifier.align(
-                            Alignment.Center
-                        ),
-                    )
-
-                    state.roundNumber?.let { round ->
-                        RoundIndicator(
-                            round = round,
-                            modifier = Modifier.align(
-                                Alignment.CenterEnd
-                            )
-                        )
-                    }
-                }
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                Column(
-                    modifier = Modifier
-                        .align(Alignment.CenterHorizontally)
-                        .width(IntrinsicSize.Max),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-
-                    GamePhaseBanner(
-                        phase = state.gamePhase,
-                        text = state.customDisplayText
-                    )
                     Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(top = 4.dp)
+                        modifier = Modifier.fillMaxWidth()
                     ) {
 
-                        // phase timer stays alive
-                        if (phaseTimerTime > 0) {
-                            Box(
-                                modifier = Modifier.alpha(
-                                    if (cardsTimerTime > 0) 0f else 1f
+                        SecondaryActionButton(
+                            label = "Leave",
+                            modifier = Modifier.align(
+                                Alignment.CenterStart
+                            ),
+                            onClick = {
+                                showLeaveDialog = true
+                            }
+                        )
+
+                        PlayersTopBar(
+                            players = state.players,
+                            playerLandmarks =
+                                state.playerLandmarks,
+                            playerCards = state.playerCards,
+                            onAccusePlayer = { accuseTargetId = it },
+                            canAccuse = canAccuse,
+                            modifier = Modifier.align(
+                                Alignment.Center
+                            ),
+                        )
+
+                        state.roundNumber?.let { round ->
+                            RoundIndicator(
+                                round = round,
+                                modifier = Modifier.align(
+                                    Alignment.CenterEnd
                                 )
-                            ) {
-                                DecreasingLineTimer(phaseTimerTime)
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .width(IntrinsicSize.Max),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+
+                        GamePhaseBanner(
+                            phase = state.gamePhase,
+                            text = state.customDisplayText
+                        )
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 4.dp)
+                        ) {
+
+                            // phase timer stays alive
+                            if (phaseTimerTime > 0) {
+                                Box(
+                                    modifier = Modifier.alpha(
+                                        if (cardsTimerTime > 0) 0f else 1f
+                                    )
+                                ) {
+                                    DecreasingLineTimer(phaseTimerTime)
+                                }
+                            }
+
+                            // cards timer overlay
+                            if (cardsTimerTime > 0) {
+                                DecreasingLineTimer(cardsTimerTime)
                             }
                         }
+                    }
+                }
+            },
 
-                        // cards timer overlay
-                        if (cardsTimerTime > 0) {
-                            DecreasingLineTimer(cardsTimerTime)
+            // =====================================
+            // LEFT
+            // =====================================
+            leftContent = {
+                Box(modifier = Modifier.fillMaxHeight()) {
+
+                    Box(modifier = Modifier.align(Alignment.Center)
+                    ) {
+                        if(state.gamePhase != GamePhase.ROLL_DICE) {
+                            state.diceResult?.let { DiceResultDisplay(dice = it) }
                         }
                     }
-                }
-            }
-        },
 
-        // =====================================
-        // LEFT
-        // =====================================
-        leftContent = {
-            Box(modifier = Modifier.fillMaxHeight()) {
+                    Box(modifier = Modifier.align(Alignment.BottomCenter)) {
+                        MarketplaceButton(
+                            onClick = {
+                                showMarketplace = !showMarketplace
+                            },
+                            enabled = isCardViewPossible
+                        )
 
-                Box(modifier = Modifier.align(Alignment.Center)
-                ) {
-                    if(state.gamePhase != GamePhase.ROLL_DICE) {
-                        state.diceResult?.let { DiceResultDisplay(dice = it) }
                     }
                 }
+            },
 
-                Box(modifier = Modifier.align(Alignment.BottomCenter)) {
-                      MarketplaceButton(
-                          onClick = {
-                              showMarketplace = !showMarketplace
-                          },
-                          enabled = isCardViewPossible
-                      )
+            // =====================================
+            // CENTER
+            // =====================================
+            centerContent = {
 
-                }
-            }
-        },
-
-        // =====================================
-        // CENTER
-        // =====================================
-        centerContent = {
-
-            Box(modifier = Modifier.align(Alignment.Center)) {
-                if(
-                    showOwnCards
-                    && isCardViewPossible
-                    && !showMarketplace
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .fillMaxSize(),
-                        horizontalAlignment = Alignment.CenterHorizontally
+                Box(modifier = Modifier.align(Alignment.Center)) {
+                    if(
+                        showOwnCards
+                        && isCardViewPossible
+                        && !showMarketplace
                     ) {
-                        Image(
-                            painter = painterResource(id = R.drawable.rotated_arrow),
-                            contentDescription = "Arrow",
+                        Column(
                             modifier = Modifier
-                                .clickable {
-                                    showOwnCards = false
-                                }
-                                .size(35.dp)
+                                .align(Alignment.Center)
+                                .fillMaxSize(),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+
+                            Image(
+                                painter = painterResource(id = R.drawable.rotated_arrow),
+                                contentDescription = "Arrow",
+                                modifier = Modifier
+                                    .clickable {
+                                        showOwnCards = false
+                                    }
+                                    .size(35.dp)
                             )
-                        BigPlayerCardsDisplay(
-                            state
-                        )
-                    }
-                }
-
-                else if(
-                    showMarketplace
-                    && isCardViewPossible
-                    && !showOwnCards
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .fillMaxSize(),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
-
-                        MarketplaceSection(state.marketplace)
-                    }
-                }
-
-                else if (state.isBuyingPhase) {
-                    if(state.isActivePlayer) {
-                        BuyingPhaseShop(
-                            state = state,
-                            items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
-                            onPurchaseClick = onPurchaseClick,
-                            recommendedCardType = cheatRecommendation,
-                            modifier = Modifier.align(Alignment.Center)
-                        )
-                    } else BasicText("Waiting for purchase")
-                }
-
-                else if (state.gamePhase == GamePhase.ROLL_DICE) {
-                    Row(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .padding(bottom = 32.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        when {
-                            state.isRolling -> DiceAnimationDisplay()
-                            state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
+                            BigPlayerCardsDisplay(
+                                state
+                            )
                         }
+                    }
 
-                        if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
-                            var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
+                    else if(
+                        showMarketplace
+                        && isCardViewPossible
+                        && !showOwnCards
+                    ) {
+                        Column(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .fillMaxSize(),
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
 
-                            if (state.hasTrainStation) {
-                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                    listOf(1, 2).forEach { count ->
-                                        Button(
-                                            onClick = { selectedDiceCount = count },
-                                            colors = ButtonDefaults.buttonColors(
-                                                containerColor = if (selectedDiceCount == count)
-                                                    MaterialTheme.colorScheme.primary
-                                                else
-                                                    MaterialTheme.colorScheme.surfaceVariant,
-                                                contentColor = if (selectedDiceCount == count)
-                                                    MaterialTheme.colorScheme.onPrimary
-                                                else
-                                                    MaterialTheme.colorScheme.onSurfaceVariant
-                                            )
-                                        ) {
-                                            Text("$count 🎲")
+                            MarketplaceSection(state.marketplace)
+                        }
+                    }
+
+                    else if (state.isBuyingPhase) {
+                        if(state.isActivePlayer) {
+                            BuyingPhaseShop(
+                                state = state,
+                                items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
+                                onPurchaseClick = onPurchaseClick,
+                                recommendedCardType = cheatRecommendation,
+                                modifier = Modifier.align(Alignment.Center)
+                            )
+                        } else BasicText("Waiting for purchase")
+                    }
+
+                    else if (state.gamePhase == GamePhase.ROLL_DICE) {
+                        Row(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .padding(bottom = 32.dp),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            when {
+                                state.isRolling -> DiceAnimationDisplay()
+                                state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
+                            }
+
+                            if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
+                                var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
+
+                                if (state.hasTrainStation) {
+                                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                        listOf(1, 2).forEach { count ->
+                                            Button(
+                                                onClick = { selectedDiceCount = count },
+                                                colors = ButtonDefaults.buttonColors(
+                                                    containerColor = if (selectedDiceCount == count)
+                                                        MaterialTheme.colorScheme.primary
+                                                    else
+                                                        MaterialTheme.colorScheme.surfaceVariant,
+                                                    contentColor = if (selectedDiceCount == count)
+                                                        MaterialTheme.colorScheme.onPrimary
+                                                    else
+                                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                                )
+                                            ) {
+                                                Text("$count 🎲")
+                                            }
                                         }
                                     }
                                 }
-                            }
 
-                            ActionButton(
-                                onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
-                                enabled = !state.isRolling,
-                                label = if (state.diceResult == null) "Würfeln" else "Nochmal würfeln",
-                                leftIcon = R.drawable.game_dice_perspective,
-                                modifier = Modifier.semantics {
-                                    contentDescription = "Würfeln"
-                                }
-                            )
+                                ActionButton(
+                                    onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
+                                    enabled = !state.isRolling,
+                                    label = if (state.diceResult == null) "Würfeln" else "Nochmal würfeln",
+                                    leftIcon = R.drawable.game_dice_perspective,
+                                    modifier = Modifier.semantics {
+                                        contentDescription = "Würfeln"
+                                    }
+                                )
+                            }
                         }
                     }
                 }
-
-                // Radio Tower reroll (#326): only the active player who built a
-                // Radio Tower may reroll, once, during RESOLVE_EFFECTS.
-                else if (state.canReroll && canReroll) {
-                    Row(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .padding(bottom = 32.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        state.diceResult?.let { DiceResultDisplay(dice = it) }
-                        ActionButton(
-                            onClick = { onReroll(state.diceResult?.size ?: 1) },
-                            enabled = !state.isRolling,
-                            label = "Nochmal würfeln",
-                            leftIcon = R.drawable.game_dice_perspective,
-                            modifier = Modifier.semantics {
-                                contentDescription = "Nochmal würfeln"
-                            }
-                        )
-                    }
-                }
-            }
-        },
+            },
 // =====================================
 // RIGHT
 // =====================================
-        rightContent = {
-            Box(modifier = Modifier
-                .fillMaxHeight()
-                .width(140.dp)
-            ) {
-
-            PlayerCoinField(
-               state = state,
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .offset(y = 45.dp)
-            )
-
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp),
-                modifier = modifier.align(Alignment.BottomCenter)
-            ) {
-                val turnFlowLabel = state.turnFlowActionLabel()
-                if (
-                    state.isActivePlayer &&
-                    state.gameStatus == GameStatus.IN_PROGRESS
+            rightContent = {
+                Box(modifier = Modifier
+                    .fillMaxHeight()
+                    .width(140.dp)
                 ) {
-                    turnFlowLabel?.let {
-                            ActionButton(
-                                onClick = if (state.isBuyingPhase) onBuySelectedClick else onTurnFlowAction,
-                                enabled = !state.isBuyingPhase || state.canConfirmSelectedPurchase(),
-                                modifier = Modifier
-                                    .semantics {
-                                        contentDescription = turnFlowLabel
-                                    }
-                                    .fillMaxWidth(),
-                                label = turnFlowLabel,
-                            )
-                    }
+
+                    PlayerCoinField(
+                        state = state,
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .offset(y = 45.dp)
+                    )
+
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = modifier.align(Alignment.BottomCenter)
+                    ) {
+                        val turnFlowLabel = state.turnFlowActionLabel()
+                        if (
+                            state.isActivePlayer &&
+                            state.gameStatus == GameStatus.IN_PROGRESS
+                        ) {
+                            turnFlowLabel?.let {
+                                ActionButton(
+                                    onClick = if (state.isBuyingPhase) onBuySelectedClick else onTurnFlowAction,
+                                    enabled = !state.isBuyingPhase || state.canConfirmSelectedPurchase(),
+                                    modifier = Modifier
+                                        .semantics {
+                                            contentDescription = turnFlowLabel
+                                        }
+                                        .fillMaxWidth(),
+                                    label = turnFlowLabel,
+                                )
+                            }
 
                             if (state.isBuyingPhase) {
-                               SecondaryActionButton(
-                                   onClick = onTurnFlowAction,
-                                   enabled = state.purchaseState != PurchaseState.PENDING,
-                                   modifier = Modifier
-                                       .semantics {
-                                           contentDescription = "Skip"
-                                       }
-                                       .fillMaxWidth(),
-                                   label = "Skip",
-                           )
+                                SecondaryActionButton(
+                                    onClick = onTurnFlowAction,
+                                    enabled = state.purchaseState != PurchaseState.PENDING,
+                                    modifier = Modifier
+                                        .semantics {
+                                            contentDescription = "Skip"
+                                        }
+                                        .fillMaxWidth(),
+                                    label = "Skip",
+                                )
+                            }
                         }
                     }
                 }
             }
-        }
-    )
+        )
 
         //Small own cards at the button
         if(isCardViewPossible && !showOwnCards && !showMarketplace) {
@@ -569,7 +541,7 @@ fun GameScreen(
                         }
                         .size(35.dp),
 
-                )
+                    )
                 Spacer(modifier = Modifier.height(4.dp))
                 PlayerCardsDisplay(
                     state,
@@ -578,11 +550,11 @@ fun GameScreen(
             }
         }
     }
-        InitializationLoadingOverlay(
-            connectionStatus = state.connectionStatus,
-            gameStatus = state.gameStatus
-        )
-    }
+    InitializationLoadingOverlay(
+        connectionStatus = state.connectionStatus,
+        gameStatus = state.gameStatus
+    )
+}
 
 
 private fun GameScreenState.turnFlowActionLabel(): String? = when (gamePhase) {
@@ -596,8 +568,8 @@ private fun GameScreenState.turnFlowActionLabel(): String? = when (gamePhase) {
 
 private fun GameScreenState.canConfirmSelectedPurchase(): Boolean =
     selectedPurchaseItemType != null &&
-        purchaseState != PurchaseState.PENDING &&
-        purchaseState != PurchaseState.SUCCESS
+            purchaseState != PurchaseState.PENDING &&
+            purchaseState != PurchaseState.SUCCESS
 
 // === PREVIEWS ===
 

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -250,27 +250,27 @@ fun GameScreen(
     Box {
 
 
-    GameScreenLayout(
-        // =====================================
-        // TOP BAR
-        // =====================================
-        topBar = {
-            Column(
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Box(
+        GameScreenLayout(
+            // =====================================
+            // TOP BAR
+            // =====================================
+            topBar = {
+                Column(
                     modifier = Modifier.fillMaxWidth()
                 ) {
+                    Box(
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
 
-                    SecondaryActionButton(
-                        label = "Leave",
-                        modifier = Modifier.align(
-                            Alignment.CenterStart
-                        ),
-                        onClick = {
-                            showLeaveDialog = true
-                        }
-                    )
+                        SecondaryActionButton(
+                            label = "Leave",
+                            modifier = Modifier.align(
+                                Alignment.CenterStart
+                            ),
+                            onClick = {
+                                showLeaveDialog = true
+                            }
+                        )
 
                         PlayersTopBar(
                             players = state.players,
@@ -284,24 +284,24 @@ fun GameScreen(
                             ),
                         )
 
-                    state.roundNumber?.let { round ->
-                        RoundIndicator(
-                            round = round,
-                            modifier = Modifier.align(
-                                Alignment.CenterEnd
+                        state.roundNumber?.let { round ->
+                            RoundIndicator(
+                                round = round,
+                                modifier = Modifier.align(
+                                    Alignment.CenterEnd
+                                )
                             )
-                        )
+                        }
                     }
-                }
 
-                Spacer(modifier = Modifier.height(8.dp))
+                    Spacer(modifier = Modifier.height(8.dp))
 
-                Column(
-                    modifier = Modifier
-                        .align(Alignment.CenterHorizontally)
-                        .width(IntrinsicSize.Max),
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .width(IntrinsicSize.Max),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
 
                         GamePhaseBanner(
                             phase = state.gamePhase,
@@ -333,63 +333,62 @@ fun GameScreen(
                 }
             },
 
-        // =====================================
-        // LEFT
-        // =====================================
-        leftContent = {
-            Box(modifier = Modifier.fillMaxHeight()) {
+            // =====================================
+            // LEFT
+            // =====================================
+            leftContent = {
+                Box(modifier = Modifier.fillMaxHeight()) {
 
-                Box(modifier = Modifier.align(Alignment.Center)
-                ) {
-                    if(state.gamePhase != GamePhase.ROLL_DICE) {
-                        state.diceResult?.let { DiceResultDisplay(dice = it) }
-                    }
-                }
-
-                Box(modifier = Modifier.align(Alignment.BottomCenter)) {
-                      MarketplaceButton(
-                          onClick = {
-                              showMarketplace = !showMarketplace
-                          },
-                          enabled = isCardViewPossible
-                      )
-
-                }
-            }
-        },
-
-        // =====================================
-        // CENTER
-        // =====================================
-        centerContent = {
-
-                Box(modifier = Modifier.align(Alignment.Center)) {
-                    if(
-                        showOwnCards
-                        && isCardViewPossible
-                        && !showMarketplace
+                    Box(modifier = Modifier.align(Alignment.Center)
                     ) {
-                        Column(
-                            modifier = Modifier
-                                .align(Alignment.Center)
-                                .fillMaxSize(),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
+                        if(state.gamePhase != GamePhase.ROLL_DICE) {
+                            state.diceResult?.let { DiceResultDisplay(dice = it) }
+                        }
+                    }
 
-                            Image(
-                                painter = painterResource(id = R.drawable.rotated_arrow),
-                                contentDescription = "Arrow",
-                                modifier = Modifier
-                                    .clickable {
-                                        showOwnCards = false
-                                    }
-                                    .size(35.dp)
-                            )
-                        BigPlayerCardsDisplay(
-                            state
+                    Box(modifier = Modifier.align(Alignment.BottomCenter)) {
+                        MarketplaceButton(
+                            onClick = {
+                                showMarketplace = !showMarketplace
+                            },
+                            enabled = isCardViewPossible
                         )
+
                     }
                 }
+            },
+
+            // =====================================
+            // CENTER
+            // =====================================
+            centerContent = {
+
+            Box(modifier = Modifier.align(Alignment.Center)) {
+                if(
+                    showOwnCards
+                    && isCardViewPossible
+                    && !showMarketplace
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .fillMaxSize(),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Image(
+                            painter = painterResource(id = R.drawable.rotated_arrow),
+                            contentDescription = "Arrow",
+                            modifier = Modifier
+                                .clickable {
+                                    showOwnCards = false
+                                }
+                                .size(35.dp)
+                            )
+                            BigPlayerCardsDisplay(
+                                state
+                            )
+                        }
+                    }
 
                     else if(
                         showMarketplace
@@ -403,59 +402,59 @@ fun GameScreen(
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
 
-                        MarketplaceSection(state.marketplace)
-                    }
-                }
-
-                else if (state.isBuyingPhase) {
-                    if(state.isActivePlayer) {
-                        BuyingPhaseShop(
-                            state = state,
-                            items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
-                            onPurchaseClick = onPurchaseClick,
-                            recommendedCardType = cheatRecommendation,
-                            modifier = Modifier.align(Alignment.Center)
-                        )
-                    } else BasicText("Waiting for purchase")
-                }
-
-                else if (state.gamePhase == GamePhase.ROLL_DICE) {
-                    Row(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .padding(bottom = 32.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        when {
-                            state.isRolling -> DiceAnimationDisplay()
-                            state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
+                            MarketplaceSection(state.marketplace)
                         }
+                    }
 
-                        if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
-                            var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
+                    else if (state.isBuyingPhase) {
+                        if(state.isActivePlayer) {
+                            BuyingPhaseShop(
+                                state = state,
+                                items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
+                                onPurchaseClick = onPurchaseClick,
+                                recommendedCardType = cheatRecommendation,
+                                modifier = Modifier.align(Alignment.Center)
+                            )
+                        } else BasicText("Waiting for purchase")
+                    }
 
-                            if (state.hasTrainStation) {
-                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                    listOf(1, 2).forEach { count ->
-                                        Button(
-                                            onClick = { selectedDiceCount = count },
-                                            colors = ButtonDefaults.buttonColors(
-                                                containerColor = if (selectedDiceCount == count)
-                                                    MaterialTheme.colorScheme.primary
-                                                else
-                                                    MaterialTheme.colorScheme.surfaceVariant,
-                                                contentColor = if (selectedDiceCount == count)
-                                                    MaterialTheme.colorScheme.onPrimary
-                                                else
-                                                    MaterialTheme.colorScheme.onSurfaceVariant
-                                            )
-                                        ) {
-                                            Text("$count 🎲")
+                    else if (state.gamePhase == GamePhase.ROLL_DICE) {
+                        Row(
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .padding(bottom = 32.dp),
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            when {
+                                state.isRolling -> DiceAnimationDisplay()
+                                state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
+                            }
+
+                            if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
+                                var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
+
+                                if (state.hasTrainStation) {
+                                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                        listOf(1, 2).forEach { count ->
+                                            Button(
+                                                onClick = { selectedDiceCount = count },
+                                                colors = ButtonDefaults.buttonColors(
+                                                    containerColor = if (selectedDiceCount == count)
+                                                        MaterialTheme.colorScheme.primary
+                                                    else
+                                                        MaterialTheme.colorScheme.surfaceVariant,
+                                                    contentColor = if (selectedDiceCount == count)
+                                                        MaterialTheme.colorScheme.onPrimary
+                                                    else
+                                                        MaterialTheme.colorScheme.onSurfaceVariant
+                                                )
+                                            ) {
+                                                Text("$count 🎲")
+                                            }
                                         }
                                     }
                                 }
-                            }
 
                             ActionButton(
                                 onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
@@ -492,8 +491,8 @@ fun GameScreen(
                         )
                     }
                 }
-            }
-        },
+                }
+            },
 // =====================================
 // RIGHT
 // =====================================
@@ -569,7 +568,7 @@ fun GameScreen(
                         }
                         .size(35.dp),
 
-                )
+                    )
                 Spacer(modifier = Modifier.height(4.dp))
                 PlayerCardsDisplay(
                     state,

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -250,27 +250,27 @@ fun GameScreen(
     Box {
 
 
-        GameScreenLayout(
-            // =====================================
-            // TOP BAR
-            // =====================================
-            topBar = {
-                Column(
+    GameScreenLayout(
+        // =====================================
+        // TOP BAR
+        // =====================================
+        topBar = {
+            Column(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Box(
                     modifier = Modifier.fillMaxWidth()
                 ) {
-                    Box(
-                        modifier = Modifier.fillMaxWidth()
-                    ) {
 
-                        SecondaryActionButton(
-                            label = "Leave",
-                            modifier = Modifier.align(
-                                Alignment.CenterStart
-                            ),
-                            onClick = {
-                                showLeaveDialog = true
-                            }
-                        )
+                    SecondaryActionButton(
+                        label = "Leave",
+                        modifier = Modifier.align(
+                            Alignment.CenterStart
+                        ),
+                        onClick = {
+                            showLeaveDialog = true
+                        }
+                    )
 
                         PlayersTopBar(
                             players = state.players,
@@ -284,24 +284,24 @@ fun GameScreen(
                             ),
                         )
 
-                        state.roundNumber?.let { round ->
-                            RoundIndicator(
-                                round = round,
-                                modifier = Modifier.align(
-                                    Alignment.CenterEnd
-                                )
+                    state.roundNumber?.let { round ->
+                        RoundIndicator(
+                            round = round,
+                            modifier = Modifier.align(
+                                Alignment.CenterEnd
                             )
-                        }
+                        )
                     }
+                }
 
-                    Spacer(modifier = Modifier.height(8.dp))
+                Spacer(modifier = Modifier.height(8.dp))
 
-                    Column(
-                        modifier = Modifier
-                            .align(Alignment.CenterHorizontally)
-                            .width(IntrinsicSize.Max),
-                        horizontalAlignment = Alignment.CenterHorizontally
-                    ) {
+                Column(
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .width(IntrinsicSize.Max),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
 
                         GamePhaseBanner(
                             phase = state.gamePhase,
@@ -333,35 +333,35 @@ fun GameScreen(
                 }
             },
 
-            // =====================================
-            // LEFT
-            // =====================================
-            leftContent = {
-                Box(modifier = Modifier.fillMaxHeight()) {
+        // =====================================
+        // LEFT
+        // =====================================
+        leftContent = {
+            Box(modifier = Modifier.fillMaxHeight()) {
 
-                    Box(modifier = Modifier.align(Alignment.Center)
-                    ) {
-                        if(state.gamePhase != GamePhase.ROLL_DICE) {
-                            state.diceResult?.let { DiceResultDisplay(dice = it) }
-                        }
-                    }
-
-                    Box(modifier = Modifier.align(Alignment.BottomCenter)) {
-                        MarketplaceButton(
-                            onClick = {
-                                showMarketplace = !showMarketplace
-                            },
-                            enabled = isCardViewPossible
-                        )
-
+                Box(modifier = Modifier.align(Alignment.Center)
+                ) {
+                    if(state.gamePhase != GamePhase.ROLL_DICE) {
+                        state.diceResult?.let { DiceResultDisplay(dice = it) }
                     }
                 }
-            },
 
-            // =====================================
-            // CENTER
-            // =====================================
-            centerContent = {
+                Box(modifier = Modifier.align(Alignment.BottomCenter)) {
+                      MarketplaceButton(
+                          onClick = {
+                              showMarketplace = !showMarketplace
+                          },
+                          enabled = isCardViewPossible
+                      )
+
+                }
+            }
+        },
+
+        // =====================================
+        // CENTER
+        // =====================================
+        centerContent = {
 
                 Box(modifier = Modifier.align(Alignment.Center)) {
                     if(
@@ -385,11 +385,11 @@ fun GameScreen(
                                     }
                                     .size(35.dp)
                             )
-                            BigPlayerCardsDisplay(
-                                state
-                            )
-                        }
+                        BigPlayerCardsDisplay(
+                            state
+                        )
                     }
+                }
 
                     else if(
                         showMarketplace
@@ -403,59 +403,59 @@ fun GameScreen(
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {
 
-                            MarketplaceSection(state.marketplace)
+                        MarketplaceSection(state.marketplace)
+                    }
+                }
+
+                else if (state.isBuyingPhase) {
+                    if(state.isActivePlayer) {
+                        BuyingPhaseShop(
+                            state = state,
+                            items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
+                            onPurchaseClick = onPurchaseClick,
+                            recommendedCardType = cheatRecommendation,
+                            modifier = Modifier.align(Alignment.Center)
+                        )
+                    } else BasicText("Waiting for purchase")
+                }
+
+                else if (state.gamePhase == GamePhase.ROLL_DICE) {
+                    Row(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(bottom = 32.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        when {
+                            state.isRolling -> DiceAnimationDisplay()
+                            state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
                         }
-                    }
 
-                    else if (state.isBuyingPhase) {
-                        if(state.isActivePlayer) {
-                            BuyingPhaseShop(
-                                state = state,
-                                items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
-                                onPurchaseClick = onPurchaseClick,
-                                recommendedCardType = cheatRecommendation,
-                                modifier = Modifier.align(Alignment.Center)
-                            )
-                        } else BasicText("Waiting for purchase")
-                    }
+                        if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
+                            var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
 
-                    else if (state.gamePhase == GamePhase.ROLL_DICE) {
-                        Row(
-                            modifier = Modifier
-                                .align(Alignment.Center)
-                                .padding(bottom = 32.dp),
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            when {
-                                state.isRolling -> DiceAnimationDisplay()
-                                state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
-                            }
-
-                            if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
-                                var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
-
-                                if (state.hasTrainStation) {
-                                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                        listOf(1, 2).forEach { count ->
-                                            Button(
-                                                onClick = { selectedDiceCount = count },
-                                                colors = ButtonDefaults.buttonColors(
-                                                    containerColor = if (selectedDiceCount == count)
-                                                        MaterialTheme.colorScheme.primary
-                                                    else
-                                                        MaterialTheme.colorScheme.surfaceVariant,
-                                                    contentColor = if (selectedDiceCount == count)
-                                                        MaterialTheme.colorScheme.onPrimary
-                                                    else
-                                                        MaterialTheme.colorScheme.onSurfaceVariant
-                                                )
-                                            ) {
-                                                Text("$count 🎲")
-                                            }
+                            if (state.hasTrainStation) {
+                                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    listOf(1, 2).forEach { count ->
+                                        Button(
+                                            onClick = { selectedDiceCount = count },
+                                            colors = ButtonDefaults.buttonColors(
+                                                containerColor = if (selectedDiceCount == count)
+                                                    MaterialTheme.colorScheme.primary
+                                                else
+                                                    MaterialTheme.colorScheme.surfaceVariant,
+                                                contentColor = if (selectedDiceCount == count)
+                                                    MaterialTheme.colorScheme.onPrimary
+                                                else
+                                                    MaterialTheme.colorScheme.onSurfaceVariant
+                                            )
+                                        ) {
+                                            Text("$count 🎲")
                                         }
                                     }
                                 }
+                            }
 
                             ActionButton(
                                 onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
@@ -569,7 +569,7 @@ fun GameScreen(
                         }
                         .size(35.dp),
 
-                    )
+                )
                 Spacer(modifier = Modifier.height(4.dp))
                 PlayerCardsDisplay(
                     state,

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/GameScreenLayout.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/GameScreenLayout.kt
@@ -2,104 +2,120 @@ package com.machikoro.client.ui.game.ui
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
-
 
 @Composable
 fun GameScreenLayout(
     modifier: Modifier = Modifier,
-
     topBar: @Composable BoxScope.() -> Unit = {},
     leftContent: @Composable BoxScope.() -> Unit = {},
     centerContent: @Composable BoxScope.() -> Unit = {},
-    rightContent: @Composable BoxScope.() -> Unit = {}
+    rightContent: @Composable BoxScope.() -> Unit = {},
 ) {
+
+    var maxTopBarHeightPx by remember {
+        mutableIntStateOf(0)
+    }
+
+    var leftWidthPx by remember {
+        mutableIntStateOf(0)
+    }
+
+    var rightWidthPx by remember {
+        mutableIntStateOf(0)
+    }
+
+    val density = LocalDensity.current
 
     Box(
         modifier = modifier
             .fillMaxSize()
-            .padding(
-                start = 42.dp,
-            )
+            .padding(start = 42.dp)
     ) {
 
-        Column(
-            modifier = Modifier.fillMaxSize()
+        // TOP BAR
+        Box(
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .fillMaxWidth()
+                .padding(
+                    end = 24.dp,
+                    bottom = 12.dp
+                )
+                .onSizeChanged {
+                    if (it.height > maxTopBarHeightPx) {
+                        maxTopBarHeightPx = it.height
+                    }
+                }
         ) {
+            topBar()
+        }
 
-            // =====================================
-            // TOP BAR
-            // =====================================
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .wrapContentHeight()
-                    .padding(
-                        end = 24.dp,
-                        bottom = 12.dp
-                    )
-            ) {
-                topBar()
-            }
-
-            // =====================================
-            // CONTENT AREA
-            // =====================================
-            Row(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-
-                // LEFT
-                Box(
-                    modifier = Modifier.wrapContentWidth()
-                        .fillMaxHeight()
-                        .padding(
-                            end = 8.dp,
-                            bottom = 32.dp,
-                        )
-                ) {
-                    leftContent()
+        // LEFT
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterStart)
+                .padding(
+                    end = 8.dp,
+                    bottom = 32.dp
+                )
+                .onSizeChanged {
+                    if (leftWidthPx != it.width) {
+                        leftWidthPx = it.width
+                    }
                 }
+        ) {
+            leftContent()
+        }
 
-                // CENTER
-                Box(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxHeight(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    centerContent()
+        // RIGHT
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(
+                    end = 12.dp,
+                    start = 8.dp,
+                    bottom = 24.dp
+                )
+                .onSizeChanged {
+                    if (rightWidthPx != it.width) {
+                        rightWidthPx = it.width
+                    }
                 }
+        ) {
+            rightContent()
+        }
 
-                // RIGHT
-                Box(
-                    modifier = Modifier.wrapContentWidth()
-                        .fillMaxHeight()
-                        .padding(
-                            end = 12.dp,
-                            start = 8.dp,
-                            bottom = 24.dp,
-                        )
-
-                ) {
-                    rightContent()
-                }
-            }
+        // CENTER
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(
+                    top = with(density) {
+                        maxTopBarHeightPx.toDp() + 12.dp
+                    },
+                    start = with(density) {
+                        leftWidthPx.toDp() + 8.dp
+                    },
+                    end = with(density) {
+                        rightWidthPx.toDp() + 20.dp
+                    }
+                ),
+            contentAlignment = Alignment.Center
+        ) {
+            centerContent()
         }
     }
 }

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Marketplace.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Marketplace.kt
@@ -1,35 +1,47 @@
 package com.machikoro.client.ui.game.ui
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.LocalOverscrollFactory
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.machikoro.client.R
 import com.machikoro.client.domain.enums.CardType
-import com.machikoro.client.domain.model.shop.CardDefinitions
-import com.machikoro.client.domain.model.state.toDisplayText
+import com.machikoro.client.ui.theme.TextBlueDark
 import com.machikoro.client.ui.theme.White
+import com.machikoro.client.R
+import kotlinx.serialization.builtins.NothingSerializer
 
+private val SHOP_CARD_SHAPE = RoundedCornerShape(8.dp)
 
 /**
  * Marketplace supply rendered from the reconnect snapshot — one chip per card
@@ -38,96 +50,129 @@ import com.machikoro.client.ui.theme.White
 @Composable
 fun MarketplaceSection(
     marketplace: Map<CardType, Int>,
-    recommendedCardType: CardType? = null,
     modifier: Modifier = Modifier
 ) {
-    val entries = CardDefinitions.sortCardTypesByActivation(CardType.entries).mapNotNull { type ->
-        marketplace[type]?.let { count -> type to count }
-    }
-    Surface(
-        color = MaterialTheme.colorScheme.surfaceVariant,
-        shape = RoundedCornerShape(12.dp),
-        tonalElevation = 2.dp,
-        modifier = modifier
+    CompositionLocalProvider(
+        LocalOverscrollFactory provides null
     ) {
-        Column(modifier = Modifier.padding(12.dp)) {
-            Text(
-                text = "Marketplace",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(bottom = 8.dp)
-            )
-            LazyRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                items(items = entries, key = { it.first }) { (type, count) ->
-                    MarketplaceCardChip(
-                        type = type,
-                        count = count,
-                        isRecommended = type == recommendedCardType,
-                    )
-                }
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(4),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(marketplace.entries.toList()) { entry ->
+                CardDisplay(
+                    cardType = entry.key,
+                    quantity = entry.value,
+                    width = 150.dp,
+                    height = 175.dp,
+                    showCounter = true,
+                    modifier = Modifier.
+                    padding(top = 8.dp)
+                )
             }
         }
     }
 }
+
 @Composable
-private fun MarketplaceCardChip(
-    type: CardType,
-    count: Int,
-    isRecommended: Boolean = false
+private fun CardDisplay(
+    cardType: CardType,
+    quantity: Int,
+    modifier: Modifier = Modifier,
+    width: Dp = 90.dp,
+    height: Dp = 110.dp,
+    showCounter: Boolean = false
 ) {
-    val description = "${type.toDisplayText()}: $count in stock" +
-            if (isRecommended) ", recommended" else ""
-    Surface(
-        color = MaterialTheme.colorScheme.surface,
-        shape = RoundedCornerShape(8.dp),
-        tonalElevation = 1.dp,
-        modifier = Modifier
-            .widthIn(min = 96.dp)
-            .then(
-                if (isRecommended) {
-                    Modifier.border(3.dp, RecommendedHighlight, RoundedCornerShape(8.dp))
-                } else {
-                    Modifier
-                }
-            )
-            .semantics { contentDescription = description }
+
+    Box(
+        modifier = modifier
+            .wrapContentSize()
     ) {
-        Column(
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Text(
-                text = type.toDisplayText(),
-                style = MaterialTheme.typography.bodySmall,
-                fontWeight = FontWeight.SemiBold,
-                textAlign = TextAlign.Center,
-                maxLines = 2
-            )
-            Text(
-                text = "×$count",
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.primary
-            )
+        val alpha = if (quantity > 0) 1f else 0.70f // if more than 0 left
+        Image(
+            painter = painterResource(id = drawableForPlayerCard(cardType)),
+            contentDescription = null,
+            contentScale = ContentScale.Fit,
+            modifier = Modifier
+                .width(width)
+                .height(height)
+                .alpha(alpha)
+                .clip(SHOP_CARD_SHAPE)
+                .semantics { }
+        )
+        if(showCounter) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .size(30.dp)
+                    .offset(x = (-6).dp, y = (-8).dp)
+                    .clip(CircleShape)
+                    .alpha(alpha)
+                    .border(
+                        width = 2.dp,
+                        color = TextBlueDark,
+                        shape = CircleShape
+                    )
+                    .background(Color.White),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = quantity.toString() + "x",
+                    color = TextBlueDark,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.labelSmall,
+                    )
+            }
         }
     }
 }
+private fun drawableForPlayerCard(cardType: CardType): Int =
+    when (cardType) {
+        CardType.WHEAT_FIELD -> R.drawable.card_wheat_field
+        CardType.RANCH -> R.drawable.card_ranch
+        CardType.FOREST -> R.drawable.card_forest
+        CardType.MINE -> R.drawable.card_mine
+        CardType.APPLE_ORCHARD -> R.drawable.card_apple_orchard
+        CardType.BAKERY -> R.drawable.card_bakery
+        CardType.CONVENIENCE_STORE -> R.drawable.card_convenience_store
+        CardType.CHEESE_FACTORY -> R.drawable.card_cheese_factory
+        CardType.FURNITURE_FACTORY -> R.drawable.card_furniture_factory
+        CardType.FRUIT_AND_VEGETABLE_MARKET ->
+            R.drawable.card_fruit_and_vegetable_market
+        CardType.CAFE -> R.drawable.card_cafe
+        CardType.FAMILY_RESTAURANT -> R.drawable.card_family_restaurant
+        CardType.STADIUM -> R.drawable.card_stadium
+        CardType.TV_STATION -> R.drawable.card_tv_station
+        CardType.BUSINESS_CENTER -> R.drawable.card_business_center
+    }
 
-// todo wire
+
 @Composable
 fun MarketplaceButton(
-    modifier: Modifier = Modifier
+    onClick: () -> Unit = {},
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true
 ) {
     Box(
-        modifier = modifier
+        modifier = modifier.clickable(
+            enabled = enabled
+        ) {
+            onClick()
+        }
     ) {
-        Column{
+        val alpha = if (enabled) 1f else 0.7f
+        Column(
+            modifier = Modifier.alpha(alpha)
+        ) {
             Image(
                 painter = painterResource(id = R.drawable.markerplace_icon),
                 contentDescription = "",
-                Modifier.size(85.dp)
-
+                modifier = Modifier.size(85.dp)
+                    .offset(x = 4.dp)
             )
+
             Text(
                 text = "Marketplace",
                 style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/PlayerCards.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/PlayerCards.kt
@@ -127,7 +127,7 @@ fun BigPlayerCardsDisplay(
                     landmarks.forEach {
                         LandmarkDisplay(it,
                             width = 155.dp,
-                            height = 180.dp
+                            height = 175.dp
                         )
                     }
                 }
@@ -146,7 +146,7 @@ fun BigPlayerCardsDisplay(
                     rowItems.forEach {
                         CardDisplay(it,
                         width = 155.dp,
-                        height = 180.dp,
+                        height = 175.dp,
                         showCounter = true
                         )
                     }

--- a/app/src/main/java/com/machikoro/client/ui/shared/Timer.kt
+++ b/app/src/main/java/com/machikoro/client/ui/shared/Timer.kt
@@ -6,11 +6,11 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
@@ -32,7 +32,6 @@ import androidx.compose.ui.unit.sp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-// TODO: adjust font size and line length upon finished game screen
 /**
  * Displays a countdown timer with a decreasing progress line.
  *
@@ -45,14 +44,15 @@ import kotlinx.coroutines.launch
  */
 @Composable
 fun DecreasingLineTimer(
-    totalTime: Int
+    totalTime: Int,
+    modifier: Modifier = Modifier
 ) {
 
-    var timeLeft by remember {
+    var timeLeft by remember(totalTime) {
         mutableIntStateOf(totalTime)
     }
 
-    val progress = remember {
+    val progress = remember(totalTime) {
         Animatable(1f)
     }
 
@@ -61,7 +61,10 @@ fun DecreasingLineTimer(
         if (timeLeft <= 5) Color.Red
         else Color.White
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(totalTime) {
+
+        // reset progress immediately
+        progress.snapTo(1f)
 
         // smooth line animation
         launch {
@@ -82,18 +85,19 @@ fun DecreasingLineTimer(
     }
 
     Row(
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.fillMaxWidth()
     ) {
 
         // line
         Box(
             modifier = Modifier
-                .width(220.dp)
+                .weight(1f)
+                .padding(end = 12.dp)
                 .height(3.dp)
                 .clip(RoundedCornerShape(50))
                 .background(Color.Gray)
         ) {
-
             Box(
                 modifier = Modifier
                     .fillMaxWidth(progress.value)
@@ -102,11 +106,7 @@ fun DecreasingLineTimer(
             )
         }
 
-        Spacer(
-            modifier = Modifier.width(12.dp)
-        )
-
-        // number
+        // fixed number on right
         Text(
             text = "$timeLeft",
             color = color,
@@ -121,8 +121,12 @@ fun DecreasingLineTimer(
 @Preview
 @Composable
 fun Timer() {
-    Box(Modifier.fillMaxSize().background(Color.Gray),
-        contentAlignment = Alignment.Center) {
+    Box(
+        Modifier
+            .fillMaxSize()
+            .background(Color.Gray),
+        contentAlignment = Alignment.Center
+    ) {
         DecreasingLineTimer(15)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,5 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 kotlin.code.style=official
 
 # Uni server connection
-backendBaseUrl=http://se2-demo.aau.at:53210
-websocketUrl=ws://se2-demo.aau.at:53210/ws
+#backendBaseUrl=http://se2-demo.aau.at:53210
+#websocketUrl=ws://se2-demo.aau.at:53210/ws

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,5 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 kotlin.code.style=official
 
 # Uni server connection
-#backendBaseUrl=http://se2-demo.aau.at:53210
-#websocketUrl=ws://se2-demo.aau.at:53210/ws
+backendBaseUrl=http://se2-demo.aau.at:53210
+websocketUrl=ws://se2-demo.aau.at:53210/ws


### PR DESCRIPTION
- GameScreenLayout adjusted layout to display content in the middle left right content and centre content based on top bar height
- Marketplace added UI with cards and quantitty
- GameScreen: added marketplace, timers automatically based on phase and content 
<img width="894" height="881" alt="Screenshot 2026-06-13 at 12 44 02" src="https://github.com/user-attachments/assets/58f02076-b89c-4e5f-847e-bebc50c8b376" />
<img width="836" height="370" alt="Screenshot 2026-06-13 at 12 44 31" src="https://github.com/user-attachments/assets/350ec337-c18b-4332-911a-63597ea07c7e" />
<img width="833" height="379" alt="Screenshot 2026-06-13 at 12 44 40" src="https://github.com/user-attachments
<img width="710" height="321" alt="Screenshot 2026-06-13 at 16 17 31" src="https://github.com/user-attachments/assets/ba727409-f446-4523-ab7c-b6da49ac262e" />
<img width="714" height="320" alt="Screenshot 2026-06-13 at 16 17 20" src="https://github.com/user-attachments/assets/346e8e25-1c39-4847-973c-49e58a5d33c6" />
/assets/780bbb0e-4730-4a04-937c-ebfc5eb168e8" />

additionally closes #332 

