### PR TITLE
101 buying duplicate cards UI

### DIFF
--- a/app/src/androidTest/java/com/machikoro/client/ui/game/GameScreenSnapshotTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/game/GameScreenSnapshotTest.kt
@@ -328,5 +328,7 @@ class GameScreenSnapshotTest {
                 "Stadium: 6 coins, activates on 6. Take 2 coins from every opponent on your turn., 1 remaining, already owned"
             )
             .assertIsDisplayed()
+        composeTestRule.onNodeWithText("Owned").assertIsDisplayed()
+        composeTestRule.onNodeWithContentDescription("Already owned card indicator").assertIsDisplayed()
     }
 }

--- a/app/src/androidTest/java/com/machikoro/client/ui/game/GameScreenSnapshotTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/game/GameScreenSnapshotTest.kt
@@ -297,4 +297,36 @@ class GameScreenSnapshotTest {
         composeTestRule.onNodeWithContentDescription("Bakery: 5 in stock").assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription("Cafe: 4 in stock").assertIsDisplayed()
     }
+
+    @Test
+    fun shopMarksAlreadyOwnedPurpleEstablishmentAsAlreadyOwned() {
+        val state = GameScreenState(
+            gameId = 1,
+            connectionStatus = ConnectionStatus.CONNECTED,
+            gamePhase = GamePhase.BUY_OR_BUILD,
+            players = listOf(
+                PlayerCoinState(
+                    id = "1",
+                    displayName = "You",
+                    coins = 10,
+                    isCurrentPlayer = true,
+                    isActivePlayer = true
+                )
+            ),
+            playerCards = mapOf(1 to listOf(PlayerCardState(CardType.STADIUM, quantity = 1))),
+            marketplace = mapOf(CardType.STADIUM to 1),
+            activePlayerId = 1,
+            myUserId = 1,
+            gameStatus = GameStatus.IN_PROGRESS,
+            purchaseState = PurchaseState.IDLE,
+        )
+
+        composeTestRule.setContent { ClientTheme { GameScreen(state = state) } }
+
+        composeTestRule
+            .onNodeWithContentDescription(
+                "Stadium: 6 coins, activates on 6. Take 2 coins from every opponent on your turn., 1 remaining, already owned"
+            )
+            .assertIsDisplayed()
+    }
 }

--- a/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
@@ -5,6 +5,7 @@ import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.enums.LandmarkType
 import com.machikoro.client.domain.enums.PurchaseType
