### PR TITLE
369 display purchased card for all players

### DIFF
--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -157,11 +157,12 @@ fun GameScreen(
 
     val phaseTimerTime =
         when {
-            state.isBuyingPhase -> 30
+            state.isBuyingPhase && state.purchaseState != PurchaseState.SUCCESS  -> 30
             state.gamePhase == GamePhase.ROLL_DICE -> 20
             // Matches the actual auto-advance dwell so the countdown the player sees
             // is the real time until RESOLVE_EFFECTS ends, not a longer, unrelated number.
             state.gamePhase == GamePhase.RESOLVE_EFFECTS -> GameScreenViewModel.RESOLVE_EFFECTS_TIMER_SECONDS
+            state.purchaseState == PurchaseState.SUCCESS -> 5
             else -> 0
         }
 
@@ -467,8 +468,7 @@ fun GameScreen(
                             modifier = Modifier.offset(y = (-SIDE_CONTENT_OFFSET).dp))
                     }
 
-                    else if (state.gamePhase == GamePhase.ROLL_DICE || state.gamePhase == GamePhase.RESOLVE_EFFECTS) {
-                        if (state.gamePhase == GamePhase.RESOLVE_EFFECTS) {
+                    else if (state.gamePhase == GamePhase.RESOLVE_EFFECTS) {
                             Column(
                                 modifier = Modifier
                                     .align(Alignment.Center)
@@ -508,7 +508,7 @@ fun GameScreen(
                                     }
                                 }
                             }
-                        } else {
+                        } else if (state.gamePhase == GamePhase.ROLL_DICE){
                             DiceSection(
                                 state = state,
                                 onRollDice = onRollDice,
@@ -519,8 +519,7 @@ fun GameScreen(
                             )
                         }
                     }
-            }
-                            },
+                },
 // =====================================
 // RIGHT
 // =====================================

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -89,7 +89,7 @@ private val MARKETPLACE_VIEW_DELAY = 10000L
 
 
 // offsets
