### PR TITLE
feat: Update Client to point to Railway production backend

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,8 +37,8 @@ fun buildProperty(name: String, defaultValue: String) =
         .orElse(providers.provider { localProperties.getProperty(name) })
         .orElse(defaultValue)
 
-val backendBaseUrl = buildProperty("backendBaseUrl", "http://10.0.2.2:8080")
-val websocketUrl = buildProperty("websocketUrl", "ws://10.0.2.2:8080/ws")
+val backendBaseUrl = buildProperty("backendBaseUrl", "https://machi-koro.up.railway.app")
+val websocketUrl = buildProperty("websocketUrl", "wss://machi-koro.up.railway.app/ws")
 
 android {
     namespace = "com.machikoro.client"

--- a/app/src/test/java/com/machikoro/client/config/AppConfigTest.kt
+++ b/app/src/test/java/com/machikoro/client/config/AppConfigTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 class AppConfigTest {
     @Test
     fun exposesConfiguredDefaultUrls() {
-        assertEquals("http://10.0.2.2:8080", AppConfig.backendBaseUrl)
-        assertEquals("ws://10.0.2.2:8080/ws", AppConfig.websocketUrl)
+        assertEquals("https://machi-koro.up.railway.app", AppConfig.backendBaseUrl)
+        assertEquals("wss://machi-koro.up.railway.app/ws", AppConfig.websocketUrl)
     }
 }


### PR DESCRIPTION
## Summary

Update the Android client to connect to the new Railway production backend instead of localhost development defaults.

## Changes

- **backendBaseUrl**: \`http://10.0.2.2:8080\` → \`https://machi-koro.up.railway.app\`
- **websocketUrl**: \`ws://10.0.2.2:8080/ws\` → \`wss://machi-koro.up.railway.app/ws\`

File: \`app/build.gradle.kts\` (lines 40-41)

## Context

The server has been migrated from AAU shared infrastructure to Railway cloud platform. The client now connects to the Railway production domain: **machi-koro.up.railway.app**

## Testing

- ✅ Build configuration updated with new endpoints
- ✅ WebSocket URL uses secure \`wss://\` for HTTPS domain
- ✅ Backend REST API URL uses HTTPS protocol

Once merged, the client will automatically connect to the production Railway backend when built.