### PR TITLE
docs(rules): document the Insider Trading cheat in the in-app tutorial (#336)

### DIFF
--- a/app/src/androidTest/java/com/machikoro/client/ui/home/CheatRulesContentTest.kt
+++ b/app/src/androidTest/java/com/machikoro/client/ui/home/CheatRulesContentTest.kt
@@ -1,0 +1,57 @@
+package com.machikoro.client.ui.home
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.machikoro.client.ui.theme.ClientTheme
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Verifies the in-app cheat/accusation tutorial section (issue #336). The
+ * section is rendered as the final page of the rules viewer, so showing it here
+ * is what a player reaches from Home -> Rules -> last page.
+ */
+class CheatRulesContentTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private fun setContent() {
+        composeTestRule.setContent {
+            ClientTheme {
+                CheatRulesContent()
+            }
+        }
+    }
+
+    @Test
+    fun showsCheatSectionHeading() {
+        setContent()
+        composeTestRule.onNodeWithText("Cheating & Accusations").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Insider Trading", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Accusing a cheater").assertIsDisplayed()
+    }
+
+    @Test
+    fun explainsCheatActivation() {
+        setContent()
+        // Both activation paths: shake gesture and the in-game "Insider tip" button.
+        composeTestRule.onNodeWithText("shake your phone", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Insider tip", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun explainsOneTurnValidityAndServerReporting() {
+        setContent()
+        composeTestRule.onNodeWithText("current turn only", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("reported to the server", substring = true).assertIsDisplayed()
+    }
+
+    @Test
+    fun explainsAccusationMechanicLimitAndPenalty() {
+        setContent()
+        composeTestRule.onNodeWithText("Accuse of cheating", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("once per turn", substring = true).assertIsDisplayed()
+        composeTestRule.onNodeWithText("lose", substring = true).assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/machikoro/client/ui/home/CheatRulesContent.kt
+++ b/app/src/main/java/com/machikoro/client/ui/home/CheatRulesContent.kt
@@ -1,0 +1,116 @@
+package com.machikoro.client.ui.home
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.machikoro.client.R
+import com.machikoro.client.ui.shared.Background
+import com.machikoro.client.ui.theme.ClientTheme
+import com.machikoro.client.ui.theme.PanelBackgroundBeige
+import com.machikoro.client.ui.theme.PrimaryOrange
+import com.machikoro.client.ui.theme.TextBlueDark
+
+/**
+ * In-app tutorial page documenting the hidden "Insider Trading" cheat and the
+ * accusation mechanic (client issue #336). Rendered as the final page of the
+ * rules viewer ([PdfViewerScreen]) so a player paging through the tutorial
+ * discovers it naturally. The wording mirrors the live in-game labels
+ * ("Insider tip", "Accuse of cheating") so the docs match what players see.
+ */
+@Composable
+fun CheatRulesContent(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp, vertical = 12.dp),
+        horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "Cheating & Accusations",
+            color = PrimaryOrange,
+            fontWeight = FontWeight.ExtraBold,
+            fontSize = 26.sp,
+            modifier = Modifier.padding(bottom = 12.dp),
+        )
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(14.dp),
+            colors = CardDefaults.cardColors(containerColor = PanelBackgroundBeige),
+            elevation = CardDefaults.cardElevation(defaultElevation = 6.dp),
+        ) {
+            Column(
+                modifier = Modifier.padding(18.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                SectionTitle("Insider Trading (the cheat)")
+                BodyLine(
+                    "On your own turn you can secretly peek at the best card to buy: " +
+                        "shake your phone, or tap the “Insider tip” button. The " +
+                        "strongest affordable establishment is highlighted in green in the shop.",
+                )
+                BodyLine("The tip is valid for the current turn only.")
+                BodyLine(
+                    "Using it is reported to the server — other players can accuse you " +
+                        "of cheating, so use it at your own risk.",
+                )
+
+                SectionTitle("Accusing a cheater")
+                BodyLine(
+                    "Suspect someone cheated? Tap that player to inspect them, then tap " +
+                        "“Accuse of cheating”.",
+                )
+                BodyLine("You can accuse only once per turn.")
+                BodyLine(
+                    "If you are right, the cheater is penalised. If you are wrong, you lose " +
+                        "a coin — so accuse carefully.",
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SectionTitle(text: String) {
+    Text(
+        text = text,
+        color = TextBlueDark,
+        fontWeight = FontWeight.Bold,
+        fontSize = 18.sp,
+        modifier = Modifier.padding(top = 4.dp),
+    )
+}
+
+@Composable
+private fun BodyLine(text: String) {
+    Text(
+        text = text,
+        color = TextBlueDark,
+        style = MaterialTheme.typography.bodyMedium,
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CheatRulesContentPreview() {
+    ClientTheme {
+        Background(R.drawable.background_wood)
+        CheatRulesContent()
+    }
+}

--- a/app/src/main/java/com/machikoro/client/ui/home/PdfViewerScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/home/PdfViewerScreen.kt
@@ -67,6 +67,10 @@ fun PdfViewerScreen(
     val context = LocalContext.current
     val configuration = LocalConfiguration.current
     val currentPage = remember { mutableIntStateOf(0) }
+    // Number of real PDF pages. The viewer appends one synthetic native page
+    // after these for the cheat/accusation tutorial (issue #336), so the
+    // displayed [totalPages] is pdfPageCount + 1 once the PDF has loaded.
+    val pdfPageCount = remember { mutableIntStateOf(0) }
     val totalPages = remember { mutableIntStateOf(0) }
     val currentBitmap = remember { mutableStateOf<Bitmap?>(null) }
     val pdfRendererRef = remember { mutableStateOf<PdfRenderer?>(null) }
@@ -98,7 +102,9 @@ fun PdfViewerScreen(
 
             fileDescriptorRef.value = fileDescriptor
             pdfRendererRef.value = pdfRenderer
-            totalPages.intValue = pdfRenderer.pageCount
+            pdfPageCount.intValue = pdfRenderer.pageCount
+            // +1 for the appended native "Cheating & Accusations" page (#336).
+            totalPages.intValue = pdfRenderer.pageCount + 1
 
             // Render first page
             renderPage(pdfRenderer, 0, currentBitmap)
@@ -107,17 +113,21 @@ fun PdfViewerScreen(
         }
     }
 
-    // Update bitmap when page changes
+    // Update bitmap when page changes (skip the appended native cheat page).
     LaunchedEffect(currentPage.intValue) {
-        pdfRendererRef.value?.let { renderer ->
-            renderPage(renderer, currentPage.intValue, currentBitmap)
+        if (currentPage.intValue < pdfPageCount.intValue) {
+            pdfRendererRef.value?.let { renderer ->
+                renderPage(renderer, currentPage.intValue, currentBitmap)
+            }
         }
     }
 
     // Re-render when orientation changes
     LaunchedEffect(configuration.orientation) {
-        pdfRendererRef.value?.let { renderer ->
-            renderPage(renderer, currentPage.intValue, currentBitmap)
+        if (currentPage.intValue < pdfPageCount.intValue) {
+            pdfRendererRef.value?.let { renderer ->
+                renderPage(renderer, currentPage.intValue, currentBitmap)
+            }
         }
     }
 
@@ -145,7 +155,10 @@ fun PdfViewerScreen(
                 .padding(top = 56.dp, bottom = if (totalPages.intValue > 1) 56.dp else 0.dp)
         ) {
             // PDF content
-            if (isLandscape) {
+            if (pdfPageCount.intValue > 0 && currentPage.intValue >= pdfPageCount.intValue) {
+                // Appended native tutorial page: Insider Trading cheat + accusations (#336).
+                CheatRulesContent(modifier = Modifier.fillMaxSize())
+            } else if (isLandscape) {
                 // Landscape: fit to height, centered
                 Box(
                     modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
## What & why

Closes #336. The Insider Trading cheat and the accusation mechanic are fully implemented but documented **nowhere a player can find them** — the only tutorial is the bundled `rules.pdf`, which has zero mention of the cheat. Sprint 3 requires the cheat to be in the tutorial.

This adds the documentation as **native Compose text appended as the final page of the existing in-app rules viewer** (issue Option A), so a player paging through the tutorial reaches it naturally. Option B (regenerating the 8.4 MB binary PDF) was rejected — not diff-friendly, not testable.

## Changes

- **`CheatRulesContent.kt`** (new) — a scrollable "Cheating & Accusations" page: an *Insider Trading* block (shake / **Insider tip** button → green highlight; valid one turn; reported to the server) and an *Accusing a cheater* block (**Accuse of cheating** via player inspection; **once per turn**; **wrong guess costs a coin**). Wording mirrors the live in-game labels so the docs match the UI.
- **`PdfViewerScreen.kt`** — tracks the real PDF page count separately and shows `totalPages = pageCount + 1`, rendering `CheatRulesContent` on the synthetic last page. Existing Previous/Next nav and the "Page X of Y" indicator are reused; a `pdfPageCount > 0` guard avoids a pre-load flash.
- **`CheatRulesContentTest.kt`** (new) — instrumented Compose test asserting the section heading and every acceptance-criterion detail is shown.

## Acceptance criteria

- [x] A player can discover the cheat + accusation rules from the in-app tutorial
- [x] Covers activation (shake / *Insider tip*), one-turn validity, server reporting, accusation mechanic + once-per-turn + wrong-accusation penalty
- [x] Reachable from the Home → Rules entry point (it's the last page)
- [x] Covered by a UI test (Option A)

## Verification

- `:app:assembleDebug` + `:app:lintDebug` — green.
- **Live emulator run**: registered + logged in, opened Home → Rules → paged to the end; the viewer reports **"Page 9 of 9"** and renders the cheat page, with "Next" correctly disabled on the last page.
- `CheatRulesContentTest` follows the existing `androidTest` convention (runs on a connected emulator, not in the lint/sonar CI).
