### PR TITLE
fix: require numeric activation numbers for card definitions

### DIFF
--- a/app/src/main/java/com/machikoro/client/domain/model/shop/ShopItem.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/shop/ShopItem.kt
@@ -300,15 +300,3 @@ fun List<Int>.toActivationText(): String? {
         "${numbers.first()}-${numbers.last()}"
     }
 }
-
-fun String.toActivationNumbers(): List<Int> {
-    val trimmed = trim()
-    if (trimmed.isBlank() || trimmed.equals("Permanent", ignoreCase = true)) return emptyList()
-    val rangeParts = trimmed.split("-", limit = 2).map { it.trim().toIntOrNull() }
-    if (rangeParts.size == 2 && rangeParts.all { it != null }) {
-        val start = rangeParts[0] ?: return emptyList()
-        val end = rangeParts[1] ?: return emptyList()
-        return (minOf(start, end)..maxOf(start, end)).toList()
-    }
-    return Regex("\\d+").findAll(trimmed).map { it.value.toInt() }.toList().distinct().sorted()
-}

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -13,7 +13,6 @@ import com.machikoro.client.domain.model.shop.PurchaseEvent
 import com.machikoro.client.domain.model.shop.ShopCatalog
 import com.machikoro.client.network.error.ClientError
 import com.machikoro.client.domain.model.shop.ShopItem
-import com.machikoro.client.domain.model.shop.toActivationNumbers
 import com.machikoro.client.domain.model.state.AccusationResult
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.PlayerCardState
@@ -1022,8 +1021,6 @@ class OkHttpWebSocketClient(
 
     private fun JSONObject.activationNumbers(): List<Int> =
         optJSONArray("activationNumbers")?.toActivationNumbers().orEmpty()
-            .ifEmpty { optString("activationRange").toActivationNumbers() }
-            .ifEmpty { optString("activationText").toActivationNumbers() }
 
     private fun JSONObject.effectText(cardType: CardType): String =
         optString("effectText")

--- a/app/src/test/java/com/machikoro/client/domain/model/shop/CardDefinitionsTest.kt
+++ b/app/src/test/java/com/machikoro/client/domain/model/shop/CardDefinitionsTest.kt
@@ -54,9 +54,9 @@ class CardDefinitionsTest {
     }
 
     @Test
-    fun activationNumbersCanBeParsedFromLegacyDisplayText() {
-        assertEquals(listOf(9, 10), "9-10".toActivationNumbers())
-        assertEquals(listOf(11, 12), "11, 12".toActivationNumbers())
-        assertEquals(emptyList<Int>(), "Permanent".toActivationNumbers())
+    fun activationTextCompactsNumericActivationNumbersForDisplay() {
+        assertEquals("9-10", listOf(10, 9, 9).toActivationText())
+        assertEquals("11-12", listOf(11, 12).toActivationText())
+        assertEquals(null, emptyList<Int>().toActivationText())
     }
 }

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -2612,6 +2612,30 @@ class OkHttpWebSocketClientTest {
     }
 
     @Test
+    fun parseCardDefinitionsDoesNotTreatDisplayTextAsActivationNumbers() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        factory.simulateText(
+            syncFrame(
+                """{"type":"SYNC","sender":"server","gameId":1,"payload":{"targetUserId":1,"state":{""" +
+                    """"game":{"id":1,"status":"IN_PROGRESS","turnPhase":"ROLL_DICE","currentTurnIndex":0},""" +
+                    """"players":[],"playerLandmarks":{},"marketplace":{"BAKERY":4},""" +
+                    """"cardDefinitions":[{"cardType":"BAKERY","cost":1,"color":"GREEN",""" +
+                    """"establishmentType":"BREAD","activationText":"9-10","activationRange":"11-12",""" +
+                    """"effectText":"Get 1 coin from the bank on your turn."}],""" +
+                    """"landmarkDefinitions":[],"turnOrder":[]}}}"""
+            )
+        )
+
+        val bakery = client.shopItems.value.single { it.type == CardType.BAKERY.name }
+        assertEquals(listOf(2, 3), bakery.activationNumbers)
+        assertEquals("2-3", bakery.activationText)
+    }
+
+    @Test
     fun parseLandmarkDefinitionsSkipsEntriesWithUnknownLandmarkType() {
         val factory = FakeWebSocketFactory()
         val client = newClient(factory)


### PR DESCRIPTION
## Summary
This finalizes #307 under the parent epic #300 by making activation numbers numeric-only for structured client logic.

The client already models shop/card activation values as `List<Int>` and derives `activationText` for UI display. This change tightens the websocket parsing boundary so server-provided card definitions only populate structured activation values from the numeric `activationNumbers` field. Legacy/display-oriented fields such as `activationText` or `activationRange` are no longer parsed back into activation numbers.

This keeps the contract clean:
- `activationNumbers` is the source of truth for sorting, recommendations, and effect-related logic.
- `activationText` remains UI-only and is derived from `activationNumbers`.
- Existing shop/card display behavior stays the same.
- The marketplace/shop behavior from #321 is unchanged.

## Changes
- Removed legacy string parsing from `ShopItem.kt`.
- Updated websocket card-definition parsing to ignore `activationText` / `activationRange` as structured activation sources.
- Added parser coverage to ensure display strings are not treated as activation numbers.
- Updated card-definition tests to focus on deriving display text from numeric activation values.