### PR TITLE
fix(#380): negotiate and emit STOMP heartbeats

### DIFF
--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -233,8 +233,9 @@ class OkHttpWebSocketClient(
     override fun disconnect() {
         intentionalDisconnect = true
         cancelReconnect()
-        stopHeartbeat()
         val currentSocket = synchronized(this) {
+            heartbeatJob?.cancel()
+            heartbeatJob = null
             val socket = webSocket
             webSocket = null
             socket
@@ -1406,8 +1407,9 @@ class OkHttpWebSocketClient(
     }
 
     private fun clearSocket() {
-        stopHeartbeat()
         synchronized(this) {
+            heartbeatJob?.cancel()
+            heartbeatJob = null
             webSocket = null
             subscribedGameId = null
             stompSessionId = null
@@ -1457,32 +1459,42 @@ class OkHttpWebSocketClient(
      * first, so reconnects don't stack jobs. No-op when negotiation opts out.
      */
     private fun startHeartbeat(serverHeartBeatHeader: String?) {
-        stopHeartbeat()
         val sendIntervalMs = negotiatedSendIntervalMs(serverHeartBeatHeader)
         if (sendIntervalMs <= 0L) {
             Log.d(TAG, "STOMP heartbeats disabled by negotiation (server='$serverHeartBeatHeader')")
+            stopHeartbeat()
             return
         }
         Log.d(TAG, "Starting STOMP heartbeats every ${sendIntervalMs}ms")
-        heartbeatJob = reconnectScope.launch {
-            while (isActive) {
-                delay(sendIntervalMs)
-                val socket = synchronized(this@OkHttpWebSocketClient) { webSocket } ?: break
-                // A lone LF is a STOMP heartbeat. Emitting it on an otherwise idle
-                // socket keeps platform proxies (e.g. Railway's edge) from reaping
-                // the connection during a player's think-time — and satisfies the
-                // server, which now expects client heartbeats (server #426).
-                if (!socket.send(HEARTBEAT_FRAME)) {
-                    Log.w(TAG, "Heartbeat send failed; stopping heartbeats")
-                    break
+        synchronized(this) {
+            heartbeatJob?.cancel()
+            heartbeatJob = reconnectScope.launch {
+                while (isActive) {
+                    delay(sendIntervalMs)
+                    val socket = synchronized(this@OkHttpWebSocketClient) { webSocket } ?: break
+                    // A lone LF is a STOMP heartbeat. Emitting it on an otherwise idle
+                    // socket keeps platform proxies (e.g. Railway's edge) from reaping
+                    // the connection during a player's think-time — and satisfies the
+                    // server, which now expects client heartbeats (server #426).
+                    try {
+                        if (!socket.send(HEARTBEAT_FRAME)) {
+                            Log.w(TAG, "Heartbeat send failed; stopping heartbeats")
+                            break
+                        }
+                    } catch (e: Exception) {
+                        Log.w(TAG, "Heartbeat send threw; stopping heartbeats", e)
+                        break
+                    }
                 }
             }
         }
     }
 
     private fun stopHeartbeat() {
-        heartbeatJob?.cancel()
-        heartbeatJob = null
+        synchronized(this) {
+            heartbeatJob?.cancel()
+            heartbeatJob = null
+        }
     }
 
     /**

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -198,6 +199,11 @@ class OkHttpWebSocketClient(
     private var reconnectJob: Job? = null
     private var reconnectAttempt = 0
 
+    // Periodic STOMP heartbeat emitter, started on CONNECTED and cancelled when
+    // the socket goes away. Keeps an idle connection alive so platform proxies
+    // don't reap it mid-game (server #426).
+    private var heartbeatJob: Job? = null
+
     init {
         require(reconnectDelaysMs.isNotEmpty()) { "reconnectDelaysMs must not be empty" }
     }
@@ -227,6 +233,7 @@ class OkHttpWebSocketClient(
     override fun disconnect() {
         intentionalDisconnect = true
         cancelReconnect()
+        stopHeartbeat()
         val currentSocket = synchronized(this) {
             val socket = webSocket
             webSocket = null
@@ -593,7 +600,7 @@ class OkHttpWebSocketClient(
                     headers = mapOf(
                         "accept-version" to WebSocketContract.stompVersion,
                         "host" to websocketHostHeader(),
-                        "heart-beat" to "0,0",
+                        "heart-beat" to "$CLIENT_HEARTBEAT_INTERVAL_MS,$CLIENT_HEARTBEAT_INTERVAL_MS",
                         AUTH_HEADER to "$BEARER_PREFIX$token",
                     )
                 ).serialize()
@@ -653,6 +660,7 @@ class OkHttpWebSocketClient(
 
                 // Signal ready only after all SUBSCRIBE frames are in the socket queue
                 mutableConnectionStatus.value = ConnectionStatus.CONNECTED
+                startHeartbeat(frame.headers["heart-beat"])
                 sendJoinMessage()
             }
             "MESSAGE" -> {
@@ -1398,6 +1406,7 @@ class OkHttpWebSocketClient(
     }
 
     private fun clearSocket() {
+        stopHeartbeat()
         synchronized(this) {
             webSocket = null
             subscribedGameId = null
@@ -1440,6 +1449,59 @@ class OkHttpWebSocketClient(
             reconnectJob = null
             reconnectAttempt = 0
         }
+    }
+
+    /**
+     * Starts the periodic heartbeat emitter using the interval negotiated with
+     * the server (see [negotiatedSendIntervalMs]). Cancels any previous emitter
+     * first, so reconnects don't stack jobs. No-op when negotiation opts out.
+     */
+    private fun startHeartbeat(serverHeartBeatHeader: String?) {
+        stopHeartbeat()
+        val sendIntervalMs = negotiatedSendIntervalMs(serverHeartBeatHeader)
+        if (sendIntervalMs <= 0L) {
+            Log.d(TAG, "STOMP heartbeats disabled by negotiation (server='$serverHeartBeatHeader')")
+            return
+        }
+        Log.d(TAG, "Starting STOMP heartbeats every ${sendIntervalMs}ms")
+        heartbeatJob = reconnectScope.launch {
+            while (isActive) {
+                delay(sendIntervalMs)
+                val socket = synchronized(this@OkHttpWebSocketClient) { webSocket } ?: break
+                // A lone LF is a STOMP heartbeat. Emitting it on an otherwise idle
+                // socket keeps platform proxies (e.g. Railway's edge) from reaping
+                // the connection during a player's think-time — and satisfies the
+                // server, which now expects client heartbeats (server #426).
+                if (!socket.send(HEARTBEAT_FRAME)) {
+                    Log.w(TAG, "Heartbeat send failed; stopping heartbeats")
+                    break
+                }
+            }
+        }
+    }
+
+    private fun stopHeartbeat() {
+        heartbeatJob?.cancel()
+        heartbeatJob = null
+    }
+
+    /**
+     * Resolves the client→server heartbeat interval from the negotiated values
+     * per STOMP 1.2. We advertise [CLIENT_HEARTBEAT_INTERVAL_MS] in both
+     * directions, so the effective send interval is the larger of our value and
+     * the server's requested receive interval (the second field of its
+     * `heart-beat` header). Returns 0 when either side opts out.
+     */
+    private fun negotiatedSendIntervalMs(serverHeartBeatHeader: String?): Long {
+        val serverWantsToReceiveMs = serverHeartBeatHeader
+            ?.split(",")
+            ?.takeIf { it.size == 2 }
+            ?.get(1)
+            ?.trim()
+            ?.toLongOrNull()
+            ?: 0L
+        if (CLIENT_HEARTBEAT_INTERVAL_MS == 0L || serverWantsToReceiveMs == 0L) return 0L
+        return maxOf(CLIENT_HEARTBEAT_INTERVAL_MS, serverWantsToReceiveMs)
     }
 
     private fun isAuthRejection(body: String): Boolean =
@@ -1546,6 +1608,13 @@ class OkHttpWebSocketClient(
     companion object {
         private const val NORMAL_CLOSURE_STATUS = 1000
         private const val TAG = "OkHttpWebSocketClient"
+        // Heartbeat interval (ms) advertised in the STOMP CONNECT frame, in both
+        // directions. Kept in sync with the server's WebSocketConfig
+        // (HEARTBEAT_INTERVAL_MS, server #426) and well under the ~60s idle window
+        // after which platform proxies reap the connection.
+        private const val CLIENT_HEARTBEAT_INTERVAL_MS = 10_000L
+        // A bare line-feed is the STOMP heartbeat frame (no NUL terminator).
+        private const val HEARTBEAT_FRAME = "\n"
         // Exponential backoff for auto-reconnect; the final value repeats once
         // the list is exhausted. Long enough to ride out a backend container
         // restart without hammering the server.

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import okhttp3.Protocol
@@ -58,6 +59,68 @@ class OkHttpWebSocketClientTest {
         assertTrue(factory.socket.sentMessages.first().startsWith("CONNECT\n"))
         assertTrue(factory.socket.sentMessages.first().contains("accept-version:1.2"))
         assertTrue(factory.socket.sentMessages.first().contains("host:10.0.2.2:8080"))
+    }
+
+    @Test
+    fun connectFrameAdvertisesHeartbeat() {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        // Must advertise non-zero heartbeats or the server (server #426) keeps
+        // them disabled and idle sockets are reaped mid-game.
+        assertTrue(factory.socket.sentMessages.first().contains("heart-beat:10000,10000"))
+    }
+
+    @Test
+    fun connectedNegotiatesAndEmitsHeartbeats() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory, reconnectScope = backgroundScope)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame(heartBeat = "10000,10000"))
+
+        advanceTimeBy(10_001)
+        runCurrent()
+
+        assertTrue(
+            "expected a lone-LF heartbeat frame to be sent",
+            factory.socket.sentMessages.any { it == "\n" },
+        )
+    }
+
+    @Test
+    fun heartbeatsStopAfterDisconnect() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory, reconnectScope = backgroundScope)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame(heartBeat = "10000,10000"))
+
+        client.disconnect()
+        val heartbeatsAfterDisconnect = factory.socket.sentMessages.count { it == "\n" }
+        advanceTimeBy(30_000)
+        runCurrent()
+
+        assertEquals(
+            "no heartbeats should be emitted after disconnect",
+            heartbeatsAfterDisconnect,
+            factory.socket.sentMessages.count { it == "\n" },
+        )
+    }
+
+    @Test
+    fun serverOptingOutDisablesHeartbeatEmission() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory, reconnectScope = backgroundScope)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame(heartBeat = "0,0"))
+
+        advanceTimeBy(30_000)
+        runCurrent()
+
+        assertFalse(factory.socket.sentMessages.any { it == "\n" })
     }
 
     @Test
@@ -3056,8 +3119,14 @@ class OkHttpWebSocketClientTest {
     }
 
     /** A bare STOMP CONNECTED frame, correctly NUL-terminated by serialize(). */
-    private fun connectedFrame(): String =
-        StompFrame(command = "CONNECTED", headers = mapOf("version" to "1.2")).serialize()
+    private fun connectedFrame(heartBeat: String? = null): String =
+        StompFrame(
+            command = "CONNECTED",
+            headers = buildMap {
+                put("version", "1.2")
+                if (heartBeat != null) put("heart-beat", heartBeat)
+            },
+        ).serialize()
 
     /** A MESSAGE frame on the per-user game-sync queue carrying [body]. */
     private fun syncFrame(body: String): String =

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -124,6 +124,102 @@ class OkHttpWebSocketClientTest {
     }
 
     @Test
+    fun missingHeartBeatHeaderDisablesHeartbeatEmission() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory, reconnectScope = backgroundScope)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame(heartBeat = null))
+
+        advanceTimeBy(30_000)
+        runCurrent()
+
+        assertFalse(factory.socket.sentMessages.any { it == "\n" })
+    }
+
+    @Test
+    fun heartbeatSendReturningFalseStopsHeartbeats() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory, reconnectScope = backgroundScope)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame(heartBeat = "10000,10000"))
+
+        // First heartbeat fires and succeeds.
+        advanceTimeBy(10_001)
+        runCurrent()
+        assertTrue("expected at least one heartbeat", factory.socket.sentMessages.any { it == "\n" })
+
+        // Next send returns false — the frame is still enqueued by FakeWebSocket before
+        // the return value is checked, so the count goes up by one and then the loop exits.
+        factory.socket.sendResult = false
+        advanceTimeBy(10_001)
+        runCurrent()
+        val countAfterFail = factory.socket.sentMessages.count { it == "\n" }
+
+        // No further heartbeats after the one that caused the failure.
+        advanceTimeBy(20_000)
+        runCurrent()
+        assertEquals(
+            "no additional heartbeats should be sent after send() returns false",
+            countAfterFail,
+            factory.socket.sentMessages.count { it == "\n" },
+        )
+    }
+
+    @Test
+    fun heartbeatSendThrowingStopsHeartbeats() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory, reconnectScope = backgroundScope)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame(heartBeat = "10000,10000"))
+
+        // First heartbeat fires and succeeds.
+        advanceTimeBy(10_001)
+        runCurrent()
+        assertTrue("expected at least one heartbeat", factory.socket.sentMessages.any { it == "\n" })
+
+        // Next send throws — the frame is still enqueued by FakeWebSocket before the
+        // throw, so the count goes up by one and then the loop exits via the catch block.
+        factory.socket.sendThrows = IllegalStateException("socket closed")
+        advanceTimeBy(10_001)
+        runCurrent()
+        val countAfterThrow = factory.socket.sentMessages.count { it == "\n" }
+
+        // No further heartbeats after the one that caused the exception.
+        advanceTimeBy(20_000)
+        runCurrent()
+        assertEquals(
+            "no additional heartbeats should be sent after send() throws",
+            countAfterThrow,
+            factory.socket.sentMessages.count { it == "\n" },
+        )
+    }
+
+    @Test
+    fun heartbeatsStopAfterSocketFailure() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory, reconnectScope = backgroundScope)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame(heartBeat = "10000,10000"))
+
+        factory.simulateFailure(java.io.IOException("network error"))
+        runCurrent()
+        val heartbeatsAtFailure = factory.socket.sentMessages.count { it == "\n" }
+        advanceTimeBy(30_000)
+        runCurrent()
+
+        assertEquals(
+            "no heartbeats should be emitted after socket failure",
+            heartbeatsAtFailure,
+            factory.socket.sentMessages.count { it == "\n" },
+        )
+    }
+
+
+    @Test
     fun connectedFrameMovesStatusToConnectedAndTriggersSubscribeAndJoin() {
         val factory = FakeWebSocketFactory()
         val client = newClient(factory)
@@ -3290,9 +3386,15 @@ class OkHttpWebSocketClientTest {
         lateinit var request: Request
         var closed = false
         val sentMessages = mutableListOf<String>()
+        var sendResult: Boolean = true
+        var sendThrows: Exception? = null
         override fun request(): Request = request
         override fun queueSize(): Long = 0L
-        override fun send(text: String): Boolean { sentMessages += text; return true }
+        override fun send(text: String): Boolean {
+            sentMessages += text
+            sendThrows?.let { throw it }
+            return sendResult
+        }
         override fun send(bytes: ByteString): Boolean = false
         override fun close(code: Int, reason: String?): Boolean { closed = true; return true }
         override fun cancel() { closed = true }


### PR DESCRIPTION
## What & why

The client advertised `heart-beat: 0,0` in the STOMP CONNECT frame, which **disables** heartbeats. Server PR [#426](https://github.com/SE2-Machi-Koro/Server/pull/426) enables broker heartbeats, but heartbeats are negotiated — with the client opting out, negotiation still yielded none, so idle WebSocket connections kept being reaped by the platform proxy (Railway's edge) during a player's think-time. That was the mid-game lag / "connection timeout" players hit.

Simply flipping the header isn't enough: once the client advertises a non-zero send interval, the server **expects** client heartbeats and will drop the client if it doesn't actually send them. So this also implements real heartbeat emission.

Closes #380. Pairs with server #426.

## Changes

`OkHttpWebSocketClient`:
- CONNECT now advertises `heart-beat: 10000,10000` (matches the server's `HEARTBEAT_INTERVAL_MS`).
- On `CONNECTED`, read the negotiated `heart-beat` header and start a periodic emitter that sends a lone LF (`\n`, the STOMP heartbeat) every negotiated interval. Interval is computed per STOMP 1.2: `max(ourSend, serverRequestedReceive)`; emission is skipped when either side opts out.
- The emitter is cancelled when the socket goes away (`clearSocket` covers failure/close; `disconnect` covers the client-initiated path), so reconnects don't stack jobs.
- Inbound heartbeats need no new handling: `StompFrame.parseFrames` already trims lone newlines.

## Testing

New unit tests in `OkHttpWebSocketClientTest` (driven on the test scheduler via `backgroundScope` + `advanceTimeBy`):
- `connectFrameAdvertisesHeartbeat` — CONNECT contains `heart-beat:10000,10000`.
- `connectedNegotiatesAndEmitsHeartbeats` — a lone-LF heartbeat is emitted one interval after CONNECTED.
- `heartbeatsStopAfterDisconnect` — no heartbeats after `disconnect()`.
- `serverOptingOutDisablesHeartbeatEmission` — server `heart-beat: 0,0` ⇒ no emission.

`./gradlew :app:testDebugUnitTest` — **BUILD SUCCESSFUL** (185 tests, 0 failures).

## Notes

- Keep `CLIENT_HEARTBEAT_INTERVAL_MS` (10s) in sync with the server constant.
- Receive-side liveness detection (reconnect if the server goes silent) is left to the existing auto-reconnect on socket close/failure; can be added later if needed.
