### PR TITLE
fix: re-animate non-active player's dice on Radio Tower reroll within the same turn

### DIFF
--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
@@ -56,6 +56,28 @@ private val DICE_FACES = listOf(
 fun diceDrawableFor(value: Int): Int =
     DICE_FACES.getOrElse(value - 1) { R.drawable.game_dice_perspective }
 
+/**
+ * Decides whether a newly received dice result should re-trigger the non-active player's
+ * rolling animation. A genuine roll or Radio Tower reroll always animates, but the
+ * authoritative snapshot that collapses the live per-die result `[a, b]` into its total
+ * `[a + b]` must not — otherwise the animation replays on every snapshot (#346).
+ *
+ * @param newResult the dice result that just arrived.
+ * @param lastAnimatedResult the result the animation last played for this turn, or null.
+ */
+internal fun shouldAnimateNonActiveRoll(
+    newResult: List<Int>?,
+    lastAnimatedResult: List<Int>?,
+): Boolean {
+    if (newResult.isNullOrEmpty()) return false
+    if (newResult == lastAnimatedResult) return false
+    val isSnapshotCollapse = newResult.size == 1 &&
+        lastAnimatedResult != null &&
+        lastAnimatedResult.size > 1 &&
+        newResult.single() == lastAnimatedResult.sum()
+    return !isSnapshotCollapse
+}
+
 @Composable
 fun DiceAnimationDisplay(
     animating: Boolean,
@@ -160,8 +182,9 @@ fun DiceSection(
     var hasRerolled by remember(state.roundNumber, state.activePlayerId) { mutableStateOf(false) }
     // Captures dice count when non-active player animation is triggered (ROLL_DICE message has per-die values).
     var localAnimationDiceCount by remember(state.roundNumber, state.activePlayerId) { mutableIntStateOf(1) }
-    // Guards against re-triggering when snapshot overwrites live [x, y] result with [total].
-    var hasAnimatedThisTurn by remember(state.roundNumber, state.activePlayerId) { mutableStateOf(false) }
+    // Last result the non-active animation played for. Lets a genuine reroll re-animate within the
+    // same turn while ignoring the snapshot that collapses the live [x, y] result into [total] (#346).
+    var lastAnimatedResult by remember(state.roundNumber, state.activePlayerId) { mutableStateOf<List<Int>?>(null) }
 
     // Active player uses frozen/selected count; snapshot only stores total so diceResult.size is unreliable after reconnect.
     // Non-active player uses the count captured from the live ROLL_DICE message (before snapshot overwrites it).
@@ -172,19 +195,21 @@ fun DiceSection(
     }
 
     LaunchedEffect(state.diceResult) {
-        when {
-            state.diceResult == null -> {
-                // New turn — reset all per-turn local state.
-                selectedDiceCount = null
-                frozenDiceCount = null
-                hasRerolled = false
-            }
-            !state.isActivePlayer && !isAnimating && !hasAnimatedThisTurn -> {
-                // Non-active player: capture count from ROLL_DICE message (has per-die values) before snapshot overwrites.
-                localAnimationDiceCount = state.diceResult.size
-                isAnimating = true
-                hasAnimatedThisTurn = true
-            }
+        val result = state.diceResult
+        if (result == null) {
+            // New turn — reset all per-turn local state.
+            selectedDiceCount = null
+            frozenDiceCount = null
+            hasRerolled = false
+            lastAnimatedResult = null
+            return@LaunchedEffect
+        }
+        if (!state.isActivePlayer && !isAnimating && shouldAnimateNonActiveRoll(result, lastAnimatedResult)) {
+            // Non-active player: capture count from the live ROLL_DICE message (has per-die values)
+            // and animate. Snapshot collapses [x, y] into [total]; that overwrite is ignored (#346).
+            localAnimationDiceCount = result.size
+            lastAnimatedResult = result
+            isAnimating = true
         }
     }
 

--- a/app/src/test/java/com/machikoro/client/ui/game/ui/DiceTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/ui/DiceTest.kt
@@ -1,0 +1,62 @@
+package com.machikoro.client.ui.game.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [shouldAnimateNonActiveRoll], the decision behind the non-active
+ * player's dice animation. Guards the Radio Tower reroll case (#346): a genuine
+ * reroll must re-animate within the same turn, while the authoritative snapshot
+ * that collapses the live per-die result into its total must not.
+ */
+class DiceTest {
+
+    @Test
+    fun firstRollAnimatesWhenNothingHasAnimatedYet() {
+        assertTrue(shouldAnimateNonActiveRoll(newResult = listOf(3, 4), lastAnimatedResult = null))
+    }
+
+    @Test
+    fun snapshotCollapseOfTwoDiceIntoTotalDoesNotReAnimate() {
+        // Live roll [3, 4] already animated; snapshot overwrites it with the total [7].
+        assertFalse(shouldAnimateNonActiveRoll(newResult = listOf(7), lastAnimatedResult = listOf(3, 4)))
+    }
+
+    @Test
+    fun rerollWithinSameTurnReAnimatesAfterCollapse() {
+        // lastAnimatedResult stays [3, 4] across the collapse; a fresh reroll [2, 5] must animate.
+        assertTrue(shouldAnimateNonActiveRoll(newResult = listOf(2, 5), lastAnimatedResult = listOf(3, 4)))
+    }
+
+    @Test
+    fun rerollWithSameTotalButDifferentDiceReAnimates() {
+        assertTrue(shouldAnimateNonActiveRoll(newResult = listOf(5, 2), lastAnimatedResult = listOf(3, 4)))
+    }
+
+    @Test
+    fun singleDieRerollReAnimates() {
+        assertTrue(shouldAnimateNonActiveRoll(newResult = listOf(6), lastAnimatedResult = listOf(4)))
+    }
+
+    @Test
+    fun identicalResultDoesNotReAnimate() {
+        assertFalse(shouldAnimateNonActiveRoll(newResult = listOf(3, 4), lastAnimatedResult = listOf(3, 4)))
+    }
+
+    @Test
+    fun nullResultDoesNotAnimate() {
+        assertFalse(shouldAnimateNonActiveRoll(newResult = null, lastAnimatedResult = listOf(3, 4)))
+    }
+
+    @Test
+    fun emptyResultDoesNotAnimate() {
+        assertFalse(shouldAnimateNonActiveRoll(newResult = emptyList(), lastAnimatedResult = null))
+    }
+
+    @Test
+    fun newSingleDieValueAfterAnotherSingleDieReAnimates() {
+        // Both results are single-die, so this is a real roll, not a snapshot collapse.
+        assertTrue(shouldAnimateNonActiveRoll(newResult = listOf(5), lastAnimatedResult = listOf(2)))
+    }
+}


### PR DESCRIPTION
Closes #346

## Background
PR #320 added a `hasAnimatedThisTurn` guard so a non-active player's dice animation would not replay when the authoritative server snapshot collapses the live per-die result (e.g. `[3, 4]`) into a single total (`[7]`). The snapshot persists only the total, so it overwrites the live result and was re-triggering the animation on every snapshot.

## Problem
That guard was too broad. A Radio Tower reroll never sets `diceResult` to `null` between rolls — the live reroll result replaces the previous value directly — so `hasAnimatedThisTurn` stayed `true` for the whole turn. Non-active players saw the first roll animate but the reroll silently swap in. The result still displayed correctly; only the rolling animation was skipped.

## Fix
Replace the boolean with `lastAnimatedResult` tracking plus a pure helper, `shouldAnimateNonActiveRoll(newResult, lastAnimatedResult)`, that distinguishes the two cases:

- **Snapshot collapse** — a single-element result whose value equals the sum of the previously animated multi-die result → do not re-animate.
- **Genuine roll / reroll** — any other new result → animate.

This keeps the original snapshot-collapse protection while allowing a same-turn reroll to animate again for non-active players.

## Testing
- New `DiceTest` unit tests for `shouldAnimateNonActiveRoll`: first roll, snapshot collapse, reroll after collapse, same-total-different-dice reroll, single-die reroll, identical-result no-op, and null/empty inputs.
- `./gradlew :app:testDebugUnitTest --tests "com.machikoro.client.ui.game.ui.DiceTest"` passes.

## Changes
- `Dice.kt` — swap `hasAnimatedThisTurn` for `lastAnimatedResult` + `shouldAnimateNonActiveRoll`.
- `DiceTest.kt` — unit coverage for the helper.
