### PR TITLE
ui refactoring

### DIFF
--- a/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
@@ -79,6 +79,8 @@ data class GameScreenState(
             it.landmarkType == landmarkType && it.isBuilt
         }
     }
+    val activePlayerUsername: String
+        get() = players.firstOrNull { it.isActivePlayer }?.displayName ?: "Player"
 
     companion object {
         fun initial() = GameScreenState(

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -429,7 +429,9 @@ fun GameScreen(
                                 recommendedCardType = cheatRecommendation,
                                 modifier = Modifier.align(Alignment.Center)
                             )
-                        } else BasicText("Waiting for purchase")
+                        } else BasicText(
+                            state.activePlayerUsername + " is deciding what card to buy",
+                            modifier = Modifier.offset(y = (-SIDE_CONTENT_OFFSET).dp))
                     }
 
                     else if (state.gamePhase == GamePhase.ROLL_DICE || state.gamePhase == GamePhase.RESOLVE_EFFECTS) {

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -342,15 +342,18 @@ fun GameScreen(
             // LEFT
             // =====================================
             leftContent = {
-                Box(modifier = Modifier.fillMaxHeight()) {
-
+                Box(modifier = Modifier
+                    .fillMaxHeight()) {
                     Box(
                         modifier = Modifier
                             .align(Alignment.Center)
                             .offset(y = SIDE_CONTENT_OFFSET.dp)
                     ) {
                         if(state.gamePhase != GamePhase.ROLL_DICE && state.gamePhase != GamePhase.RESOLVE_EFFECTS) {
-                            state.diceResult?.let { DiceResultDisplay(dice = it) }
+                            state.diceResult?.let {
+                                DiceResultDisplay(dice = it,
+                                    diceSize = 42.dp)
+                            }
                         }
                     }
 

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -352,7 +352,8 @@ fun GameScreen(
                         if(state.gamePhase != GamePhase.ROLL_DICE && state.gamePhase != GamePhase.RESOLVE_EFFECTS) {
                             state.diceResult?.let {
                                 DiceResultDisplay(dice = it,
-                                    diceSize = 42.dp)
+                                    diceSize = 42.dp,
+                                    modifier = Modifier.offset(y = (-10).dp))
                             }
                         }
                     }

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
@@ -22,13 +22,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.machikoro.client.R
@@ -48,6 +49,7 @@ private const val DICE_ANIMATION_INTERVAL_MS = 100L // faster change
 // is only the upper bound; non-active players already hold the result and reveal it
 // after the same short spin.
 private const val DICE_ANIMATION_DURATION_MS = 1500L
+private val DICE_SIZE = 64.dp
 private val DICE_FACES = listOf(
     R.drawable.game_dice_1,
     R.drawable.game_dice_2,
@@ -120,46 +122,76 @@ fun DiceCountSelector(
 @Composable
 fun DiceResultDisplay(
     dice: List<Int>,
+    diceSize: Dp = DICE_SIZE,
     modifier: Modifier = Modifier
 ) {
     val sum = dice.sum()
     // Doubles (two equal dice) matter in Machi Koro — the Amusement Park grants an
     // extra turn on doubles — so call them out instead of leaving players to notice.
     val isDoubles = dice.size == 2 && dice.distinct().size == 1
-
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(4.dp),
         modifier = modifier
     ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            dice.forEach { value ->
-                Image(
-                    painter = painterResource(id = diceDrawableFor(value)),
-                    contentDescription = "Dice showing $value",
-                    modifier = Modifier.size(56.dp)
-                )
-            }
-            Text(
-                text = "$sum",
-                style = MaterialTheme.typography.bodyLarge,
-                fontSize = 36.sp,
-                fontWeight = FontWeight.Bold,
-                color = Color.White
-            )
-        }
         if (isDoubles) {
             Text(
                 text = "Doubles!",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 color = Color.Yellow,
-                modifier = Modifier.semantics { contentDescription = "Doubles" }
+                modifier = Modifier.semantics {
+                    contentDescription = "Doubles"
+                }
             )
         }
+
+        if (dice.size == 1) {
+            // One die: image and number in one row
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Image(
+                    painter = painterResource(id = diceDrawableFor(dice.first())),
+                    contentDescription = "Dice showing ${dice.first()}",
+                    contentScale = ContentScale.FillBounds,
+                    modifier = Modifier.size(diceSize)
+                )
+
+                Text(
+                    text = "$sum",
+                    fontSize = 36.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White
+                )
+            }
+        } else {
+            // Two dice: dice in one row, number underneath
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Row {
+                    dice.forEach { value ->
+                        Image(
+                            painter = painterResource(id = diceDrawableFor(value)),
+                            contentDescription = "Dice showing $value",
+                            contentScale = ContentScale.FillBounds,
+                            modifier = Modifier.size(diceSize)
+                        )
+                    }
+                }
+
+                Text(
+                    text = "$sum",
+                    fontSize = 36.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White
+                )
+            }
+        }
+
+
     }
 }
 

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
@@ -132,7 +132,7 @@ fun DiceCountSelector(
                 contentDescription = "Select $diceCount dice",
                 modifier = modifier
                     .size(80.dp)
-                    .alpha(if (isSelected) 1f else 0.6f),
+                    .alpha(if (isSelected) 1f else 0.5f),
             )
             Image(
                 painter = painterResource(id = R.drawable.game_dice_perspective),
@@ -310,12 +310,8 @@ fun DiceSection(
                 }
             }
             state.diceResult != null -> {
-                Column {
-                    if(!state.isActivePlayer) {
-                        BasicText(
-                            state.activePlayerUsername + " has rolled:",
-                        )
-                    }
+                if (!state.isActivePlayer) {
+                    BasicText(state.activePlayerUsername + " has rolled:")
                 }
                 DiceResultDisplay(dice = state.diceResult)
             }
@@ -364,7 +360,7 @@ fun DiceSection(
                             onRollDice(chosen)
                         },
                         enabled = true,
-                        label = "Roll Dice" + if(chosen > 1) "s" else "",
+                        label = if (chosen > 1) "Roll $chosen Dice" else "Roll Dice",
                         modifier = Modifier.semantics {
                             contentDescription = "Roll Dice"
                         }

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -39,6 +40,7 @@ import com.machikoro.client.domain.enums.GamePhase
 import com.machikoro.client.domain.enums.GameStatus
 import com.machikoro.client.domain.model.state.GameScreenState
 import com.machikoro.client.ui.shared.ActionButton
+import com.machikoro.client.ui.shared.BasicText
 import com.machikoro.client.ui.shared.SecondaryActionButton
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -307,10 +309,23 @@ fun DiceSection(
                     }
                 }
             }
-            state.diceResult != null -> DiceResultDisplay(dice = state.diceResult)
+            state.diceResult != null -> {
+                Column {
+                    if(!state.isActivePlayer) {
+                        BasicText(
+                            state.activePlayerUsername + " has rolled:",
+                        )
+                    }
+                }
+                DiceResultDisplay(dice = state.diceResult)
+            }
             else -> {}
         }