+import com.machikoro.client.domain.enums.ShopItemColor
 import com.machikoro.client.domain.model.shop.ShopItem
 
 data class GameScreenState(
@@ -105,3 +106,12 @@ fun GameScreenState.remainingMarketplaceQuantityFor(item: ShopItem): Int? {
 
 fun GameScreenState.isShopItemAvailableFromMarketplace(item: ShopItem): Boolean =
     remainingMarketplaceQuantityFor(item)?.let { it > 0 } ?: item.isAvailable
+
+fun GameScreenState.isAlreadyOwnedPurpleEstablishment(item: ShopItem): Boolean {
+    if (item.purchaseType != PurchaseType.ESTABLISHMENT || item.color != ShopItemColor.PURPLE) {
+        return false
+    }
+    val activePlayerId = players.firstOrNull { it.isActivePlayer }?.id?.toIntOrNull() ?: return false
+    val cardType = runCatching { CardType.valueOf(item.type) }.getOrNull() ?: return false
+    return playerCards[activePlayerId].orEmpty().any { it.cardType == cardType && it.quantity > 0 }
+}

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
@@ -15,6 +15,7 @@ import com.machikoro.client.domain.model.state.PurchaseState
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.session.SessionStateHolder
+import com.machikoro.client.domain.model.state.isAlreadyOwnedPurpleEstablishment
 import com.machikoro.client.domain.model.state.isShopItemAvailableFromMarketplace
 import com.machikoro.client.network.debug.DebugApi
 import com.machikoro.client.network.debug.EndGameRequest
@@ -411,6 +412,7 @@ class GameScreenViewModel(
             purchaseState != PurchaseState.SUCCESS &&
             isShopItemAvailableFromMarketplace(item) &&
             hasEnoughKnownCoinsFor(item) &&
+            !isAlreadyOwnedPurpleEstablishment(item) &&
             !isKnownBuiltLandmark(item)
 
     private fun GameScreenState.canStartPurchase(item: ShopItem): Boolean =
@@ -421,6 +423,7 @@ class GameScreenViewModel(
             purchaseState != PurchaseState.SUCCESS &&
             isShopItemAvailableFromMarketplace(item) &&
             hasEnoughKnownCoinsFor(item) &&
+            !isAlreadyOwnedPurpleEstablishment(item) &&
             !isKnownBuiltLandmark(item)
 
     private fun GameScreenState.hasEnoughKnownCoinsFor(item: ShopItem): Boolean {

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
@@ -1,11 +1,13 @@
 package com.machikoro.client.ui.game.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.LocalOverscrollFactory
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -16,6 +18,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
@@ -27,6 +30,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.machikoro.client.domain.enums.CardType
 import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.enums.GameStatus
@@ -45,6 +49,8 @@ import com.machikoro.client.domain.model.state.remainingMarketplaceQuantityFor
 import com.machikoro.client.ui.game.GameScreen
 import com.machikoro.client.ui.shared.BasicText
 import com.machikoro.client.ui.theme.ClientTheme
+import com.machikoro.client.ui.theme.CardPurpleBackground
+import com.machikoro.client.ui.theme.CardPurpleText
 import com.machikoro.client.ui.theme.PrimaryOrange
 import com.machikoro.client.ui.theme.TextBlueDark
 
@@ -198,7 +204,31 @@ private fun ShopImageTile(
                 modifier = Modifier.align(Alignment.TopStart)
             )
         }
+        if (isAlreadyOwnedPurple) {
+            OwnedCardIndicator(
+                modifier = Modifier.align(Alignment.TopEnd)
+            )
+        }
     }
+}
+
+@Composable
+private fun OwnedCardIndicator(modifier: Modifier = Modifier) {
+    Text(
+        text = "Owned",
+        color = CardPurpleText,
+        fontSize = 12.sp,
+        style = MaterialTheme.typography.labelSmall,
+        modifier = modifier
+            .padding(top = 6.dp, end = 6.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .background(CardPurpleBackground)
+            .border(1.dp, CardPurpleText, RoundedCornerShape(8.dp))
+            .padding(horizontal = 8.dp, vertical = 3.dp)
+            .semantics {
+                contentDescription = "Already owned card indicator"
+            }
+    )
 }
 
 internal fun GameScreenState.shouldShowBuyingPhaseShop(): Boolean =

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
@@ -39,6 +39,7 @@ import com.machikoro.client.domain.model.state.GameScreenState
 import com.machikoro.client.domain.model.state.PlayerCoinState
 import com.machikoro.client.domain.model.state.PlayerLandmarkState
 import com.machikoro.client.domain.model.state.PurchaseState
+import com.machikoro.client.domain.model.state.isAlreadyOwnedPurpleEstablishment
 import com.machikoro.client.domain.model.state.isShopItemAvailableFromMarketplace
 import com.machikoro.client.domain.model.state.remainingMarketplaceQuantityFor
 import com.machikoro.client.ui.game.GameScreen
@@ -147,6 +148,7 @@ private fun ShopImageTile(
     val isSelected = state.selectedPurchaseItemType == item.type
     val isFeedbackItem = state.purchaseFeedbackItemType == item.type
     val remainingQuantity = state.remainingMarketplaceQuantityFor(item)
+    val isAlreadyOwnedPurple = state.isAlreadyOwnedPurpleEstablishment(item)
 
     val borderColor = when {
         isFeedbackItem && state.purchaseState == PurchaseState.SUCCESS -> PrimaryOrange
@@ -179,6 +181,7 @@ private fun ShopImageTile(
                     contentDescription = "${item.displayName}: ${item.cost} coins, activates on ${item.activationText}. ${item.effectText}" +
                             remainingQuantity?.let { ", $it remaining" }.orEmpty() +
                             (if (remainingQuantity == 0) ", unavailable" else "") +
+                            (if (isAlreadyOwnedPurple) ", already owned" else "") +
                             (if (isRecommended) ", recommended" else "")
                 }
         ) {
@@ -209,6 +212,7 @@ private fun GameScreenState.canPurchaseItem(item: ShopItem): Boolean =
             purchaseState != PurchaseState.PENDING &&
             purchaseState != PurchaseState.SUCCESS &&
             hasEnoughKnownCoinsFor(item) &&
+            !isAlreadyOwnedPurpleEstablishment(item) &&
             !isKnownBuiltLandmark(item)
 
 private fun GameScreenState.hasEnoughKnownCoinsFor(item: ShopItem): Boolean {

--- a/app/src/test/java/com/machikoro/client/ui/game/BuyingPhaseShopStateTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/BuyingPhaseShopStateTest.kt
@@ -8,8 +8,10 @@ import com.machikoro.client.domain.enums.ShopItemColor
 import com.machikoro.client.domain.model.shop.ShopItem
 import com.machikoro.client.domain.model.state.ConnectionStatus
 import com.machikoro.client.domain.model.state.GameScreenState
+import com.machikoro.client.domain.model.state.PlayerCardState
 import com.machikoro.client.domain.model.state.PlayerCoinState
 import com.machikoro.client.domain.model.state.PurchaseState
+import com.machikoro.client.domain.model.state.isAlreadyOwnedPurpleEstablishment
 import com.machikoro.client.domain.model.state.isShopItemAvailableFromMarketplace
 import com.machikoro.client.domain.model.state.remainingMarketplaceQuantityFor
 import com.machikoro.client.ui.game.ui.shouldShowBuyingPhaseShop
@@ -62,6 +64,47 @@ class BuyingPhaseShopStateTest {
         assertTrue(state.isShopItemAvailableFromMarketplace(item))
     }
 
+    @Test
+    fun activePlayersOwnedPurpleEstablishmentIsUnavailableForRepurchase() {
+        val item = shopItem("STADIUM", isAvailable = true, color = ShopItemColor.PURPLE)
+        val state = buyingPhaseState(activePlayerId = 42, myUserId = 42).copy(
+            players = listOf(
+                PlayerCoinState(
+                    id = "100",
+                    displayName = "Active player",
+                    coins = 6,
+                    isActivePlayer = true,
+                    isCurrentPlayer = true
+                )
+            ),
+            playerCards = mapOf(100 to listOf(PlayerCardState(CardType.STADIUM, quantity = 1))),
+            marketplace = mapOf(CardType.STADIUM to 1)
+        )
+
+        assertTrue(state.isAlreadyOwnedPurpleEstablishment(item))
+    }
+
+    @Test
+    fun ownedNonPurpleEstablishmentIsStillAvailableForDuplicates() {
+        val item = shopItem("BAKERY", isAvailable = true, color = ShopItemColor.GREEN)
+        val state = buyingPhaseState(activePlayerId = 42, myUserId = 42).copy(
+            players = listOf(
+                PlayerCoinState(
+                    id = "100",
+                    displayName = "Active player",
+                    coins = 6,
+                    isActivePlayer = true,
+                    isCurrentPlayer = true
+                )
+            ),
+            playerCards = mapOf(100 to listOf(PlayerCardState(CardType.BAKERY, quantity = 1))),
+            marketplace = mapOf(CardType.BAKERY to 3)
+        )
+
+        assertFalse(state.isAlreadyOwnedPurpleEstablishment(item))
+        assertTrue(state.isShopItemAvailableFromMarketplace(item))
+    }
+
     private fun buyingPhaseState(
         activePlayerId: Int,
         myUserId: Int,
@@ -87,12 +130,13 @@ class BuyingPhaseShopStateTest {
     private fun shopItem(
         type: String,
         isAvailable: Boolean,
+        color: ShopItemColor = ShopItemColor.GREEN,
     ) = ShopItem(
         type = type,
         displayName = "Bakery",
         cost = 1,
         purchaseType = PurchaseType.ESTABLISHMENT,
-        color = ShopItemColor.GREEN,
+        color = color,
         establishmentType = "BREAD",
         activationNumbers = listOf(2, 3),
         effectText = "Get 1 coin from the bank on your turn.",

--- a/app/src/test/java/com/machikoro/client/ui/game/BuyingPhaseShopStateTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/BuyingPhaseShopStateTest.kt
@@ -85,6 +85,77 @@ class BuyingPhaseShopStateTest {
     }
 
     @Test
+    fun unownedPurpleEstablishmentIsAvailableForPurchase() {
+        val item = shopItem("STADIUM", isAvailable = true, color = ShopItemColor.PURPLE)
+        val state = buyingPhaseState(activePlayerId = 42, myUserId = 42).copy(
+            players = listOf(
+                PlayerCoinState(
+                    id = "100",
+                    displayName = "Active player",
+                    coins = 6,
+                    isActivePlayer = true,
+                    isCurrentPlayer = true
+                )
+            ),
+            playerCards = mapOf(100 to listOf(PlayerCardState(CardType.TV_STATION, quantity = 1))),
+            marketplace = mapOf(CardType.STADIUM to 1)
+        )
+
+        assertFalse(state.isAlreadyOwnedPurpleEstablishment(item))
+        assertTrue(state.isShopItemAvailableFromMarketplace(item))
+    }
+
+    @Test
+    fun zeroQuantityPurpleEstablishmentIsNotTreatedAsOwned() {
+        val item = shopItem("STADIUM", isAvailable = true, color = ShopItemColor.PURPLE)
+        val state = buyingPhaseState(activePlayerId = 42, myUserId = 42).copy(
+            players = listOf(
+                PlayerCoinState(
+                    id = "100",
+                    displayName = "Active player",
+                    coins = 6,
+                    isActivePlayer = true,
+                    isCurrentPlayer = true
+                )
+            ),
+            playerCards = mapOf(100 to listOf(PlayerCardState(CardType.STADIUM, quantity = 0))),
+            marketplace = mapOf(CardType.STADIUM to 1)
+        )
+
+        assertFalse(state.isAlreadyOwnedPurpleEstablishment(item))
+    }
+
+    @Test
+    fun purpleEstablishmentWithUnknownCardTypeIsNotTreatedAsOwned() {
+        val item = shopItem("UNKNOWN_CARD", isAvailable = true, color = ShopItemColor.PURPLE)
+        val state = buyingPhaseState(activePlayerId = 42, myUserId = 42).copy(
+            players = listOf(
+                PlayerCoinState(
+                    id = "100",
+                    displayName = "Active player",
+                    coins = 6,
+                    isActivePlayer = true,
+                    isCurrentPlayer = true
+                )
+            ),
+            playerCards = mapOf(100 to listOf(PlayerCardState(CardType.STADIUM, quantity = 1)))
+        )
+
+        assertFalse(state.isAlreadyOwnedPurpleEstablishment(item))
+    }
+
+    @Test
+    fun purpleEstablishmentWithoutKnownActivePlayerCardsIsNotTreatedAsOwned() {
+        val item = shopItem("STADIUM", isAvailable = true, color = ShopItemColor.PURPLE)
+        val state = buyingPhaseState(activePlayerId = 42, myUserId = 42).copy(
+            players = emptyList(),
+            playerCards = mapOf(100 to listOf(PlayerCardState(CardType.STADIUM, quantity = 1)))
+        )
+
+        assertFalse(state.isAlreadyOwnedPurpleEstablishment(item))
+    }
+
+    @Test
     fun ownedNonPurpleEstablishmentIsStillAvailableForDuplicates() {
         val item = shopItem("BAKERY", isAvailable = true, color = ShopItemColor.GREEN)
         val state = buyingPhaseState(activePlayerId = 42, myUserId = 42).copy(

--- a/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
@@ -515,6 +515,142 @@ class GameScreenViewModelTest {
     }
 
     @Test
+    fun selectingAlreadyOwnedPurpleEstablishmentIsIgnored() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 42)
+
+        fakeClient.emitActiveGameId(7)
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
+        fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
+        fakeClient.emitActivePlayerId(42)
+        fakeClient.emitPlayers(
+            listOf(
+                PlayerCoinState(
+                    id = "100",
+                    displayName = "Active player",
+                    coins = 10,
+                    isActivePlayer = true,
+                    isCurrentPlayer = true
+                )
+            )
+        )
+        fakeClient.emitPlayerCards(mapOf(100 to listOf(PlayerCardState(CardType.STADIUM, quantity = 1))))
+        fakeClient.emitMarketplace(mapOf(CardType.STADIUM to 1))
+        advanceUntilIdle()
+
+        viewModel.selectPurchaseItem("STADIUM")
+
+        assertNull(viewModel.state.value.selectedPurchaseItemType)
+        assertNull(fakeClient.lastPurchase)
+    }
+
+    @Test
+    fun purchaseAlreadyOwnedPurpleEstablishmentIsIgnored() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 42)
+
+        fakeClient.emitActiveGameId(7)
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
+        fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
+        fakeClient.emitActivePlayerId(42)
+        fakeClient.emitPlayers(
+            listOf(
+                PlayerCoinState(
+                    id = "100",
+                    displayName = "Active player",
+                    coins = 10,
+                    isActivePlayer = true,
+                    isCurrentPlayer = true
+                )
+            )
+        )
+        fakeClient.emitPlayerCards(mapOf(100 to listOf(PlayerCardState(CardType.STADIUM, quantity = 1))))
+        fakeClient.emitMarketplace(mapOf(CardType.STADIUM to 1))
+        advanceUntilIdle()
+
+        viewModel.purchase("STADIUM")
+
+        assertNull(fakeClient.lastPurchase)
+        assertEquals(PurchaseState.IDLE, viewModel.state.value.purchaseState)
+    }
+
+    @Test
+    fun ownedNonPurpleEstablishmentCanStillBePurchasedAsDuplicate() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 42)
+
+        fakeClient.emitActiveGameId(7)
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
+        fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
+        fakeClient.emitActivePlayerId(42)
+        fakeClient.emitPlayers(
+            listOf(
+                PlayerCoinState(
+                    id = "100",
+                    displayName = "Active player",
+                    coins = 10,
+                    isActivePlayer = true,
+                    isCurrentPlayer = true
+                )
+            )
+        )
+        fakeClient.emitPlayerCards(mapOf(100 to listOf(PlayerCardState(CardType.BAKERY, quantity = 1))))
+        fakeClient.emitMarketplace(mapOf(CardType.BAKERY to 5))
+        advanceUntilIdle()
+
+        viewModel.purchase("BAKERY")
+
+        assertEquals(
+            FakeWebSocketClient.PurchaseCall(
+                gameId = 7,
+                purchaseType = PurchaseType.ESTABLISHMENT,
+                cardType = "BAKERY",
+                landmarkType = null
+            ),
+            fakeClient.lastPurchase
+        )
+        assertEquals(PurchaseState.PENDING, viewModel.state.value.purchaseState)
+    }
+
+    @Test
+    fun unownedPurpleEstablishmentCanBePurchased() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 42)
+
+        fakeClient.emitActiveGameId(7)
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
+        fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
+        fakeClient.emitActivePlayerId(42)
+        fakeClient.emitPlayers(
+            listOf(
+                PlayerCoinState(
+                    id = "100",
+                    displayName = "Active player",
+                    coins = 10,
+                    isActivePlayer = true,
+                    isCurrentPlayer = true
+                )
+            )
+        )
+        fakeClient.emitPlayerCards(mapOf(100 to listOf(PlayerCardState(CardType.BAKERY, quantity = 1))))
+        fakeClient.emitMarketplace(mapOf(CardType.STADIUM to 1))
+        advanceUntilIdle()
+
+        viewModel.purchase("STADIUM")
+
+        assertEquals(
+            FakeWebSocketClient.PurchaseCall(
+                gameId = 7,
+                purchaseType = PurchaseType.ESTABLISHMENT,
+                cardType = "STADIUM",
+                landmarkType = null
+            ),
+            fakeClient.lastPurchase
+        )
+        assertEquals(PurchaseState.PENDING, viewModel.state.value.purchaseState)
+    }
+
+    @Test
     fun activePlayerCanPurchaseLandmarkDuringBuyOrBuild() = runTest {
         val fakeClient = FakeWebSocketClient()
         val viewModel = viewModel(fakeClient, userId = 42)


### PR DESCRIPTION
### Summary
This PR aligns the client shop behavior with the Machi Koro card ownership rule for purple establishments.

Duplicate ownership display was already present in the client through `PlayerCardState.quantity`, owned-card counters, and opponent card inventory quantity display. The missing piece was that the shop still allowed the active player to select and attempt to buy a purple establishment they already owned.

### Changes
- Added client-side detection for already-owned purple establishments.
- Reused the existing active player card state to check whether the active player already owns the selected purple card.
- Disabled already-owned purple establishment tiles in the shop using the existing faded/unavailable UI behavior.
- Added `already owned` to the shop tile accessibility description.
- Blocked already-owned purple establishments in both selection and purchase guards.
- Kept duplicate purchases allowed for green, red, and blue establishments when marketplace stock and coin checks pass.