### PR TITLE
Fix Roll Dice button UI: rename label and reposition dice image (#306)

### DIFF
--- a/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
@@ -29,6 +29,10 @@ data class GameScreenState(
     // Short feedback text shown in the shop for pending, success, or retryable errors.
     val purchaseMessage: String? = null,
     val isRolling: Boolean = false,
+    // Dice count the active player requested for the in-flight roll. Drives the
+    // rolling animation (how many dice spin) since the snapshot persists only
+    // the total, making diceResult.size unreliable after a reconnect.
+    val requestedDiceCount: Int = 1,
     // Reconnect snapshot fields (from /app/game.sync).
     val gameStatus: GameStatus? = null,
     val roundNumber: Int? = null,
@@ -88,6 +92,7 @@ data class GameScreenState(
             purchaseFeedbackItemType = null,
             purchaseMessage = null,
             isRolling = false,
+            requestedDiceCount = 1,
             gameStatus = null,
             roundNumber = null,
             playerCards = emptyMap(),

--- a/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
@@ -16,6 +16,10 @@ data class GameScreenState(
     val customDisplayText: String? = null,
     val players: List<PlayerCoinState>,
     val diceResult: List<Int>? = null,
+    // Bumped on every genuine roll/reroll (not on reconnect snapshots) so the UI
+    // can animate non-active players for each real roll, including a same-turn
+    // Radio Tower reroll (#346).
+    val diceRollTick: Long = 0L,
     val activePlayerId: Int? = null,
     val winnerId: Int? = null,
     val myUserId: Int? = null,

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -1015,9 +1015,17 @@ class OkHttpWebSocketClient(
         parseTurnPhase(game.optString("turnPhase"))?.let { mutableGamePhase.value = it }
         game.optIntOrNull("roundNumber")?.let { mutableRoundNumber.value = it }
         // The snapshot persists only the dice total (lastDiceRoll), not the
-        // individual dice — surface it as a single-element list so the game
-        // screen can show the last roll on reconnect.
-        game.optIntOrNull("lastDiceRoll")?.let { mutableDiceResult.value = listOf(it) }
+        // individual dice. Surface it as a single-element list so the last roll
+        // still shows on reconnect — but do NOT clobber a richer per-die result we
+        // already hold for the same roll (it sums to this total). Otherwise a
+        // routine snapshot collapses [x, y] into a single generic die mid-turn,
+        // which is the inconsistent "one vs two dice" display and also hides doubles.
+        game.optIntOrNull("lastDiceRoll")?.let { total ->
+            val current = mutableDiceResult.value
+            if (current == null || current.sum() != total) {
+                mutableDiceResult.value = listOf(total)
+            }
+        }
 
         val playerUsernames = parsePlayerUsernames(state.optJSONObject("playerUsernames"))
         mutablePlayers.value = state.optJSONArray("players").toPlayerCoinStates(state, game, playerUsernames)

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -75,6 +75,8 @@ class OkHttpWebSocketClient(
 
     override val diceResult: StateFlow<List<Int>?>
         get() = mutableDiceResult.asStateFlow()
+    override val diceRollTick: StateFlow<Long>
+        get() = mutableDiceRollTick.asStateFlow()
 
     override val activePlayerId: StateFlow<Int?>
         get() = mutableActivePlayerId.asStateFlow()
@@ -138,6 +140,7 @@ class OkHttpWebSocketClient(
     private val mutableWinnerId = MutableStateFlow<Int?>(null)
 
     private val mutableDiceResult = MutableStateFlow<List<Int>?>(null)
+    private val mutableDiceRollTick = MutableStateFlow(0L)
     private val mutableActivePlayerId = MutableStateFlow<Int?>(null)
     private val mutableActiveGameId = MutableStateFlow<Int?>(null)
     private val mutableIsLobbyHost = MutableStateFlow(false)
@@ -673,7 +676,12 @@ class OkHttpWebSocketClient(
                 }
                 parsePurchaseSuccess(json)?.let { mutablePurchaseEvents.tryEmit(it) }
                 parsePurchaseFailure(json)?.let { mutablePurchaseEvents.tryEmit(it) }
-                parseDiceResult(json)?.let { mutableDiceResult.value = it }
+                parseDiceResult(json)?.let {
+                    // Set the result first, then bump the tick so any collector
+                    // that reacts to the tick already sees the new dice (#346).
+                    mutableDiceResult.value = it
+                    mutableDiceRollTick.value += 1
+                }
                 handleGameEnded(json)
             }
             "ERROR" -> {
@@ -1407,6 +1415,7 @@ class OkHttpWebSocketClient(
         mutableGamePhase.value = GamePhase.NONE
         mutablePlayers.value = emptyList()
         mutableDiceResult.value = null
+        mutableDiceRollTick.value = 0L
         mutableActivePlayerId.value = null
         mutableLobbyCode.value = null
         mutableGameStatus.value = null

--- a/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
@@ -34,6 +34,10 @@ interface WebSocketClient {
     // Holds the latest dice result received from the server.
     // Null if no dice have been rolled yet in the current turn.
     val diceResult: StateFlow<List<Int>?>
+    // Monotonic counter bumped only on a genuine DICE_ROLLED/DICE_REROLLED frame
+    // (never on a reconnect snapshot). Lets the UI animate every real roll and
+    // reroll without being fooled by the [x, y] -> [total] snapshot collapse (#346).
+    val diceRollTick: StateFlow<Long>
     val activePlayerId: StateFlow<Int?>
     val winnerId: StateFlow<Int?>
 

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -143,7 +143,9 @@ fun GameScreen(
         when {
             state.isBuyingPhase -> 30
             state.gamePhase == GamePhase.ROLL_DICE -> 20
-            state.gamePhase == GamePhase.RESOLVE_EFFECTS -> 25
+            // Matches the actual auto-advance dwell so the countdown the player sees
+            // is the real time until RESOLVE_EFFECTS ends, not a longer, unrelated number.
+            state.gamePhase == GamePhase.RESOLVE_EFFECTS -> GameScreenViewModel.RESOLVE_EFFECTS_TIMER_SECONDS
             else -> 0
         }
 

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -441,6 +441,13 @@ fun GameScreen(
                             when {
                                 state.isRolling -> DiceAnimationDisplay()
                                 state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
+                                // #306: dice image sits beside the button (not inside it)
+                                // so a static die is shown before the first roll.
+                                else -> Image(
+                                    painter = painterResource(id = R.drawable.game_dice_perspective),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(56.dp)
+                                )
                             }
 
                             if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
@@ -473,10 +480,9 @@ fun GameScreen(
                                         ActionButton(
                                             onClick = { onReroll(state.diceResult?.size ?: 1) },
                                             enabled = !state.isRolling,
-                                            label = "Nochmal würfeln",
-                                            leftIcon = R.drawable.game_dice_perspective,
+                                            label = "Roll Dice Again",
                                             modifier = Modifier.semantics {
-                                                contentDescription = "Nochmal würfeln"
+                                                contentDescription = "Roll Dice Again"
                                             }
                                         )
                                         SecondaryActionButton(
@@ -492,10 +498,9 @@ fun GameScreen(
                                     ActionButton(
                                         onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
                                         enabled = !state.isRolling,
-                                        label = if (state.diceResult == null) "Würfeln" else "Nochmal würfeln",
-                                        leftIcon = R.drawable.game_dice_perspective,
+                                        label = if (state.diceResult == null) "Roll Dice" else "Roll Dice Again",
                                         modifier = Modifier.semantics {
-                                            contentDescription = "Würfeln"
+                                            contentDescription = "Roll Dice"
                                         }
                                     )
                                 }

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -431,17 +431,17 @@ fun GameScreen(
                     }
 
                     else if (state.gamePhase == GamePhase.ROLL_DICE || showRadioTowerReroll) {
-                        Row(
+                        Column(
                             modifier = Modifier
                                 .align(Alignment.Center)
                                 .padding(bottom = 32.dp),
-                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                            verticalAlignment = Alignment.CenterVertically
+                            verticalArrangement = Arrangement.spacedBy(12.dp),
+                            horizontalAlignment = Alignment.CenterHorizontally
                         ) {
                             when {
                                 state.isRolling -> DiceAnimationDisplay()
                                 state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
-                                // #306: dice image sits beside the button (not inside it)
+                                // #306: dice image sits above the button (not inside it)
                                 // so a static die is shown before the first roll.
                                 else -> Image(
                                     painter = painterResource(id = R.drawable.game_dice_perspective),

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -17,15 +17,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -53,8 +50,8 @@ import com.machikoro.client.domain.model.state.PurchaseState
 import com.machikoro.client.ui.cheat.ShakeDetector
 import com.machikoro.client.ui.game.ui.BigPlayerCardsDisplay
 import com.machikoro.client.ui.game.ui.BuyingPhaseShop
-import com.machikoro.client.ui.game.ui.DiceAnimationDisplay
 import com.machikoro.client.ui.game.ui.DiceResultDisplay
+import com.machikoro.client.ui.game.ui.DiceSection
 import com.machikoro.client.ui.game.ui.GamePhaseBanner
 import com.machikoro.client.ui.game.ui.GameScreenLayout
 import com.machikoro.client.ui.game.ui.InitializationLoadingOverlay
@@ -159,7 +156,6 @@ fun GameScreen(
 
     val isCardViewPossible = ((state.gamePhase == GamePhase.ROLL_DICE || state.gamePhase == GamePhase.BUY_OR_BUILD )
             && !state.isActivePlayer)
-    val showRadioTowerReroll = state.canReroll && canReroll
 
     LaunchedEffect(showOwnCards) {
         if (showOwnCards) {
@@ -351,7 +347,7 @@ fun GameScreen(
                             .align(Alignment.Center)
                             .offset(y = SIDE_CONTENT_OFFSET.dp)
                     ) {
-                        if(state.gamePhase != GamePhase.ROLL_DICE && !showRadioTowerReroll) {
+                        if(state.gamePhase != GamePhase.ROLL_DICE && state.gamePhase != GamePhase.RESOLVE_EFFECTS) {
                             state.diceResult?.let { DiceResultDisplay(dice = it) }
                         }
                     }
@@ -430,82 +426,15 @@ fun GameScreen(
                         } else BasicText("Waiting for purchase")
                     }
 
-                    else if (state.gamePhase == GamePhase.ROLL_DICE || showRadioTowerReroll) {
-                        Column(
-                            modifier = Modifier
-                                .align(Alignment.Center)
-                                .padding(bottom = 32.dp),
-                            verticalArrangement = Arrangement.spacedBy(12.dp),
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            when {
-                                state.isRolling -> DiceAnimationDisplay()
-                                state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
-                                // #306: dice image sits above the button (not inside it)
-                                // so a static die is shown before the first roll.
-                                else -> Image(
-                                    painter = painterResource(id = R.drawable.game_dice_perspective),
-                                    contentDescription = null,
-                                    modifier = Modifier.size(56.dp)
-                                )
-                            }
-
-                            if (state.isActivePlayer && state.gameStatus == GameStatus.IN_PROGRESS) {
-                                var selectedDiceCount by remember(state.roundNumber) { mutableIntStateOf(1) }
-
-                                if (state.gamePhase == GamePhase.ROLL_DICE && state.hasTrainStation) {
-                                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                        listOf(1, 2).forEach { count ->
-                                            Button(
-                                                onClick = { selectedDiceCount = count },
-                                                colors = ButtonDefaults.buttonColors(
-                                                    containerColor = if (selectedDiceCount == count)
-                                                        MaterialTheme.colorScheme.primary
-                                                    else
-                                                        MaterialTheme.colorScheme.surfaceVariant,
-                                                    contentColor = if (selectedDiceCount == count)
-                                                        MaterialTheme.colorScheme.onPrimary
-                                                    else
-                                                        MaterialTheme.colorScheme.onSurfaceVariant
-                                                )
-                                            ) {
-                                                Text("$count 🎲")
-                                            }
-                                        }
-                                    }
-                                }
-
-                                if (showRadioTowerReroll) {
-                                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                        ActionButton(
-                                            onClick = { onReroll(state.diceResult?.size ?: 1) },
-                                            enabled = !state.isRolling,
-                                            label = "Roll Dice Again",
-                                            modifier = Modifier.semantics {
-                                                contentDescription = "Roll Dice Again"
-                                            }
-                                        )
-                                        SecondaryActionButton(
-                                            onClick = onSkipReroll,
-                                            enabled = !state.isRolling,
-                                            label = "Skip",
-                                            modifier = Modifier.semantics {
-                                                contentDescription = "Skip reroll"
-                                            }
-                                        )
-                                    }
-                                } else {
-                                    ActionButton(
-                                        onClick = { onRollDice(if (state.hasTrainStation) selectedDiceCount else 1) },
-                                        enabled = !state.isRolling,
-                                        label = if (state.diceResult == null) "Roll Dice" else "Roll Dice Again",
-                                        modifier = Modifier.semantics {
-                                            contentDescription = "Roll Dice"
-                                        }
-                                    )
-                                }
-                            }
-                        }
+                    else if (state.gamePhase == GamePhase.ROLL_DICE || state.gamePhase == GamePhase.RESOLVE_EFFECTS) {
+                        DiceSection(
+                            state = state,
+                            onRollDice = onRollDice,
+                            onReroll = onReroll,
+                            onSkipReroll = onSkipReroll,
+                            canReroll = canReroll,
+                            modifier = Modifier.align(Alignment.Center)
+                        )
                     }
                 }
             },

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
@@ -298,7 +298,7 @@ class GameScreenViewModel(
         // the dice animation stuck in the rolling state.
         if (mutableState.value.isRolling) return
 
-        mutableState.update { it.copy(isRolling = true) }
+        mutableState.update { it.copy(isRolling = true, requestedDiceCount = diceCount) }
         startRollTimeout(expectedPhase = GamePhase.ROLL_DICE)
         webSocketClient.rollDice(diceCount)
     }

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
@@ -615,10 +615,16 @@ class GameScreenViewModel(
     companion object {
         /**
          * #302: how long the client dwells on RESOLVE_EFFECTS before auto-sending
-         * resolveEffects. Configurable; ~20s per the issue. A placeholder constant
-         * for now — a visible timer will replace it later.
+         * resolveEffects — long enough to read the dice result and income, then
+         * advance. This is the same value the RESOLVE_EFFECTS phase timer counts
+         * down (see [RESOLVE_EFFECTS_TIMER_SECONDS]), so the visible countdown and
+         * the actual phase length stay in lockstep. Players without a Radio Tower
+         * have nothing to decide here, so it is kept short rather than the old 20s.
          */
-        const val DEFAULT_RESOLVE_EFFECTS_DWELL_MS = 20_000L
+        const val DEFAULT_RESOLVE_EFFECTS_DWELL_MS = 6_000L
+
+        /** RESOLVE_EFFECTS phase-timer length, in seconds, derived from the dwell. */
+        const val RESOLVE_EFFECTS_TIMER_SECONDS = (DEFAULT_RESOLVE_EFFECTS_DWELL_MS / 1000L).toInt()
     }
 
     class Factory(

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
@@ -175,6 +175,14 @@ class GameScreenViewModel(
             }
         }
         viewModelScope.launch {
+            // #346: drives the non-active player's roll/reroll animation. Bumped
+            // only on a real DICE_ROLLED/DICE_REROLLED frame, so a same-turn reroll
+            // animates while the snapshot collapse ([x, y] -> [total]) does not.
+            webSocketClient.diceRollTick.collect { tick ->
+                mutableState.update { it.copy(diceRollTick = tick) }
+            }
+        }
+        viewModelScope.launch {
             webSocketClient.activePlayerId.collect { activePlayerId ->
                 // The Insider Trading cheat is valid for one turn only — drop it when the turn rotates.
                 if (mutableState.value.activePlayerId != activePlayerId) {

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
@@ -141,7 +141,17 @@ class GameScreenViewModel(
             webSocketClient.gamePhase.collect { gamePhase ->
                 var shouldCancelPendingRoll = false
                 mutableState.update { state ->
-                    state.copy(gamePhase = gamePhase)
+                    // A new roll phase means a fresh roll: drop the previous turn's
+                    // dice. The server never sends a null diceResult between turns, so
+                    // without this the stale result lingers — hiding the Roll Dice
+                    // button (its condition is diceResult == null) and leaving the last
+                    // number and a frozen die on screen.
+                    val enteringRollDice =
+                        gamePhase == GamePhase.ROLL_DICE && state.gamePhase != GamePhase.ROLL_DICE
+                    state.copy(
+                        gamePhase = gamePhase,
+                        diceResult = if (enteringRollDice) null else state.diceResult,
+                    )
                         .resetPurchaseFeedbackIf(gamePhase != GamePhase.BUY_OR_BUILD)
                         .let { updated ->
                             // Issue #175: if the server advances the phase without a

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
@@ -160,8 +160,9 @@ fun DiceSection(
     var hasRerolled by remember(state.roundNumber, state.activePlayerId) { mutableStateOf(false) }
     // Captures dice count when non-active player animation is triggered (ROLL_DICE message has per-die values).
     var localAnimationDiceCount by remember(state.roundNumber, state.activePlayerId) { mutableIntStateOf(1) }
-    // Guards against re-triggering when snapshot overwrites live [x, y] result with [total].
-    var hasAnimatedThisTurn by remember(state.roundNumber, state.activePlayerId) { mutableStateOf(false) }
+    // Last roll tick we already animated. Seeded with the current tick so entering
+    // mid-turn does not replay a roll that already happened (#346).
+    var lastAnimatedTick by remember { mutableStateOf(state.diceRollTick) }
 
     // Active player uses frozen/selected count; snapshot only stores total so diceResult.size is unreliable after reconnect.
     // Non-active player uses the count captured from the live ROLL_DICE message (before snapshot overwrites it).
@@ -172,25 +173,27 @@ fun DiceSection(
     }
 
     LaunchedEffect(state.diceResult) {
-        when {
-            state.diceResult == null -> {
-                // New turn — reset all per-turn local state.
-                selectedDiceCount = null
-                frozenDiceCount = null
-                hasRerolled = false
-                // #346: also clear the once-per-turn animation guard so a fresh
-                // result within the same turn (e.g. a Radio Tower reroll) animates
-                // again for non-active players instead of the result silently
-                // swapping in without a roll animation.
-                hasAnimatedThisTurn = false
-            }
-            !state.isActivePlayer && !isAnimating && !hasAnimatedThisTurn -> {
-                // Non-active player: capture count from ROLL_DICE message (has per-die values) before snapshot overwrites.
-                localAnimationDiceCount = state.diceResult.size
-                isAnimating = true
-                hasAnimatedThisTurn = true
-            }
+        if (state.diceResult == null) {
+            // New turn — reset per-turn local state.
+            selectedDiceCount = null
+            frozenDiceCount = null
+            hasRerolled = false
         }
+    }
+
+    // #346: animate non-active players on every genuine roll AND reroll. The tick
+    // is bumped only by real DICE_ROLLED/DICE_REROLLED frames, so a same-turn
+    // Radio Tower reroll replays the animation, while the [x, y] -> [total]
+    // snapshot collapse (which does not bump the tick) does not.
+    LaunchedEffect(state.diceRollTick) {
+        if (!state.isActivePlayer &&
+            state.diceResult != null &&
+            state.diceRollTick > lastAnimatedTick
+        ) {
+            localAnimationDiceCount = state.diceResult.size
+            isAnimating = true
+        }
+        lastAnimatedTick = state.diceRollTick
     }
 
     LaunchedEffect(isAnimating) {

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
@@ -1,29 +1,48 @@
 package com.machikoro.client.ui.game.ui
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.machikoro.client.R
+import com.machikoro.client.domain.enums.GamePhase
+import com.machikoro.client.domain.enums.GameStatus
+import com.machikoro.client.domain.model.state.GameScreenState
+import com.machikoro.client.ui.shared.ActionButton
+import com.machikoro.client.ui.shared.SecondaryActionButton
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 
-private const val DICE_ANIMATION_INTERVAL_MS = 100L
+private const val DICE_ANIMATION_INTERVAL_MS = 100L // faster change
+private const val DICE_ANIMATION_DURATION_MS = 5000L // active player: full timer
+private const val NON_ACTIVE_DICE_ANIMATION_MS = 2000L // non-active player: brief animation before reveal
 private val DICE_FACES = listOf(
     R.drawable.game_dice_1,
     R.drawable.game_dice_2,
@@ -33,21 +52,63 @@ private val DICE_FACES = listOf(
     R.drawable.game_dice_6
 )
 
+fun diceDrawableFor(value: Int): Int =
+    DICE_FACES.getOrElse(value - 1) { R.drawable.game_dice_perspective }
+
 @Composable
-fun DiceAnimationDisplay(modifier: Modifier = Modifier) {
+fun DiceAnimationDisplay(
+    animating: Boolean,
+    intervalMs: Long = DICE_ANIMATION_INTERVAL_MS,
+    modifier: Modifier = Modifier
+) {
     var currentFaceIndex by remember { mutableIntStateOf(0) }
 
-    LaunchedEffect(Unit) {
-        while (true) {
-            delay(DICE_ANIMATION_INTERVAL_MS)
-            currentFaceIndex = (0..5).random()
+    LaunchedEffect(animating) {
+        if (animating) {
+            // Keep changing faces while animating is true. This loop is cancelable when
+            // the composable's LaunchedEffect key changes (animating -> false) or
+            // when the composition leaves.
+            while (animating && isActive) {
+                currentFaceIndex = (0..5).random()
+                delay(intervalMs)
+            }
         }
     }
 
     Image(
         painter = painterResource(id = DICE_FACES[currentFaceIndex]),
-        contentDescription = "Dice",
+        contentDescription = "Dice rolling",
+        modifier = modifier.size(64.dp)
+    )
+}
+
+@Composable
+fun DiceCountSelector(
+    diceCount: Int,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Image(
+        painter = painterResource(id = diceDrawableFor(diceCount)),
+        contentDescription = "Select $diceCount dice",
         modifier = modifier
+            .size(80.dp)
+            .border(
+                width = if (isSelected) 4.dp else 2.dp,
+                color = if (isSelected)
+                    MaterialTheme.colorScheme.primary
+                else
+                    MaterialTheme.colorScheme.outlineVariant,
+                shape = RoundedCornerShape(12.dp)
+            )
+            .padding(8.dp)
+            .clickable(
+                enabled = true,
+                onClick = onClick,
+                role = Role.Button
+            )
+            .alpha(if (isSelected) 1f else 0.6f)
     )
 }
 
@@ -62,33 +123,188 @@ fun DiceResultDisplay(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        // Removed for now
-        /*
         dice.forEach { value ->
-            Text(
-                text = DICE_FACES.getOrElse(value - 1) { value.toString() },
-                style = MaterialTheme.typography.displaySmall
+            Image(
+                painter = painterResource(id = diceDrawableFor(value)),
+                contentDescription = "Dice showing $value",
+                modifier = Modifier.size(56.dp)
             )
         }
-         */
-        Image(
-            painter = painterResource(id = R.drawable.game_dice_perspective),
-            contentDescription = "Dice",
-            modifier = Modifier.size(56.dp)
-        )
-
         Text(
             text = "$sum",
-            fontSize = 30.sp,
+            style = MaterialTheme.typography.bodyLarge,
+            fontSize = 36.sp,
             fontWeight = FontWeight.Bold,
             color = Color.White
         )
     }
 }
 
+@Composable
+fun DiceSection(
+    state: GameScreenState,
+    onRollDice: (diceCount: Int) -> Unit,
+    onReroll: (diceCount: Int) -> Unit,
+    onSkipReroll: () -> Unit = {},
+    canReroll: Boolean = true,
+    modifier: Modifier = Modifier
+) {
+    // Show during rolling and the reroll window (Radio Tower)
+    if (state.gamePhase != GamePhase.ROLL_DICE && state.gamePhase != GamePhase.RESOLVE_EFFECTS) return
+
+    var isAnimating by remember { mutableStateOf(false) }
+    // Key on both roundNumber + activePlayerId so state resets on every player's turn, not just per round.
+    var selectedDiceCount by remember(state.roundNumber, state.activePlayerId) { mutableStateOf<Int?>(null) }
+    var frozenDiceCount by remember(state.roundNumber, state.activePlayerId) { mutableStateOf<Int?>(null) }
+    // Tracks whether the player already used the Radio Tower reroll this turn.
+    var hasRerolled by remember(state.roundNumber, state.activePlayerId) { mutableStateOf(false) }
+    // Captures dice count when non-active player animation is triggered (ROLL_DICE message has per-die values).
+    var localAnimationDiceCount by remember(state.roundNumber, state.activePlayerId) { mutableIntStateOf(1) }
+    // Guards against re-triggering when snapshot overwrites live [x, y] result with [total].
+    var hasAnimatedThisTurn by remember(state.roundNumber, state.activePlayerId) { mutableStateOf(false) }
+
+    // Active player uses frozen/selected count; snapshot only stores total so diceResult.size is unreliable after reconnect.
+    // Non-active player uses the count captured from the live ROLL_DICE message (before snapshot overwrites it).
+    val animationDiceCount = if (state.isActivePlayer) {
+        frozenDiceCount ?: selectedDiceCount ?: state.requestedDiceCount
+    } else {
+        localAnimationDiceCount
+    }
+
+    LaunchedEffect(state.diceResult) {
+        when {
+            state.diceResult == null -> {
+                // New turn — reset all per-turn local state.
+                selectedDiceCount = null
+                frozenDiceCount = null
+                hasRerolled = false
+                // #346: also clear the once-per-turn animation guard so a fresh
+                // result within the same turn (e.g. a Radio Tower reroll) animates
+                // again for non-active players instead of the result silently
+                // swapping in without a roll animation.
+                hasAnimatedThisTurn = false
+            }
+            !state.isActivePlayer && !isAnimating && !hasAnimatedThisTurn -> {
+                // Non-active player: capture count from ROLL_DICE message (has per-die values) before snapshot overwrites.
+                localAnimationDiceCount = state.diceResult.size
+                isAnimating = true
+                hasAnimatedThisTurn = true
+            }
+        }
+    }
+
+    LaunchedEffect(isAnimating) {
+        if (isAnimating) {
+            // Non-active players already have the result; show a shorter animation before revealing it.
+            delay(if (state.isActivePlayer) DICE_ANIMATION_DURATION_MS else NON_ACTIVE_DICE_ANIMATION_MS)
+            isAnimating = false
+        }
+    }
+
+    // Stop animation for active player as soon as server confirms the result — avoids blocking
+    // the result display behind the full fixed timer when server responds in <5 s.
+    LaunchedEffect(state.isRolling) {
+        if (!state.isRolling && state.isActivePlayer && isAnimating) {
+            isAnimating = false
+        }
+    }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = modifier.padding(bottom = 32.dp)
+    ) {
+        when {
+            isAnimating -> {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    repeat(animationDiceCount) {
+                        DiceAnimationDisplay(animating = true)
+                    }
+                }
+            }
+            state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
+            else -> {}
+        }
+
+        if (state.isActivePlayer &&
+            state.gameStatus == GameStatus.IN_PROGRESS &&
+            !isAnimating
+        ) {
+            // Roll controls only appear during the actual rolling phase
+            if (state.gamePhase == GamePhase.ROLL_DICE && state.hasTrainStation) {
+                Row(horizontalArrangement = Arrangement.spacedBy(24.dp)) {
+                    listOf(1, 2).forEach { count ->
+                        val isSelected = (selectedDiceCount ?: state.requestedDiceCount) == count
+                        DiceCountSelector(
+                            diceCount = count,
+                            isSelected = isSelected,
+                            onClick = {
+                                selectedDiceCount = count
+                                frozenDiceCount = count
+                            }
+                        )
+                    }
+                }
+            }
+
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                // Roll button: only when server has no result yet and we are in ROLL_DICE
+                if (state.gamePhase == GamePhase.ROLL_DICE && state.diceResult == null) {
+                    val chosen = frozenDiceCount ?: selectedDiceCount ?: state.requestedDiceCount
+                    Image(
+                        painter = painterResource(id = R.drawable.game_dice_perspective),
+                        contentDescription = "Dice",
+                        modifier = Modifier.size(48.dp)
+                    )
+                    ActionButton(
+                        onClick = {
+                            frozenDiceCount = chosen
+                            isAnimating = true
+                            onRollDice(chosen)
+                        },
+                        enabled = true,
+                        label = "Roll Dice",
+                        modifier = Modifier.semantics {
+                            contentDescription = "Roll Dice"
+                        }
+                    )
+                }
+
+                // Reroll button: canReroll already gates this to RESOLVE_EFFECTS + Radio Tower + result exists
+                if (state.canReroll && canReroll && !hasRerolled) {
+                    val rerollCount = frozenDiceCount ?: state.diceResult?.size ?: 1
+                    ActionButton(
+                        onClick = {
+                            hasRerolled = true
+                            frozenDiceCount = rerollCount
+                            isAnimating = true
+                            onReroll(rerollCount)
+                        },
+                        enabled = true,
+                        label = "Roll Dice Again",
+                        modifier = Modifier.semantics {
+                            contentDescription = "Reroll Dice"
+                        }
+                    )
+                    SecondaryActionButton(
+                        onClick = onSkipReroll,
+                        enabled = true,
+                        label = "Skip",
+                        modifier = Modifier.semantics {
+                            contentDescription = "Skip reroll"
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
 
 @Preview(showBackground = true, widthDp = 412, heightDp = 400)
 @Composable
-private fun GameScreenNonePreview() {
-    DiceAnimationDisplay()
+private fun DiceAnimationPreview() {
+    DiceAnimationDisplay(animating = true, intervalMs = 80)
 }

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
@@ -41,8 +41,13 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 
 private const val DICE_ANIMATION_INTERVAL_MS = 100L // faster change
-private const val DICE_ANIMATION_DURATION_MS = 5000L // active player: full timer
-private const val NON_ACTIVE_DICE_ANIMATION_MS = 2000L // non-active player: brief animation before reveal
+// One brief roll animation for everyone, so the reveal isn't held behind a long fixed
+// delay and active/non-active players stay in lockstep (matters during a Radio Tower
+// reroll where both spin off the same roll tick). The active player's spin also ends
+// the instant the server confirms the result (see the isRolling effect below), so this
+// is only the upper bound; non-active players already hold the result and reveal it
+// after the same short spin.
+private const val DICE_ANIMATION_DURATION_MS = 1500L
 private val DICE_FACES = listOf(
     R.drawable.game_dice_1,
     R.drawable.game_dice_2,
@@ -198,8 +203,8 @@ fun DiceSection(
 
     LaunchedEffect(isAnimating) {
         if (isAnimating) {
-            // Non-active players already have the result; show a shorter animation before revealing it.
-            delay(if (state.isActivePlayer) DICE_ANIMATION_DURATION_MS else NON_ACTIVE_DICE_ANIMATION_MS)
+            // Same brief spin for active and non-active players before the result shows.
+            delay(DICE_ANIMATION_DURATION_MS)
             isAnimating = false
         }
     }
@@ -257,11 +262,6 @@ fun DiceSection(
                 // Roll button: only when server has no result yet and we are in ROLL_DICE
                 if (state.gamePhase == GamePhase.ROLL_DICE && state.diceResult == null) {
                     val chosen = frozenDiceCount ?: selectedDiceCount ?: state.requestedDiceCount
-                    Image(
-                        painter = painterResource(id = R.drawable.game_dice_perspective),
-                        contentDescription = "Dice",
-                        modifier = Modifier.size(48.dp)
-                    )
                     ActionButton(
                         onClick = {
                             frozenDiceCount = chosen

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
@@ -123,25 +123,43 @@ fun DiceResultDisplay(
     modifier: Modifier = Modifier
 ) {
     val sum = dice.sum()
+    // Doubles (two equal dice) matter in Machi Koro — the Amusement Park grants an
+    // extra turn on doubles — so call them out instead of leaving players to notice.
+    val isDoubles = dice.size == 2 && dice.distinct().size == 1
 
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+        modifier = modifier
     ) {
-        dice.forEach { value ->
-            Image(
-                painter = painterResource(id = diceDrawableFor(value)),
-                contentDescription = "Dice showing $value",
-                modifier = Modifier.size(56.dp)
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            dice.forEach { value ->
+                Image(
+                    painter = painterResource(id = diceDrawableFor(value)),
+                    contentDescription = "Dice showing $value",
+                    modifier = Modifier.size(56.dp)
+                )
+            }
+            Text(
+                text = "$sum",
+                style = MaterialTheme.typography.bodyLarge,
+                fontSize = 36.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color.White
             )
         }
-        Text(
-            text = "$sum",
-            style = MaterialTheme.typography.bodyLarge,
-            fontSize = 36.sp,
-            fontWeight = FontWeight.Bold,
-            color = Color.White
-        )
+        if (isDoubles) {
+            Text(
+                text = "Doubles!",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = Color.Yellow,
+                modifier = Modifier.semantics { contentDescription = "Doubles" }
+            )
+        }
     }
 }
 

--- a/app/src/test/java/com/machikoro/client/network/websocket/FakeWebSocketClient.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/FakeWebSocketClient.kt
@@ -42,6 +42,9 @@ class FakeWebSocketClient : WebSocketClient {
     override val diceResult: StateFlow<List<Int>?>
         get() = mutableDiceResult
 
+    override val diceRollTick: StateFlow<Long>
+        get() = mutableDiceRollTick
+
     override val activePlayerId: StateFlow<Int?>
         get() = mutableActivePlayerId
 
@@ -90,6 +93,7 @@ class FakeWebSocketClient : WebSocketClient {
     )
     private val mutableWinnerId = MutableStateFlow<Int?>(null)
     private val mutableDiceResult = MutableStateFlow<List<Int>?>(null)
+    private val mutableDiceRollTick = MutableStateFlow(0L)
     private val mutableActivePlayerId = MutableStateFlow<Int?>(null)
     private val mutableActiveGameId = MutableStateFlow<Int?>(null)
     private val mutableIsLobbyHost = MutableStateFlow(false)
@@ -190,6 +194,7 @@ class FakeWebSocketClient : WebSocketClient {
         mutablePlayers.value = emptyList()
         mutableLobbyCode.value = null
         mutableDiceResult.value = null
+        mutableDiceRollTick.value = 0L
         mutableActivePlayerId.value = null
         mutableActiveGameId.value = null
         mutableIsLobbyHost.value = false
@@ -271,6 +276,7 @@ class FakeWebSocketClient : WebSocketClient {
     
     fun emitDiceResult(dice: List<Int>) {
         mutableDiceResult.value = dice
+        mutableDiceRollTick.value += 1
     }
 
     fun emitActivePlayerId(id: Int?) {

--- a/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
@@ -182,6 +182,22 @@ class WebSocketClientTest {
     }
 
     @Test
+    fun laterSnapshotDoesNotCollapsePerDiceResultIntoTotal() {
+        val fixture = okHttpClientFixture()
+
+        // Live roll gives the individual dice (2 + 6 = 8).
+        fixture.deliverMessage(rollDiceMessage())
+        assertEquals(listOf(2, 6), fixture.client.diceResult.value)
+
+        // A routine snapshot only carries the total (lastDiceRoll:8). It must not
+        // overwrite the richer per-die result for the same roll, or the dice display
+        // would flip from two dice to one generic die and hide doubles.
+        fixture.deliverMessage(gameActionMessage())
+
+        assertEquals(listOf(2, 6), fixture.client.diceResult.value)
+    }
+
+    @Test
     fun gameEndAppliesFinalSnapshot() {
         val fixture = okHttpClientFixture()
 

--- a/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
@@ -49,6 +49,7 @@ class DummyWebSocketClient : WebSocketClient {
     override val isLobbyHost: StateFlow<Boolean> = MutableStateFlow(false)
     override val winnerId: StateFlow<Int?> = MutableStateFlow(null)
     override val diceResult: StateFlow<List<Int>?> = MutableStateFlow(null)
+    override val diceRollTick: StateFlow<Long> = MutableStateFlow(0L)
     override val activePlayerId: StateFlow<Int?> = MutableStateFlow(null)
     override val authRejections = kotlinx.coroutines.flow.MutableSharedFlow<Unit>()
     override val lobbyJoinErrors: SharedFlow<ClientError.WebSocket> = MutableSharedFlow(

--- a/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
@@ -93,6 +93,26 @@ class GameScreenViewModelTest {
     }
 
     @Test
+    fun diceRollTickIncrementsInStateOnEachRoll() = runTest {
+        // #346: the tick is what drives the non-active player's roll/reroll
+        // animation, so every genuine dice result must bump it in state.
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient)
+
+        assertEquals(0L, viewModel.state.value.diceRollTick)
+
+        fakeClient.emitDiceResult(listOf(3, 4))
+        advanceUntilIdle()
+        val afterRoll = viewModel.state.value.diceRollTick
+        assertTrue(afterRoll > 0L)
+
+        // A same-turn reroll (a second genuine result) bumps the tick again.
+        fakeClient.emitDiceResult(listOf(6, 6))
+        advanceUntilIdle()
+        assertTrue(viewModel.state.value.diceRollTick > afterRoll)
+    }
+
+    @Test
     fun gamePhaseUpdatesAreReflectedInState() = runTest {
         val fakeClient = FakeWebSocketClient()
         val viewModel = viewModel(fakeClient)

--- a/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
@@ -214,6 +214,24 @@ class GameScreenViewModelTest {
     }
 
     @Test
+    fun diceResultIsClearedWhenEnteringRollDicePhase() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient)
+
+        // Previous turn's result, outside the roll phase.
+        fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
+        fakeClient.emitDiceResult(listOf(3, 4))
+        advanceUntilIdle()
+        assertEquals(listOf(3, 4), viewModel.state.value.diceResult)
+
+        // A new turn enters ROLL_DICE: the stale result must be dropped so the
+        // Roll Dice button reappears and the old number/die stop showing.
+        fakeClient.emitGamePhase(GamePhase.ROLL_DICE)
+        advanceUntilIdle()
+        assertNull(viewModel.state.value.diceResult)
+    }
+
+    @Test
     fun activeGameIdFromClientIsReflectedInState() = runTest {
         val fakeClient = FakeWebSocketClient()
         val viewModel = viewModel(fakeClient)

--- a/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
@@ -250,6 +250,7 @@ class HomeScreenViewModelTest {
             MutableStateFlow(GamePhase.NONE)
         override val diceResult: StateFlow<List<Int>?> =
             MutableStateFlow(null)
+        override val diceRollTick: StateFlow<Long> = MutableStateFlow(0L)
         override val activePlayerId: StateFlow<Int?> = // NEU
             MutableStateFlow(null)
         override val players: StateFlow<List<PlayerCoinState>> =


### PR DESCRIPTION
## Overview

Reworks the dice‑roll UI on the game screen and incorporates several rounds of review feedback. Closes:

- **#306** — Roll Dice button UI: rename label and reposition the dice image.
- **#346** — Non‑active players do not see the Radio Tower reroll animation within the same turn.

The branch starts from the revert of #320 (reverted in #348), **merges current `main`**, then re‑applies the dice work and the review fixes on top.

---

## #306 — Roll Dice button label & dice image
- Label reads **"Roll Dice"** (and **"Roll Dice Again"** for a reroll) instead of the German "Würfeln".
- Per review, the standalone die image previously shown beside the button was **removed** — the button stands on its own.

## #346 — Reroll animation for non‑active players
Non‑active players now animate on **every genuine roll and same‑turn reroll**, driven by a monotonic `diceRollTick` that is bumped only on real `DICE_ROLLED`/`DICE_REROLLED` frames (never on a reconnect snapshot). This animates real rerolls while ignoring the `[x, y] → [total]` snapshot collapse, order‑independently.

- `WebSocketClient` exposes `diceRollTick`; `OkHttpWebSocketClient` bumps it only on the accept path of a genuine roll/reroll frame.
- `GameScreenViewModel` folds it into `GameScreenState.diceRollTick`.
- `DiceSection` animates non‑active players when the tick advances (seeded with the current tick so entering mid‑turn doesn't replay an old roll).

---

## Review feedback addressed

**Roll dice timing / phase delay**
- Unified the rolling animation to a single brief duration (~1.5s) for active and non‑active players, so reveals stay in lockstep — which matters during a Radio Tower reroll where both spin off the same roll tick. The active player's spin still ends the instant the server confirms the result.
- The RESOLVE_EFFECTS auto‑advance dwell dropped from **20s → 6s** and now **drives the phase timer's countdown** (`RESOLVE_EFFECTS_TIMER_SECONDS`), so the number players see is the real time until the phase ends. Players without a Radio Tower no longer wait 20s with nothing to decide.

**Missing Roll Dice button / stale dice on screen**
- The server never sends a `null` `diceResult` between turns, so the previous turn's result lingered into the next `ROLL_DICE` phase — hiding the Roll Dice button (its condition is `diceResult == null`) and leaving a frozen die + number on screen. The ViewModel now clears `diceResult` when a new `ROLL_DICE` phase begins.

**Inconsistent dice display (one die vs two)**
- A live roll sets `diceResult = [x, y]`, but a routine snapshot only stores `lastDiceRoll` (the total) and was overwriting it with `[x+y]` — a single generic die — mid‑turn. The snapshot now yields to a per‑die result that already sums to that total, keeping the two‑dice display stable.

**Doubles not visible**
- `DiceResultDisplay` now shows a **"Doubles!"** label when two equal dice are rolled (e.g. relevant for the Amusement Park's extra turn).

---

## Train Station / reroll controls (unchanged behaviour, kept)
- Train‑Station 1/2 dice‑count selector during `ROLL_DICE`.
- Radio Tower reroll (#326): **"Roll Dice Again"** + **"Skip"** during `RESOLVE_EFFECTS`.

## Changed files
- `ui/game/ui/Dice.kt` — `DiceSection`, `DiceCountSelector`, animated `DiceAnimationDisplay`, per‑die `DiceResultDisplay` (+ doubles label); removed the die image beside the button; unified animation duration.
- `network/websocket/WebSocketClient.kt` + `OkHttpWebSocketClient.kt` — `diceRollTick`; snapshot no longer collapses a per‑die result into the total.
- `domain/model/state/GameScreenState.kt` — `requestedDiceCount`, `diceRollTick`.
- `ui/game/GameScreenViewModel.kt` — `rollDice()` sets `requestedDiceCount`; collect `diceRollTick`; clear stale `diceResult` on entering `ROLL_DICE`; shorter resolve dwell wired to the phase timer.
- `ui/game/GameScreen.kt` — render `DiceSection` for `ROLL_DICE`/`RESOLVE_EFFECTS`; phase timer reads the resolve dwell.
- Tests — `diceRollTickIncrementsInStateOnEachRoll`, `diceResultIsClearedWhenEnteringRollDicePhase`, `laterSnapshotDoesNotCollapsePerDiceResultIntoTotal`, plus test‑double updates.

## Verification
- `:app:compileDebugKotlin`, `:app:compileDebugUnitTestKotlin` compile.
- `:app:testDebugUnitTest` — **603 tests, 0 failures**.

Closes #306
Closes #346