-
+        if(!state.isActivePlayer && state.diceResult == null) {
+            BasicText(
+                state.activePlayerUsername + " is rolling dice",
+                modifier = Modifier.offset(y = (-35).dp))
+        }
         if (state.isActivePlayer &&
             state.gameStatus == GameStatus.IN_PROGRESS &&
             !isAnimating
@@ -349,10 +364,12 @@ fun DiceSection(
                             onRollDice(chosen)
                         },
                         enabled = true,
-                        label = "Roll Dice",
+                        label = "Roll Dice" + if(chosen > 1) "s" else "",
                         modifier = Modifier.semantics {
                             contentDescription = "Roll Dice"
                         }
+
+                            .width(145.dp)
                     )
                 }
 

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
@@ -177,7 +177,7 @@ fun DiceResultDisplay(
             // One die: image and number in one row
             Row(
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(4.dp)
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 Image(
                     painter = painterResource(id = diceDrawableFor(dice.first())),
@@ -199,7 +199,7 @@ fun DiceResultDisplay(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Row(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
                 ) {
                     dice.forEach { value ->
                         Image(

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
@@ -310,10 +310,19 @@ fun DiceSection(
                 }
             }
             state.diceResult != null -> {
-                if (!state.isActivePlayer) {
-                    BasicText(state.activePlayerUsername + " has rolled:")
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                )
+                {
+                    if(!state.isActivePlayer) {
+                        BasicText(
+                             state.activePlayerUsername + " has rolled:",
+                        )
+                    }
+                    DiceResultDisplay(dice = state.diceResult)
                 }
-                DiceResultDisplay(dice = state.diceResult)
+
             }
             else -> {}
         }
@@ -360,12 +369,11 @@ fun DiceSection(
                             onRollDice(chosen)
                         },
                         enabled = true,
-                        label = if (chosen > 1) "Roll $chosen Dice" else "Roll Dice",
+                        label = "Roll " + (if(chosen > 1) "Two " else "One ") + "Dice",
                         modifier = Modifier.semantics {
                             contentDescription = "Roll Dice"
                         }
-
-                            .width(145.dp)
+                            .width(180.dp)
                     )
                 }
 

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
@@ -369,7 +369,7 @@ fun DiceSection(
                             onRollDice(chosen)
                         },
                         enabled = true,
-                        label = "Roll " + (if(chosen > 1) "Two " else "One ") + "Dice",
+                        label = "Roll " + (if (chosen > 1) "Two Dice" else "One Die"),
                         modifier = Modifier.semantics {
                             contentDescription = "Roll Dice"
                         }

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
@@ -1,14 +1,16 @@
 package com.machikoro.client.ui.game.ui
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -96,27 +98,50 @@ fun DiceCountSelector(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Image(
-        painter = painterResource(id = diceDrawableFor(diceCount)),
-        contentDescription = "Select $diceCount dice",
-        modifier = modifier
-            .size(80.dp)
-            .border(
-                width = if (isSelected) 4.dp else 2.dp,
-                color = if (isSelected)
-                    MaterialTheme.colorScheme.primary
-                else
-                    MaterialTheme.colorScheme.outlineVariant,
-                shape = RoundedCornerShape(12.dp)
-            )
-            .padding(8.dp)
-            .clickable(
+    if(diceCount == 1) {
+        Box(
+            modifier =   Modifier.clickable(
                 enabled = true,
                 onClick = onClick,
-                role = Role.Button
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                role = Role.Button)
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.game_dice_perspective),
+                contentDescription = "Select $diceCount dice",
+                modifier = modifier
+                    .size(80.dp)
+                    .alpha(if (isSelected) 1f else 0.5f)
             )
-            .alpha(if (isSelected) 1f else 0.6f)
-    )
+        }
+    } else {
+        Row(
+            modifier = Modifier.clickable(
+                enabled = true,
+                onClick = onClick,
+                indication = null,
+                interactionSource = remember { MutableInteractionSource()},
+                role = Role.Button)
+                .wrapContentSize()
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.game_dice_perspective),
+                contentDescription = "Select $diceCount dice",
+                modifier = modifier
+                    .size(80.dp)
+                    .alpha(if (isSelected) 1f else 0.6f),
+            )
+            Image(
+                painter = painterResource(id = R.drawable.game_dice_perspective),
+                contentDescription = "Select $diceCount dice",
+                modifier = modifier
+                    .size(80.dp)
+                    .offset(y = (-35).dp)
+                    .alpha(if (isSelected) 1f else 0.5f),
+            )
+        }
+    }
 }
 
 @Composable
