### PR TITLE
fix: prevent leaderboard navigation from being bounced back to Home (#373)

### DIFF
--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -106,8 +106,8 @@ fun AppRoot(
     val showConnectionBanner = currentRoute != null && currentRoute != AppRoute.Main.route
 
     DisposableEffect(navController) {
-        val listener = NavController.OnDestinationChangedListener { _, _, _ ->
-            navigationViewModel.clearLastNavigation()
+        val listener = NavController.OnDestinationChangedListener { _, destination, _ ->
+            navigationViewModel.onDestinationChanged(destination.route)
         }
         navController.addOnDestinationChangedListener(listener)
         onDispose {

--- a/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
+++ b/app/src/main/java/com/machikoro/client/ui/AppRoot.kt
@@ -128,7 +128,11 @@ fun AppRoot(
         gameScreenState,
         startScreenState,
         lobbyCode,
-        navigationUiState.showLobbyScreen
+        navigationUiState.showLobbyScreen,
+        // Re-evaluate when the destination changes so that leaving an overlay
+        // route (e.g. Back from Leaderboard) recalculates the state-driven
+        // target and doesn't strand the user on a screen with stale data (#373).
+        currentRoute,
     ) {
         navigationViewModel.updateNavigationBasedOnState(
             gameScreenState = gameScreenState,

--- a/app/src/main/java/com/machikoro/client/ui/navigation/NavigationViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/navigation/NavigationViewModel.kt
@@ -47,9 +47,22 @@ class NavigationViewModel(
     // which can cause unnecessary navigation attempts and UI churn.
     internal var lastNavigation: Pair<AppRoute, AppRoute.AppRouteArguments>? = null
 
+    // Route currently shown by the NavController. Kept in sync via
+    // onDestinationChanged so state-driven routing can tell when an overlay
+    // route (see overlayRoutes) is in front.
+    internal var currentRoute: String? = null
+        private set
+
     // True only after the user explicitly enters a lobby this session.
     // Prevents reconnect snapshots from auto-navigating to Game right after login.
     private var hasBeenInLobby = false
+
+    // Overlay routes are opened by an explicit user action (e.g. tapping
+    // "View Leaderboard") and layer on top of the state-driven flow. While one of
+    // these is the current destination, background state updates must not navigate
+    // away from it, otherwise a competing state-driven NavigateTo can bounce the
+    // user off the overlay (issue #373).
+    private val overlayRoutes = setOf(AppRoute.Leaderboard.route)
 
     fun showLobby() {
         hasBeenInLobby = true
@@ -142,6 +155,13 @@ class NavigationViewModel(
                 else -> AppRoute.Home
             }
 
+            // Don't let a background state update pull the user off an overlay
+            // route they explicitly opened (issue #373). A forced logout still
+            // wins because unauthenticated users must always return to Main.
+            if (currentRoute in overlayRoutes && targetRoute != AppRoute.Main) {
+                return@launch
+            }
+
             val routeArguments = AppRoute.AppRouteArguments(
                 lobbyCode = lobbyCode,
                 gameId = gameScreenState.gameId,
@@ -168,6 +188,17 @@ class NavigationViewModel(
      */
     fun clearLastNavigation() {
         lastNavigation = null
+    }
+
+    /**
+     * Records the NavController's current destination and clears the
+     * lastNavigation cache. Called whenever the NavController changes
+     * destination so state-driven routing knows which route is in front and can
+     * leave overlay routes (e.g. Leaderboard) untouched.
+     */
+    fun onDestinationChanged(route: String?) {
+        currentRoute = route
+        clearLastNavigation()
     }
 }
 

--- a/app/src/test/java/com/machikoro/client/ui/navigation/NavigationViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/navigation/NavigationViewModelTest.kt
@@ -257,6 +257,77 @@ class NavigationViewModelTest {
     }
 
     @Test
+    fun stateUpdateWhileOnLeaderboardDoesNotNavigateAway() = runTest {
+        val viewModel = NavigationViewModel()
+        val events = collectNavigationEvents(viewModel)
+
+        viewModel.onUserLoggedIn()
+        // Simulate the leaderboard overlay becoming the current destination.
+        viewModel.onDestinationChanged(AppRoute.Leaderboard.route)
+
+        // A background state update that would otherwise route to Home must not
+        // pull the user off the leaderboard (issue #373).
+        viewModel.updateNavigationBasedOnState(
+            gameScreenState = GameScreenState.initial(),
+            startScreenState = StartScreenState.placeholder().copy(loggedInAs = "alice"),
+            lobbyCode = null,
+        )
+        advanceUntilIdle()
+
+        assertTrue(events.isEmpty())
+    }
+
+    @Test
+    fun logoutWhileOnLeaderboardStillNavigatesToMain() = runTest {
+        val viewModel = NavigationViewModel()
+        val events = collectNavigationEvents(viewModel)
+
+        viewModel.onUserLoggedIn()
+        viewModel.onDestinationChanged(AppRoute.Leaderboard.route)
+
+        // A forced logout must always win over an overlay route.
+        viewModel.updateNavigationBasedOnState(
+            gameScreenState = GameScreenState.initial(),
+            startScreenState = StartScreenState.placeholder(),
+            lobbyCode = null,
+        )
+        advanceUntilIdle()
+
+        assertEquals(NavigationEvent.NavigateTo(AppRoute.Main), events.single())
+    }
+
+    @Test
+    fun stateUpdateNavigatesNormallyWhenNotOnOverlay() = runTest {
+        val viewModel = NavigationViewModel()
+        val events = collectNavigationEvents(viewModel)
+
+        viewModel.onUserLoggedIn()
+        // Leave the leaderboard: current destination is now Home, not an overlay.
+        viewModel.onDestinationChanged(AppRoute.Leaderboard.route)
+        viewModel.onDestinationChanged(AppRoute.Home.route)
+
+        viewModel.updateNavigationBasedOnState(
+            gameScreenState = GameScreenState.initial(),
+            startScreenState = StartScreenState.placeholder().copy(loggedInAs = "alice"),
+            lobbyCode = null,
+        )
+        advanceUntilIdle()
+
+        assertEquals(NavigationEvent.NavigateTo(AppRoute.Home), events.single())
+    }
+
+    @Test
+    fun onDestinationChangedTracksRouteAndClearsLastNavigation() = runTest {
+        val viewModel = NavigationViewModel()
+
+        viewModel.navigateTo(AppRoute.Home)
+        viewModel.onDestinationChanged(AppRoute.Home.route)
+
+        assertEquals(AppRoute.Home.route, viewModel.currentRoute)
+        assertEquals(null, viewModel.lastNavigation)
+    }
+
+    @Test
     fun onUserLoggedOutResetsLoginFlagAndLobbyVisibility() {
         val viewModel = NavigationViewModel()
 

--- a/app/src/test/java/com/machikoro/client/ui/navigation/NavigationViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/navigation/NavigationViewModelTest.kt
@@ -317,6 +317,59 @@ class NavigationViewModelTest {
     }
 
     @Test
+    fun winnerToLeaderboardThenBackReevaluatesNavigationToHome() = runTest {
+        val viewModel = NavigationViewModel()
+        val events = collectNavigationEvents(viewModel)
+
+        viewModel.onUserLoggedIn()
+
+        // Finished game routes the user to the Winner screen.
+        viewModel.updateNavigationBasedOnState(
+            gameScreenState = GameScreenState.initial().copy(
+                gameStatus = GameStatus.FINISHED,
+                gameId = 42,
+                winnerId = 11,
+            ),
+            startScreenState = StartScreenState.placeholder().copy(loggedInAs = "alice"),
+            lobbyCode = null,
+        )
+        advanceUntilIdle()
+        viewModel.onDestinationChanged(AppRoute.Winner.route)
+
+        // Tapping "View Leaderboard" clears the finished-game state and opens the
+        // leaderboard overlay; the resulting Home target is suppressed.
+        viewModel.onDestinationChanged(AppRoute.Leaderboard.route)
+        viewModel.updateNavigationBasedOnState(
+            gameScreenState = GameScreenState.initial(),
+            startScreenState = StartScreenState.placeholder().copy(loggedInAs = "alice"),
+            lobbyCode = null,
+        )
+        advanceUntilIdle()
+
+        // Pressing Back returns to Winner. Navigation must re-evaluate (the route
+        // change re-runs updateNavigationBasedOnState) and route to Home instead
+        // of leaving the user on a Winner screen with cleared data (#373 review).
+        viewModel.onDestinationChanged(AppRoute.Winner.route)
+        viewModel.updateNavigationBasedOnState(
+            gameScreenState = GameScreenState.initial(),
+            startScreenState = StartScreenState.placeholder().copy(loggedInAs = "alice"),
+            lobbyCode = null,
+        )
+        advanceUntilIdle()
+
+        assertEquals(
+            listOf(
+                NavigationEvent.NavigateTo(
+                    route = AppRoute.Winner,
+                    arguments = AppRoute.AppRouteArguments(gameId = 42),
+                ),
+                NavigationEvent.NavigateTo(AppRoute.Home),
+            ),
+            events,
+        )
+    }
+
+    @Test
     fun onDestinationChangedTracksRouteAndClearsLastNavigation() = runTest {
         val viewModel = NavigationViewModel()
 

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -61,7 +61,12 @@ the only exception, because unauthenticated users must always return to `Main`.
 
 The current destination is tracked through
 `NavigationViewModel.onDestinationChanged(route)`, which `AppRoot` wires to the
-`NavController`'s `OnDestinationChangedListener`.
+`NavController`'s `OnDestinationChangedListener`. The current route is also a key
+of the `updateNavigationBasedOnState` `LaunchedEffect`, so leaving an overlay
+(e.g. pressing Back from Leaderboard) re-evaluates the state-driven target. This
+matters because the Winner → Leaderboard flow clears the finished-game state: on
+Back the re-evaluation routes the user to `Home` rather than stranding them on a
+Winner screen with cleared data.
 
 ## Navigation Flow
 

--- a/docs/navigation.md
+++ b/docs/navigation.md
@@ -43,9 +43,25 @@ screen.
 | `Lobby` | Lobby screen before a game starts. | Optional `lobbyCode` |
 | `Game` | Active game screen. | Optional `gameId` |
 | `Winner` | Finished-game winner screen. | None |
+| `Leaderboard` | Global leaderboard, opened as an overlay from Home or Winner. | None |
 
 Argumented destinations are built through `AppRoute.destination(arguments)`.
 Callers should not assemble route strings manually.
+
+### Overlay routes
+
+`Leaderboard` is an **overlay route**: it is opened by an explicit user action
+(tapping "View Leaderboard") and layers on top of the state-driven flow rather
+than being derived from app state. While an overlay route is the current
+destination, `updateNavigationBasedOnState` will not navigate away from it, so a
+competing state-driven `NavigateTo` (for example a server snapshot computing
+`Home`) cannot bounce the user off it (issue
+[#373](https://github.com/SE2-Machi-Koro/Client/issues/373)). A forced logout is
+the only exception, because unauthenticated users must always return to `Main`.
+
+The current destination is tracked through
+`NavigationViewModel.onDestinationChanged(route)`, which `AppRoot` wires to the
+`NavController`'s `OnDestinationChangedListener`.
 
 ## Navigation Flow
 


### PR DESCRIPTION
## Summary

Fixes the latent navigation race described in #373: the leaderboard could be unexpectedly bounced back to **Home** by a competing state-driven navigation event.

The leaderboard is opened by an explicit user action (tapping **View Leaderboard** on the Winner screen, or **Ranking** on Home), but it layers on top of the state-driven flow rather than being derived from app state. Previously a competing `updateNavigationBasedOnState` call could compute `Home` and navigate away from it:

- On the Winner screen, `onClearGameState()` runs before navigating to the leaderboard. Clearing finished-game state triggers `updateNavigationBasedOnState`, which (logged in, no active/finished game) resolves to `Home`.
- `clearLastNavigation()` fires on every `OnDestinationChangedListener` callback, so the `lastNavigation` dedup guard reopens right after the leaderboard navigation lands.
- A stale `NavigateTo(Home)` can therefore land **after** the leaderboard navigation and bounce the user back.
- The same mechanism let a **server snapshot arriving while the leaderboard is open** pull the user back to Home.

## Approach

This implements the recommended "overlay route" direction from the issue.

`NavigationViewModel` now tracks the current destination and treats `Leaderboard` as an **overlay route**. While an overlay route is the current destination, `updateNavigationBasedOnState` does not navigate away from it, so background/state-driven `NavigateTo` events can no longer override an explicit user navigation. A forced logout remains an exception, since unauthenticated users must always return to `Main`.

## Changes

- **`NavigationViewModel.kt`**
  - Tracks `currentRoute`, updated via the new `onDestinationChanged(route)` (which also clears `lastNavigation`, preserving prior behavior).
  - Added an `overlayRoutes` set (currently `Leaderboard`).
  - `updateNavigationBasedOnState` skips navigation when an overlay route is in front, unless the target is `Main` (logout).
- **`AppRoot.kt`** — the `OnDestinationChangedListener` now calls `onDestinationChanged(destination.route)` instead of `clearLastNavigation()`, so the ViewModel knows which route is in front.
- **`docs/navigation.md`** — documents the `Leaderboard` route and the overlay-route behavior.

## Tests

Added unit tests in `NavigationViewModelTest`:
- `stateUpdateWhileOnLeaderboardDoesNotNavigateAway` — a state update that would route to Home emits nothing while on the leaderboard.
- `logoutWhileOnLeaderboardStillNavigatesToMain` — a forced logout still wins over the overlay.
- `stateUpdateNavigatesNormallyWhenNotOnOverlay` — normal state-driven routing is unaffected once off the overlay.
- `onDestinationChangedTracksRouteAndClearsLastNavigation` — verifies route tracking and dedup-cache clearing.