-private val SIDE_CONTENT_OFFSET = 35
+const val SIDE_CONTENT_OFFSET = 35
 
 @Composable
 fun GameScreen(
@@ -455,7 +455,6 @@ fun GameScreen(
                     }
 
                     else if (state.isBuyingPhase) {
-                        if(state.isActivePlayer) {
                             BuyingPhaseShop(
                                 state = state,
                                 items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
@@ -463,9 +462,6 @@ fun GameScreen(
                                 recommendedCardType = cheatRecommendation,
                                 modifier = Modifier.align(Alignment.Center)
                             )
-                        } else BasicText(
-                            state.activePlayerUsername + " is deciding what card to buy",
-                            modifier = Modifier.offset(y = (-SIDE_CONTENT_OFFSET).dp))
                     }
 
                     else if (state.gamePhase == GamePhase.RESOLVE_EFFECTS) {
@@ -565,7 +561,7 @@ fun GameScreen(
                                 )
                             }
 
-                            if (state.isBuyingPhase) {
+                            if (state.isBuyingPhase && state.purchaseState != PurchaseState.SUCCESS) {
                                 SecondaryActionButton(
                                     onClick = onTurnFlowAction,
                                     enabled = state.purchaseState != PurchaseState.PENDING,

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.launch
 // Failsafe for issue #175: the server is expected to answer a roll with a
 // diceResult, but if that message is lost or delayed the UI must not animate forever.
 private const val DICE_ROLL_TIMEOUT_MS = 10_000L
+private const val PURCHASE_DISPLAY_DELAY = 5_000L
 
 class GameScreenViewModel(
     private val webSocketClient: WebSocketClient,
@@ -279,6 +280,7 @@ class GameScreenViewModel(
                     before.gamePhase == GamePhase.BUY_OR_BUILD &&
                     before.isActivePlayer
                 ) {
+                    delay(PURCHASE_DISPLAY_DELAY)
                     webSocketClient.endTurn(before.gameId)
                 }
             }

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
@@ -575,9 +575,10 @@ class GameScreenViewModel(
     private fun GameScreenState.applyPurchaseEvent(event: PurchaseEvent): GameScreenState =
         when (event) {
             is PurchaseEvent.Success -> {
-                // Only finish the local pending action when the server confirms the same target.
+                // The active buyer must still match its local pending action. Other players have
+                // no pending purchase, but should display the server's broadcast success feedback.
                 val matchesPending = pendingPurchaseItemType == event.itemType
-                if (!matchesPending) {
+                if (isActivePlayer && !matchesPending) {
                     this
                 } else {
                     copy(

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
@@ -59,6 +59,9 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import com.machikoro.client.ui.shared.AnimatedItem
+import com.machikoro.client.ui.shared.AnimationType
 
 private val SHOP_CARD_SHAPE = RoundedCornerShape(8.dp)
 val RecommendedHighlight = Color(0xFF00C853)
@@ -72,74 +75,90 @@ internal fun BuyingPhaseShop(
     modifier: Modifier = Modifier,
     recommendedCardType: CardType? = null
 ) {
-
-    val landmarks = remember(
-        items,
-        state.playerLandmarks,
-        state.players
-    ) {
-        items
-            .filter { it.purchaseType == PurchaseType.LANDMARK }
-            .filterNot { state.isKnownBuiltLandmark(it) }
-            .sortedBy { it.cost }
-    }
-
-    val establishments = remember(items) {
-        CardDefinitions.sortShopItemsByActivation(
-            items.filter { it.purchaseType == PurchaseType.ESTABLISHMENT }
-        )
-    }
-
-    CompositionLocalProvider(
-        LocalOverscrollFactory provides null
-    ) {
-        LazyColumn(
-            modifier = modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-
-            // LANDMARKS TITLE
-            item {
-                BasicText("Landmarks")
+    // displays purchased card after SUCCESS
+    if(state.purchaseState == PurchaseState.SUCCESS) {
+        state.purchaseFeedbackItemType?.let {
+            AnimatedItem(
+                delayMillis = 0,
+                animationType = AnimationType.Bounce
+            ) {
+                CardDisplay(drawableForPlayerCard(it))}
+        }
+    } else {
+        if(state.isActivePlayer) {
+            val landmarks = remember(
+                items,
+                state.playerLandmarks,
+                state.players
+            ) {
+                items
+                    .filter { it.purchaseType == PurchaseType.LANDMARK }
+                    .filterNot { state.isKnownBuiltLandmark(it) }
+                    .sortedBy { it.cost }
             }
 
-            // LANDMARKS ROW
-            item {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
+            val establishments = remember(items) {
+                CardDefinitions.sortShopItemsByActivation(
+                    items.filter { it.purchaseType == PurchaseType.ESTABLISHMENT }
+                )
+            }
+
+            CompositionLocalProvider(
+                LocalOverscrollFactory provides null
+            ) {
+                LazyColumn(
+                    modifier = modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
                 ) {
-                    landmarks.forEach { item ->
-                        ShopImageTile(
-                            item = item,
-                            state = state,
-                            onPurchaseClick = onPurchaseClick,
-                            isRecommended = item.type == recommendedCardType?.name
-                        )
+
+                    // LANDMARKS TITLE
+                    item {
+                        BasicText("Landmarks")
+                    }
+
+                    // LANDMARKS ROW
+                    item {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            landmarks.forEach { item ->
+                                ShopImageTile(
+                                    item = item,
+                                    state = state,
+                                    onPurchaseClick = onPurchaseClick,
+                                    isRecommended = item.type == recommendedCardType?.name
+                                )
+                            }
+                        }
+                    }
+
+                    // ESTABLISHMENTS TITLE
+                    item {
+                        BasicText("Establishments")
+                    }
+
+                    // GRID
+                    items(establishments.chunked(4)) { rowItems ->
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            rowItems.forEach { item ->
+                                ShopImageTile(
+                                    item = item,
+                                    state = state,
+                                    onPurchaseClick = onPurchaseClick,
+                                    isRecommended = item.type == recommendedCardType?.name
+                                )
+                            }
+                        }
                     }
                 }
             }
-
-            // ESTABLISHMENTS TITLE
-            item {
-                BasicText("Establishments")
-            }
-
-            // GRID
-            items(establishments.chunked(4)) { rowItems ->
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    rowItems.forEach { item ->
-                        ShopImageTile(
-                            item = item,
-                            state = state,
-                            onPurchaseClick = onPurchaseClick,
-                            isRecommended = item.type == recommendedCardType?.name
-                        )
-                    }
-                }
-            }
+        } else {
+            BasicText(
+                state.activePlayerUsername + " is deciding what card to buy",
+            )
         }
     }
 }
@@ -154,8 +173,6 @@ private fun ShopImageTile(
 ) {
     val canPurchase = state.canPurchaseItem(item)
     val isSelected = state.selectedPurchaseItemType == item.type
-    val isFeedbackItem = state.purchaseFeedbackItemType == item.type
-    val isSuccessFeedback = isFeedbackItem && state.purchaseState == PurchaseState.SUCCESS
     val remainingQuantity = state.remainingMarketplaceQuantityFor(item)
     val isAlreadyOwnedPurple = state.isAlreadyOwnedPurpleEstablishment(item)
     val isClickable = canPurchase || isSelected
@@ -200,7 +217,7 @@ private fun ShopImageTile(
             )
         }
 
-        if (isRecommended && !isSelected && !isSuccessFeedback) {
+        if (isRecommended && !isSelected) {
             Image(
                 painter = painterResource(R.drawable.card_frame_green),
                 contentDescription = null,
@@ -211,7 +228,7 @@ private fun ShopImageTile(
             )
         }
 
-        if (isSelected  || isSuccessFeedback) {
+        if (isSelected) {
             Image(
                 painter = painterResource(R.drawable.card_frame),
                 contentDescription = null,
@@ -291,11 +308,55 @@ private fun GameScreenState.isKnownBuiltLandmark(item: ShopItem): Boolean {
     }
 }
 
+private fun drawableForPlayerCard(cardType: String): Int =
+    when (cardType) {
+        CardType.WHEAT_FIELD.name -> R.drawable.card_wheat_field
+        CardType.RANCH.name -> R.drawable.card_ranch
+        CardType.FOREST.name -> R.drawable.card_forest
+        CardType.MINE.name -> R.drawable.card_mine
+        CardType.APPLE_ORCHARD.name -> R.drawable.card_apple_orchard
+        CardType.BAKERY.name -> R.drawable.card_bakery
+        CardType.CONVENIENCE_STORE.name -> R.drawable.card_convenience_store
+        CardType.CHEESE_FACTORY.name -> R.drawable.card_cheese_factory
+        CardType.FURNITURE_FACTORY.name -> R.drawable.card_furniture_factory
+        CardType.FRUIT_AND_VEGETABLE_MARKET.name ->
+            R.drawable.card_fruit_and_vegetable_market
+        CardType.CAFE.name -> R.drawable.card_cafe
+        CardType.FAMILY_RESTAURANT.name -> R.drawable.card_family_restaurant
+        CardType.STADIUM.name -> R.drawable.card_stadium
+        CardType.TV_STATION.name -> R.drawable.card_tv_station
+        CardType.BUSINESS_CENTER.name -> R.drawable.card_business_center
+        LandmarkType.TRAIN_STATION.name -> R.drawable.landmark_train_station
+        LandmarkType.SHOPPING_MALL.name -> R.drawable.landmark_shopping_mall
+        LandmarkType.AMUSEMENT_PARK.name -> R.drawable.landmark_amusement_park
+        LandmarkType.RADIO_TOWER.name -> R.drawable.landmark_radio_tower
+
+        else -> R.drawable.card_wheat_field
+    }
+
 @Composable
-private fun PurchaseState.toFeedbackColor(): Color = when (this) {
-    PurchaseState.ERROR -> MaterialTheme.colorScheme.error
-    PurchaseState.SUCCESS -> PrimaryOrange
-    else -> TextBlueDark
+private fun CardDisplay(
+    drawable: Int,
+    modifier: Modifier = Modifier,
+    width: Dp = 155.dp,
+    height: Dp = 175.dp,
+) {
+    Box(
+        modifier = modifier.wrapContentSize()
+    ) {
+
+        Image(
+            painter = painterResource(
+                drawable
+            ),
+            contentDescription = null,
+            contentScale = ContentScale.Fit,
+            modifier = Modifier
+                .width(width)
+                .height(height)
+                .semantics { }
+        )
+    }
 }
 
 @Preview(showBackground = true, widthDp = 915, heightDp = 430)

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
@@ -52,20 +52,15 @@ import com.machikoro.client.ui.shared.BasicText
 import com.machikoro.client.ui.theme.ClientTheme
 import com.machikoro.client.ui.theme.CardPurpleBackground
 import com.machikoro.client.ui.theme.CardPurpleText
-import com.machikoro.client.ui.theme.PrimaryOrange
-import com.machikoro.client.ui.theme.TextBlueDark
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.offset
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
+import com.machikoro.client.ui.game.SIDE_CONTENT_OFFSET
 import com.machikoro.client.ui.shared.AnimatedItem
 import com.machikoro.client.ui.shared.AnimationType
-
-private val SHOP_CARD_SHAPE = RoundedCornerShape(8.dp)
-val RecommendedHighlight = Color(0xFF00C853)
-val SelectedHighlight = Color(0xFFFFD700) // Gold color for selected card
 
 @Composable
 internal fun BuyingPhaseShop(
@@ -158,7 +153,7 @@ internal fun BuyingPhaseShop(
         } else {
             BasicText(
                 state.activePlayerUsername + " is deciding what card to buy",
-            )
+                modifier = Modifier.offset(y = (-SIDE_CONTENT_OFFSET).dp))
         }
     }
 }

--- a/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
@@ -834,6 +834,31 @@ class GameScreenViewModelTest {
     }
 
     @Test
+    fun purchaseSuccessEventShowsFeedbackForNonActivePlayer() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 7)
+
+        fakeClient.emitActiveGameId(7)
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
+        fakeClient.emitGamePhase(GamePhase.BUY_OR_BUILD)
+        fakeClient.emitActivePlayerId(42)
+        advanceUntilIdle()
+
+        fakeClient.emitPurchaseEvent(
+            PurchaseEvent.Success(
+                purchaseType = PurchaseType.ESTABLISHMENT,
+                itemType = "BAKERY"
+            )
+        )
+        advanceUntilIdle()
+
+        assertEquals(PurchaseState.SUCCESS, viewModel.state.value.purchaseState)
+        assertEquals("BAKERY", viewModel.state.value.purchaseFeedbackItemType)
+        assertEquals("Bakery bought", viewModel.state.value.purchaseMessage)
+        assertNull(fakeClient.endedTurnGameId)
+    }
+
+    @Test
     fun matchingPurchaseSuccessEventEndsTurn() = runTest {
         val fakeClient = FakeWebSocketClient()
         val viewModel = viewModel(fakeClient, userId = 42)


### PR DESCRIPTION
## Summary

Displays successful purchase feedback to all players during the Buy or Build phase.

Previously, all clients received the purchase broadcast, but non-active players ignored it because they had no locally pending purchase. They continued seeing the waiting message instead of the purchased card.

## Changes

- Allow non-active players to apply purchase-success broadcasts.
- Preserve pending-purchase validation for the active player.
- Ensure only the active player ends the turn.
- Add regression coverage for non-active purchase feedback.

## Current flow:

1. Non-active player sees “Player X is deciding what card to buy.”
2. Active player selects and confirms a card.
3. Server broadcasts `PURCHASE_COMPLETED` to all players.
4. Both players display the purchased card for about 5 seconds.
5. Only the active player’s client calls `endTurn`.
6. The server advances the turn, and both screens continue to the next phase/player.