@@ -155,7 +180,7 @@ fun DiceResultDisplay(
                 Image(
                     painter = painterResource(id = diceDrawableFor(dice.first())),
                     contentDescription = "Dice showing ${dice.first()}",
-                    contentScale = ContentScale.FillBounds,
+                    contentScale = ContentScale.Fit,
                     modifier = Modifier.size(diceSize)
                 )
 
@@ -171,12 +196,14 @@ fun DiceResultDisplay(
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
-                Row {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
                     dice.forEach { value ->
                         Image(
                             painter = painterResource(id = diceDrawableFor(value)),
                             contentDescription = "Dice showing $value",
-                            contentScale = ContentScale.FillBounds,
+                            contentScale = ContentScale.Fit,
                             modifier = Modifier.size(diceSize)
                         )
                     }
@@ -290,7 +317,10 @@ fun DiceSection(
         ) {
             // Roll controls only appear during the actual rolling phase
             if (state.gamePhase == GamePhase.ROLL_DICE && state.hasTrainStation) {
-                Row(horizontalArrangement = Arrangement.spacedBy(24.dp)) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(24.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.wrapContentSize()) {
                     listOf(1, 2).forEach { count ->
                         val isSelected = (selectedDiceCount ?: state.requestedDiceCount) == count
                         DiceCountSelector(

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
@@ -22,7 +22,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -56,8 +55,10 @@ import com.machikoro.client.ui.theme.CardPurpleText
 import com.machikoro.client.ui.theme.PrimaryOrange
 import com.machikoro.client.ui.theme.TextBlueDark
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.offset
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
 
 private val SHOP_CARD_SHAPE = RoundedCornerShape(8.dp)
 val RecommendedHighlight = Color(0xFF00C853)
@@ -222,15 +223,21 @@ private fun ShopImageTile(
         }
 
         remainingQuantity?.let { count ->
-            CardQuantityIndicator(
-                quantity = count,
-                modifier = Modifier.align(Alignment.TopStart)
-            )
+                if(!isAlreadyOwnedPurple) {
+                CardQuantityIndicator(
+                    quantity = count,
+                    modifier = Modifier.align(Alignment.TopStart)
+                )
+            }
         }
 
         if (isAlreadyOwnedPurple) {
             OwnedCardIndicator(
-                modifier = Modifier.align(Alignment.TopEnd)
+                modifier = Modifier
+                    .align(Alignment.TopStart)
+                    .offset(
+                        y = (-15).dp,
+                    )
             )
         }
     }
@@ -241,14 +248,15 @@ private fun OwnedCardIndicator(modifier: Modifier = Modifier) {
     Text(
         text = "Owned",
         color = CardPurpleText,
-        fontSize = 12.sp,
+        fontSize = 14.sp,
         style = MaterialTheme.typography.labelSmall,
+        fontWeight = FontWeight.Bold,
         modifier = modifier
             .padding(top = 6.dp, end = 6.dp)
-            .clip(RoundedCornerShape(8.dp))
+            .clip(RoundedCornerShape(24.dp))
             .background(CardPurpleBackground)
-            .border(1.dp, CardPurpleText, RoundedCornerShape(8.dp))
-            .padding(horizontal = 8.dp, vertical = 3.dp)
+            .border(2.dp, CardPurpleText, RoundedCornerShape(24.dp))
+            .padding(horizontal = 14.dp, vertical = 4.dp)
             .semantics {
                 contentDescription = "Already owned card indicator"
             }

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
@@ -223,7 +223,7 @@ private fun ShopImageTile(
         }
 
         remainingQuantity?.let { count ->
-                if(!isAlreadyOwnedPurple) {
+            if (!isAlreadyOwnedPurple) {
                 CardQuantityIndicator(
                     quantity = count,
                     modifier = Modifier.align(Alignment.TopStart)


### PR DESCRIPTION
ui staff:
- smaller dices for left part
- different dice selection 


- added text info for non active players about active player actions: 
<img width="890" height="412" alt="Screenshot 2026-06-21 at 01 11 01" src="https://github.com/user-attachments/assets/33888d8a-0415-42e5-b2ff-ccd8a3187084" />
<img width="899" height="409" alt="Screenshot 2026-06-21 at 01 10 54" src="https://github.com/user-attachments/assets/5684f0e1-c088-4fa6-bb1d-5726dea7625e" />

<img width="900" height="414" alt="Screenshot 2026-06-21 at 01 11 18" src="https://github.com/user-attachments/assets/16c4dfba-36cd-444c-9da4-083b05a3f3d9" />
<img width="791" height="360" alt="Screenshot 2026-06-21 at 01 10 44" src="https://github.com/user-attachments/assets/aac76bc6-d941-428f-b4e0-f5a674336e4e" />

closes #347, #363 

