### PR TITLE
326 align client with radio tower reroll server endpoint

### DIFF
--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -112,6 +112,7 @@ class MainActivity : ComponentActivity() {
             val gameScreenState by gameScreenViewModel.state.collectAsState()
             val cheatRecommendation by gameScreenViewModel.cheatRecommendation.collectAsState()
             val canAccuse by gameScreenViewModel.canAccuseThisTurn.collectAsState()
+            val canReroll by gameScreenViewModel.canRerollThisTurn.collectAsState()
             val context = LocalContext.current
             val lobbyCode by homeViewModel.lobbyCode.collectAsState()
             val activeGameId by homeViewModel.activeGameId.collectAsState()
@@ -252,10 +253,12 @@ class MainActivity : ComponentActivity() {
                             homeViewModel.clearLobbyCode()
                         },
                         onRollDice = gameScreenViewModel::rollDice,
+                        onReroll = gameScreenViewModel::rerollDice,
                         cheatRecommendation = cheatRecommendation,
                         onShake = gameScreenViewModel::onShake,
                         onAccuse = { gameScreenViewModel.accuse(it) },
                         canAccuse = canAccuse,
+                        canReroll = canReroll,
                         onTurnFlowAction = gameScreenViewModel::performTurnFlowAction,
                         modifier = Modifier.padding(innerPadding),
                         lobbyCode = lobbyCode,

--- a/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
@@ -43,13 +43,32 @@ data class GameScreenState(
         get() = gamePhase == GamePhase.BUY_OR_BUILD
 
     val hasTrainStation: Boolean
-        get() {
-            val activePlayerDatabaseId = players.firstOrNull { it.isActivePlayer }?.id?.toIntOrNull()
-                ?: return false
-            return playerLandmarks[activePlayerDatabaseId].orEmpty().any {
-                it.landmarkType == LandmarkType.TRAIN_STATION && it.isBuilt
-            }
+        get() = activePlayerHasBuiltLandmark(LandmarkType.TRAIN_STATION)
+
+    // Radio Tower (#326) unlocks the once-per-turn reroll during RESOLVE_EFFECTS.
+    val hasRadioTower: Boolean
+        get() = activePlayerHasBuiltLandmark(LandmarkType.RADIO_TOWER)
+
+    /**
+     * Radio Tower reroll gate (#326): the active player may reroll the dice
+     * during RESOLVE_EFFECTS once they have built a Radio Tower and a roll
+     * already exists this turn. The server stays authoritative for the
+     * once-per-turn rule; this only drives the client action and its button.
+     */
+    val canReroll: Boolean
+        get() = gameStatus == GameStatus.IN_PROGRESS &&
+            gamePhase == GamePhase.RESOLVE_EFFECTS &&
+            isActivePlayer &&
+            hasRadioTower &&
+            diceResult != null
+
+    private fun activePlayerHasBuiltLandmark(landmarkType: LandmarkType): Boolean {
+        val activePlayerDatabaseId = players.firstOrNull { it.isActivePlayer }?.id?.toIntOrNull()
+            ?: return false
+        return playerLandmarks[activePlayerDatabaseId].orEmpty().any {
+            it.landmarkType == landmarkType && it.isBuilt
         }
+    }
 
     companion object {
         fun initial() = GameScreenState(

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -397,14 +397,25 @@ class OkHttpWebSocketClient(
     }
 
     override fun rollDice(diceCount: Int) {
+        sendDiceRoll(WebSocketContract.rollDiceDestination, diceCount, "Roll dice")
+    }
+
+    // Radio Tower reroll (#326). Identical envelope to rollDice but routed to the
+    // rerollDice destination; the server reuses RollDiceRequest and enforces the
+    // Radio Tower / once-per-turn gate.
+    override fun rerollDice(diceCount: Int) {
+        sendDiceRoll(WebSocketContract.rerollDiceDestination, diceCount, "Reroll dice")
+    }
+
+    private fun sendDiceRoll(destination: String, diceCount: Int, actionName: String) {
         val socket = synchronized(this) { webSocket }
         if (socket == null) {
-            Log.w(TAG, "rollDice called but no active WebSocket connection")
+            Log.w(TAG, "$actionName called but no active WebSocket connection")
             return
         }
         val gameId = mutableActiveGameId.value
         if (gameId == null) {
-            Log.w(TAG, "rollDice called but no active game id")
+            Log.w(TAG, "$actionName called but no active game id")
             return
         }
         val payload = JSONObject()
@@ -419,13 +430,13 @@ class OkHttpWebSocketClient(
             StompFrame(
                 command = "SEND",
                 headers = mapOf(
-                    "destination" to WebSocketContract.rollDiceDestination,
+                    "destination" to destination,
                     "content-type" to "application/json"
                 ),
                 body = body
             ).serialize()
         )
-        Log.d(TAG, "Roll dice message sent (gameId=$gameId, diceCount=$diceCount)")
+        Log.d(TAG, "$actionName message sent (gameId=$gameId, diceCount=$diceCount)")
     }
 
     override fun advancePhase(gameId: Int) {
@@ -1167,7 +1178,10 @@ class OkHttpWebSocketClient(
     }
 
     /**
-     * Parses incoming ROLL_DICE results from the server.
+     * Parses incoming ROLL_DICE results from the server. The server reuses the
+     * ROLL_DICE type for both the initial roll (`payload.event == DICE_ROLLED`)
+     * and the Radio Tower reroll (`payload.event == DICE_REROLLED`, #326), and
+     * both carry the dice in `payload.result`, so this single parser handles both.
      */
     private fun parseDiceResult(json: JSONObject): List<Int>? {
         if (json.optString("type") != ROLL_DICE_TYPE) return null

--- a/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
@@ -85,6 +85,11 @@ interface WebSocketClient {
     )
 
     fun rollDice(diceCount: Int = 1)
+
+    // Radio Tower reroll (#326). Re-rolls the active player's dice during
+    // RESOLVE_EFFECTS; the server gates it on a built Radio Tower and the
+    // once-per-turn rule, and broadcasts the result as a ROLL_DICE / DICE_REROLLED.
+    fun rerollDice(diceCount: Int = 1)
     fun advancePhase(gameId: Int)
     fun resolveEffects(gameId: Int)
     fun endTurn(gameId: Int)

--- a/app/src/main/java/com/machikoro/client/network/websocket/WebSocketContract.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WebSocketContract.kt
@@ -12,6 +12,9 @@ object WebSocketContract {
     const val addUserDestination: String = "/app/chat.addUser"
     const val chatSendDestination: String = "/app/chat.send"
     const val rollDiceDestination: String = "/app/game.rollDice"
+    // Radio Tower reroll (#326 / server #359). Reuses the ROLL_DICE broadcast,
+    // distinguished by payload.event == DICE_REROLLED.
+    const val rerollDiceDestination: String = "/app/game.rerollDice"
     const val advancePhaseDestination: String = "/app/game.advancePhase"
     const val resolveEffectsDestination: String = "/app/game.resolveEffects"
     const val endTurnDestination: String = "/app/game.endTurn"

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -77,6 +77,7 @@ fun AppRoot(
     onFillWithDummies: () -> Unit = {},
     onResetLobby: () -> Unit = {},
     onRollDice: (diceCount: Int) -> Unit = {},
+    onReroll: (diceCount: Int) -> Unit = {},
     onTurnFlowAction: () -> Unit = {},
     onPurchaseClick: (String) -> Unit = {},
     onBuySelectedClick: () -> Unit = {},
@@ -88,6 +89,7 @@ fun AppRoot(
     onShake: () -> Unit = {},
     onAccuse: (Int) -> Unit = {},
     canAccuse: Boolean = true,
+    canReroll: Boolean = true,
     hasActiveGame: Boolean = false,
     onResumeGameClick: () -> Unit = {},
     onPurgeClick: () -> Unit = {},
@@ -233,6 +235,7 @@ fun AppRoot(
                 GameScreen(
                     state = gameScreenState.copy(gameId = routedGameId ?: gameScreenState.gameId),
                     onRollDice = onRollDice,
+                    onReroll = onReroll,
                     onTurnFlowAction = onTurnFlowAction,
                     onPurchaseClick = onPurchaseClick,
                     onBuySelectedClick = onBuySelectedClick,
@@ -242,6 +245,7 @@ fun AppRoot(
                     onShake = onShake,
                     onAccuse = onAccuse,
                     canAccuse = canAccuse,
+                    canReroll = canReroll,
                 )
             }
 

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -79,6 +79,7 @@ fun GameScreen(
     onPurchaseClick: (String) -> Unit = {},
     onBuySelectedClick: () -> Unit = {},
     onRollDice: (diceCount: Int) -> Unit = {},
+    onReroll: (diceCount: Int) -> Unit = {},
     onTurnFlowAction: () -> Unit = {},
     onLeaveGame: () -> Unit = {},
     onEndGame: () -> Unit = {},
@@ -86,6 +87,9 @@ fun GameScreen(
     onShake: () -> Unit = {},
     onAccuse: (accusedPlayerId: Int) -> Unit = {},
     canAccuse: Boolean = true,
+    // Radio Tower reroll budget (#326): false once the active player has rerolled
+    // this turn. Combined with [GameScreenState.canReroll] to show the button.
+    canReroll: Boolean = true,
     modifier: Modifier = Modifier
 ) {
     ShakeDetector(
@@ -390,6 +394,29 @@ fun GameScreen(
                                 }
                             )
                         }
+                    }
+                }
+
+                // Radio Tower reroll (#326): only the active player who built a
+                // Radio Tower may reroll, once, during RESOLVE_EFFECTS.
+                else if (state.canReroll && canReroll) {
+                    Row(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(bottom = 32.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        state.diceResult?.let { DiceResultDisplay(dice = it) }
+                        ActionButton(
+                            onClick = { onReroll(state.diceResult?.size ?: 1) },
+                            enabled = !state.isRolling,
+                            label = "Nochmal würfeln",
+                            leftIcon = R.drawable.game_dice_perspective,
+                            modifier = Modifier.semantics {
+                                contentDescription = "Nochmal würfeln"
+                            }
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
@@ -74,6 +74,16 @@ class GameScreenViewModel(
     val canAccuseThisTurn: StateFlow<Boolean>
         get() = mutableCanAccuseThisTurn.asStateFlow()
     private val mutableCanAccuseThisTurn = MutableStateFlow(true)
+
+    /**
+     * Radio Tower reroll budget (#326). True until the active player spends their
+     * once-per-turn reroll; renews when the turn rotates or a new game starts,
+     * using the same non-null discipline as the accusation budget. The server is
+     * authoritative — this just stops the client re-sending within a turn.
+     */
+    val canRerollThisTurn: StateFlow<Boolean>
+        get() = mutableCanRerollThisTurn.asStateFlow()
+    private val mutableCanRerollThisTurn = MutableStateFlow(true)
     private var lastTurnOwnerUserId: Int? = null
     private var lastSeenRoundNumber: Int? = null
     private val mutableCheatActivations = MutableSharedFlow<CardType?>(
@@ -99,9 +109,11 @@ class GameScreenViewModel(
     init {
         viewModelScope.launch {
             webSocketClient.activeGameId.collect { gameId ->
-                // A different game means a fresh accusation budget (#280).
+                // A different game means a fresh accusation budget (#280) and a
+                // fresh reroll budget (#326).
                 if (gameId != null && mutableState.value.gameId != gameId) {
                     mutableCanAccuseThisTurn.value = true
+                    mutableCanRerollThisTurn.value = true
                 }
                 mutableState.update { current ->
                     current.copy(gameId = gameId)
@@ -142,6 +154,7 @@ class GameScreenViewModel(
                 if (activePlayerId != null) {
                     if (lastTurnOwnerUserId != null && activePlayerId != lastTurnOwnerUserId) {
                         mutableCanAccuseThisTurn.value = true
+                        mutableCanRerollThisTurn.value = true
                     }
                     lastTurnOwnerUserId = activePlayerId
                 }
@@ -170,6 +183,7 @@ class GameScreenViewModel(
                 if (roundNumber != null) {
                     if (lastSeenRoundNumber != null && roundNumber != lastSeenRoundNumber) {
                         mutableCanAccuseThisTurn.value = true
+                        mutableCanRerollThisTurn.value = true
                     }
                     lastSeenRoundNumber = roundNumber
                 }
@@ -250,6 +264,20 @@ class GameScreenViewModel(
         if (!mutableState.value.isActivePlayer) return
         mutableState.update { it.copy(isRolling = true) }
         webSocketClient.rollDice(diceCount)
+    }
+
+    /**
+     * Radio Tower reroll (#326). Re-rolls the active player's dice during
+     * RESOLVE_EFFECTS when they have built a Radio Tower ([GameScreenState.canReroll])
+     * and still have their once-per-turn budget ([canRerollThisTurn]). No-op
+     * otherwise; the server stays authoritative for the result and phase.
+     */
+    fun rerollDice(diceCount: Int = 1) {
+        if (!mutableState.value.canReroll) return
+        if (!mutableCanRerollThisTurn.value) return
+        mutableCanRerollThisTurn.value = false
+        mutableState.update { it.copy(isRolling = true) }
+        webSocketClient.rerollDice(diceCount)
     }
 
     /**

--- a/app/src/test/java/com/machikoro/client/domain/model/state/GameScreenStateTest.kt
+++ b/app/src/test/java/com/machikoro/client/domain/model/state/GameScreenStateTest.kt
@@ -1,6 +1,7 @@
 package com.machikoro.client.domain.model.state
 
 import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.enums.LandmarkType
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -149,6 +150,89 @@ class GameScreenStateTest {
 
         assertFalse(state.hasTrainStation)
     }
+
+    @Test
+    fun hasRadioTowerIsTrueWhenActivePlayerHasBuiltRadioTower() {
+        val state = trainStationState(
+            playerLandmarks = mapOf(
+                ACTIVE_PLAYER_DATABASE_ID to listOf(
+                    PlayerLandmarkState(
+                        landmarkType = LandmarkType.RADIO_TOWER,
+                        isBuilt = true,
+                    ),
+                ),
+            ),
+        )
+
+        assertTrue(state.hasRadioTower)
+    }
+
+    @Test
+    fun hasRadioTowerIsFalseWhenRadioTowerIsNotBuilt() {
+        val state = trainStationState(
+            playerLandmarks = mapOf(
+                ACTIVE_PLAYER_DATABASE_ID to listOf(
+                    PlayerLandmarkState(
+                        landmarkType = LandmarkType.RADIO_TOWER,
+                        isBuilt = false,
+                    ),
+                ),
+            ),
+        )
+
+        assertFalse(state.hasRadioTower)
+    }
+
+    @Test
+    fun canRerollIsTrueForActivePlayerWithRadioTowerDuringResolveEffectsWithDice() {
+        assertTrue(rerollState().canReroll)
+    }
+
+    @Test
+    fun canRerollIsFalseOutsideResolveEffectsPhase() {
+        assertFalse(rerollState(gamePhase = GamePhase.BUY_OR_BUILD).canReroll)
+    }
+
+    @Test
+    fun canRerollIsFalseWithoutBuiltRadioTower() {
+        assertFalse(rerollState(radioTowerBuilt = false).canReroll)
+    }
+
+    @Test
+    fun canRerollIsFalseBeforeAnyDiceRollExists() {
+        assertFalse(rerollState(diceResult = null).canReroll)
+    }
+
+    @Test
+    fun canRerollIsFalseWhenGameIsNotInProgress() {
+        assertFalse(rerollState(gameStatus = GameStatus.FINISHED).canReroll)
+    }
+
+    /**
+     * State where the local active player (database id [ACTIVE_PLAYER_DATABASE_ID])
+     * is in RESOLVE_EFFECTS after a roll, optionally owning a built Radio Tower —
+     * the baseline for the [GameScreenState.canReroll] gate (#326).
+     */
+    private fun rerollState(
+        gamePhase: GamePhase = GamePhase.RESOLVE_EFFECTS,
+        gameStatus: GameStatus = GameStatus.IN_PROGRESS,
+        radioTowerBuilt: Boolean = true,
+        diceResult: List<Int>? = listOf(4),
+    ): GameScreenState =
+        trainStationState(
+            playerLandmarks = mapOf(
+                ACTIVE_PLAYER_DATABASE_ID to listOf(
+                    PlayerLandmarkState(
+                        landmarkType = LandmarkType.RADIO_TOWER,
+                        isBuilt = radioTowerBuilt,
+                    ),
+                ),
+            ),
+        ).copy(
+            gamePhase = gamePhase,
+            gameStatus = gameStatus,
+            diceResult = diceResult,
+        )
 
     private fun trainStationState(
         playerLandmarks: Map<Int, List<PlayerLandmarkState>>,

--- a/app/src/test/java/com/machikoro/client/network/websocket/FakeWebSocketClient.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/FakeWebSocketClient.kt
@@ -113,6 +113,10 @@ class FakeWebSocketClient : WebSocketClient {
 
     var lastRolledDiceCount: Int? = null
         private set
+    var lastRerolledDiceCount: Int? = null
+        private set
+    var rerollCallCount = 0
+        private set
     var advancedPhaseGameId: Int? = null
         private set
     var resolvedEffectsGameId: Int? = null
@@ -196,6 +200,11 @@ class FakeWebSocketClient : WebSocketClient {
 
     override fun rollDice(diceCount: Int) {
         lastRolledDiceCount = diceCount
+    }
+
+    override fun rerollDice(diceCount: Int) {
+        lastRerolledDiceCount = diceCount
+        rerollCallCount++
     }
 
     override fun advancePhase(gameId: Int) {

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -731,6 +731,83 @@ class OkHttpWebSocketClientTest {
     }
 
     @Test
+    fun rerollDiceSendsStompFrameToRerollDiceDestination() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        factory.simulateText(gameStartedFrame(gameId = 7))
+
+        client.rerollDice(diceCount = 1)
+
+        assertTrue(factory.socket.sentMessages.any {
+            it.startsWith("SEND\n") &&
+                it.contains("destination:/app/game.rerollDice") &&
+                it.contains("\"gameId\":7") &&
+                it.contains("\"diceCount\":1")
+        })
+    }
+
+    @Test
+    fun rerollDiceReusesRollDiceEnvelopeWithGameIdInTopLevelAndPayload() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        factory.simulateText(gameStartedFrame(gameId = 7))
+
+        client.rerollDice(diceCount = 2)
+
+        val body = JSONObject(factory.socket.rerollDiceFrames().last().body)
+        assertEquals("ROLL_DICE", body.getString("type"))
+        assertEquals(7, body.getInt("gameId"))
+        assertEquals(7, body.getJSONObject("payload").getInt("gameId"))
+        assertEquals(2, body.getJSONObject("payload").getInt("diceCount"))
+    }
+
+    @Test
+    fun rerollDiceWithoutActiveGameIdIsIgnored() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+
+        client.rerollDice(diceCount = 1)
+
+        assertTrue(factory.socket.rerollDiceFrames().isEmpty())
+    }
+
+    @Test
+    fun rerollDiceWithoutConnectionIsIgnored() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+
+        client.rerollDice(diceCount = 1)
+
+        assertTrue(factory.socket.sentMessages.isEmpty())
+    }
+
+    @Test
+    fun rerolledDiceMessageFromServerUpdatesDiceResult() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText("CONNECTED\nversion:1.2\n\n ")
+        // Backward compatibility: the reroll reuses the ROLL_DICE type, tagged
+        // with event DICE_REROLLED, and carries dice in payload.result (#326).
+        factory.simulateText(
+            gameActionFrame(
+                """{"type":"ROLL_DICE","payload":{"event":"DICE_REROLLED","playerId":"p1","result":[2,4],"timestamp":123}}"""
+            )
+        )
+        assertEquals(listOf(2, 4), client.diceResult.value)
+    }
+
+    @Test
     fun advancePhaseSendsGameIdPayloadToAdvancePhaseDestination() {
         val factory = FakeWebSocketFactory()
         val client = newClient(factory)
@@ -3014,6 +3091,10 @@ class OkHttpWebSocketClientTest {
     private fun FakeWebSocket.rollDiceFrames(): List<StompFrame> =
         sentFrames()
             .filter { it.headers["destination"] == WebSocketContract.rollDiceDestination }
+
+    private fun FakeWebSocket.rerollDiceFrames(): List<StompFrame> =
+        sentFrames()
+            .filter { it.headers["destination"] == WebSocketContract.rerollDiceDestination }
 
     private fun FakeWebSocket.sentFrames(): List<StompFrame> =
         sentMessages.flatMap { parseFrames(StringBuilder(it)) }

--- a/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
@@ -69,6 +69,7 @@ class DummyWebSocketClient : WebSocketClient {
     override fun clearGameState() {}
     override fun sendGameStart() {}
     override fun rollDice(diceCount: Int) {}
+    override fun rerollDice(diceCount: Int) {}
     override fun advancePhase(gameId: Int) {}
     override fun resolveEffects(gameId: Int) {}
     override fun endTurn(gameId: Int) {}

--- a/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
@@ -247,6 +247,116 @@ class GameScreenViewModelTest {
     }
 
     @Test
+    fun rerollForwardsDiceCountWhenActivePlayerHasRadioTowerInResolveEffects() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 42)
+        setUpRerollableTurn(fakeClient)
+        advanceUntilIdle()
+
+        viewModel.rerollDice(diceCount = 2)
+
+        assertEquals(2, fakeClient.lastRerolledDiceCount)
+    }
+
+    @Test
+    fun rerollIsIgnoredOutsideResolveEffectsPhase() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 42)
+        setUpRerollableTurn(fakeClient)
+        fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
+        advanceUntilIdle()
+
+        viewModel.rerollDice(diceCount = 1)
+
+        assertNull(fakeClient.lastRerolledDiceCount)
+    }
+
+    @Test
+    fun rerollIsIgnoredWhenActivePlayerHasNoRadioTower() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 42)
+        setUpRerollableTurn(fakeClient, radioTowerBuilt = false)
+        advanceUntilIdle()
+
+        viewModel.rerollDice(diceCount = 1)
+
+        assertNull(fakeClient.lastRerolledDiceCount)
+    }
+
+    @Test
+    fun rerollIsIgnoredWhenNotActivePlayer() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 1)
+        setUpRerollableTurn(fakeClient, activePlayerId = 99)
+        advanceUntilIdle()
+
+        viewModel.rerollDice(diceCount = 1)
+
+        assertNull(fakeClient.lastRerolledDiceCount)
+    }
+
+    @Test
+    fun rerollIsLimitedToOncePerTurn() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 42)
+        setUpRerollableTurn(fakeClient)
+        advanceUntilIdle()
+
+        viewModel.rerollDice(diceCount = 1)
+        viewModel.rerollDice(diceCount = 1)
+
+        assertEquals(1, fakeClient.rerollCallCount)
+        assertFalse(viewModel.canRerollThisTurn.value)
+    }
+
+    @Test
+    fun rerollBudgetRenewsWhenTurnRotates() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 42)
+        setUpRerollableTurn(fakeClient)
+        advanceUntilIdle()
+
+        viewModel.rerollDice(diceCount = 1)
+        // Turn rotates to another player and back to us. advanceUntilIdle between
+        // emits so the conflating StateFlow actually surfaces the intermediate
+        // owner (99) to the rotation observer rather than collapsing to 42.
+        fakeClient.emitActivePlayerId(99)
+        advanceUntilIdle()
+        fakeClient.emitActivePlayerId(42)
+        advanceUntilIdle()
+
+        assertTrue(viewModel.canRerollThisTurn.value)
+
+        viewModel.rerollDice(diceCount = 1)
+
+        assertEquals(2, fakeClient.rerollCallCount)
+    }
+
+    /**
+     * Drives the fake client into a state where the local player (user id 42,
+     * database id 7) is the active player in RESOLVE_EFFECTS after a roll, with a
+     * built Radio Tower — the precondition for [GameScreenViewModel.rerollDice].
+     */
+    private fun setUpRerollableTurn(
+        client: FakeWebSocketClient,
+        activePlayerId: Int = 42,
+        radioTowerBuilt: Boolean = true,
+    ) {
+        client.emitGameStatus(GameStatus.IN_PROGRESS)
+        client.emitGamePhase(GamePhase.RESOLVE_EFFECTS)
+        client.emitActivePlayerId(activePlayerId)
+        client.emitPlayers(
+            listOf(
+                PlayerCoinState(id = "7", displayName = "alice", coins = 5, isActivePlayer = true),
+            )
+        )
+        client.emitPlayerLandmarks(
+            mapOf(7 to listOf(PlayerLandmarkState(LandmarkType.RADIO_TOWER, isBuilt = radioTowerBuilt)))
+        )
+        client.emitDiceResult(listOf(4))
+    }
+
+    @Test
     fun activePlayerIdFromClientIsReflectedInState() = runTest {
         val fakeClient = FakeWebSocketClient()
         val viewModel = viewModel(fakeClient)

--- a/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
@@ -212,6 +212,7 @@ class HomeScreenViewModelTest {
         override fun connect() { connectCalled = true }
         override fun disconnect() { disconnectCalled = true }
         override fun rollDice(diceCount: Int) = Unit
+        override fun rerollDice(diceCount: Int) = Unit
         override fun advancePhase(gameId: Int) = Unit
         override fun resolveEffects(gameId: Int) = Unit
         override fun endTurn(gameId: Int) = Unit

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -46,6 +46,7 @@ topic before subscribing to the new one.
 | `/app/lobby.leave` | `sendLeaveLobby` | Leave envelope with `payload.gameId`. |
 | `/app/game.start` | `sendGameStart` | `gameId`, `lobbyCode`, both, or `{}` depending on known state. |
 | `/app/game.rollDice` | `rollDice` | Envelope with top-level `gameId` and `payload.gameId`/`payload.diceCount`. |
+| `/app/game.rerollDice` | `rerollDice` | Same envelope as `rollDice`; Radio Tower reroll (#326). |
 | `/app/game.purchase` | `sendPurchase` | `{"gameId":...,"purchaseType":"...","cardType":"..."}` or `landmarkType`. |
 | `/app/game.advancePhase` | `advancePhase` | `{"gameId":...}` |
 | `/app/game.resolveEffects` | `resolveEffects` | `{"gameId":...}` |
@@ -58,6 +59,12 @@ during `BUY_OR_BUILD`; `END_TURN` is treated as a server-side transition phase
 and does not expose a client action. Server broadcasts remain authoritative for
 the resulting phase and game state.
 
+During `RESOLVE_EFFECTS`, the active player may additionally send
+`/app/game.rerollDice` (#326) when they have built a `RADIO_TOWER` and a roll
+already exists this turn. The client gates this to the active player with a
+Radio Tower and limits it to once per turn (renewed on turn rotation); the
+server stays authoritative for the once-per-turn rule and the result.
+
 ## Handled Message Types
 
 | Type | Effect |
@@ -68,7 +75,7 @@ the resulting phase and game state.
 | `LOBBY_ROSTER` | Replaces the local lobby roster with the server roster. |
 | `GAME_STARTED` | Applies initial game state, player list, phase, active player, and shop data. |
 | `GAME_ACTION` | Applies authoritative state snapshots and purchase success events. |
-| `ROLL_DICE` | Applies authoritative state snapshots and the individual dice result. |
+| `ROLL_DICE` | Applies authoritative state snapshots and the individual dice result. Covers both the initial roll (`payload.event == DICE_ROLLED`) and the Radio Tower reroll (`payload.event == DICE_REROLLED`, #326), which share `payload.result`. |
 | `GAME_END` | Marks the game finished, stores winner/round data, and unsubscribes from the game topic. |
 | `SYNC` | Restores a full reconnect snapshot from `/user/queue/game-sync`. |
 | `ERROR` | Emits lobby or purchase errors; auth failures sign the user out. |


### PR DESCRIPTION
Closes [#326](https://github.com/SE2-Machi-Koro/Client/issues/326)

Aligns the Android client with the server's /app/game.rerollDice endpoint (Server PR [#359](https://github.com/SE2-Machi-Koro/Server/pull/359)). When the active player has built a Radio Tower, they can now reroll their dice once during the RESOLVE_EFFECTS phase.

Server contract this targets
Send: /app/game.rerollDice, reusing RollDiceRequest (gameId + diceCount/payload).
Broadcast: the server reuses the ROLL_DICE message type, distinguished by payload.event — DICE_ROLLED for the initial roll, DICE_REROLLED for the reroll — both carrying the dice in payload.result.
Changes
WebSocket contract & client

Added rerollDiceDestination = "/app/game.rerollDice" to WebSocketContract.
Added rerollDice(diceCount) to the WebSocketClient interface and OkHttpWebSocketClient. It reuses the exact rollDice envelope routed to the reroll destination; both now share a single sendDiceRoll(...) helper.
Backward compatible: parseDiceResult keys on type == ROLL_DICE + payload.result, so DICE_ROLLED and DICE_REROLLED parse identically — no change needed to dice-result handling.
Reroll action & access control

GameScreenState: added hasRadioTower and a canReroll gate (IN_PROGRESS + RESOLVE_EFFECTS + active player + built RADIO_TOWER + a roll already exists).
GameScreenViewModel: added rerollDice() plus a canRerollThisTurn once-per-turn budget that renews on turn rotation (mirrors the existing accusation budget). The server remains authoritative for the once-per-turn rule.
UI: a reroll button surfaces during RESOLVE_EFFECTS only for the eligible active player, wired through GameScreen → AppRoot → MainActivity.
Docs

Updated docs/websocket-protocol.md with the new send destination, the RESOLVE_EFFECTS reroll rule, and the DICE_ROLLED/DICE_REROLLED note.