### PR TITLE
ci: add GitHub Actions workflow for itch.io APK deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,9 @@ jobs:
         run: chmod +x gradlew
 
       - name: Decode Keystore
-        run: echo "${{ secrets.KEYSTORE_FILE }}" | base64 -d > keystore.jks
+        env:
+          KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
+        run: echo "$KEYSTORE_FILE" | base64 -d > keystore.jks
 
       - name: Build Release APK
         run: ./gradlew assembleRelease

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,13 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Decode Keystore
+        run: echo "${{ secrets.KEYSTORE_FILE }}" | base64 -d > keystore.jks
+
       - name: Build Release APK
         run: ./gradlew assembleRelease
         env:
-          KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
+          KEYSTORE_PATH: ${{ github.workspace }}/keystore.jks
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}

--- a/.github/workflows/deploy-to-itch.yml
+++ b/.github/workflows/deploy-to-itch.yml
@@ -27,10 +27,13 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Decode Keystore
+        run: echo "${{ secrets.KEYSTORE_FILE }}" | base64 -d > keystore.jks
+
       - name: Build Release APK
         run: ./gradlew assembleRelease
         env:
-          KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
+          KEYSTORE_PATH: ${{ github.workspace }}/keystore.jks
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}

--- a/.github/workflows/deploy-to-itch.yml
+++ b/.github/workflows/deploy-to-itch.yml
@@ -28,7 +28,9 @@ jobs:
         run: chmod +x gradlew
 
       - name: Decode Keystore
-        run: echo "${{ secrets.KEYSTORE_FILE }}" | base64 -d > keystore.jks
+        env:
+          KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
+        run: echo "$KEYSTORE_FILE" | base64 -d > keystore.jks
 
       - name: Build Release APK
         run: ./gradlew assembleRelease
@@ -40,11 +42,13 @@ jobs:
 
       - name: Install Butler
         run: |
-          curl -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
+          curl --proto '=https' --tlsv1.2 -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
           unzip butler.zip
           chmod +x butler
 
       - name: Deploy to itch.io via Butler
-        run: ./butler push app/build/outputs/apk/release/ ${{ secrets.ITCH_USER }}/${{ secrets.ITCH_GAME }}:android
         env:
           BUTLER_API_KEY: ${{ secrets.BUTLER_CREDENTIALS }}
+          ITCH_USER: ${{ secrets.ITCH_USER }}
+          ITCH_GAME: ${{ secrets.ITCH_GAME }}
+        run: ./butler push app/build/outputs/apk/release/ "$ITCH_USER/$ITCH_GAME:android"

--- a/.github/workflows/deploy-to-itch.yml
+++ b/.github/workflows/deploy-to-itch.yml
@@ -1,0 +1,45 @@
+name: Deploy to itch.io
+
+on:
+  push:
+    branches: [ "main" ]
+  release:
+    types: [ published ]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Build & Deploy APK to itch.io
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build Release APK
+        run: ./gradlew assembleRelease
+        env:
+          KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+
+      - name: Deploy to itch.io via Butler
+        uses: manleydev/butler-publish-itchio-action@master
+        env:
+          BUTLER_CREDENTIALS: ${{ secrets.BUTLER_CREDENTIALS }}
+          CHANNEL: android
+          ITCH_GAME: ${{ secrets.ITCH_GAME }}
+          ITCH_USER: ${{ secrets.ITCH_USER }}
+          PACKAGE: app/build/outputs/apk/release/

--- a/.github/workflows/deploy-to-itch.yml
+++ b/.github/workflows/deploy-to-itch.yml
@@ -36,7 +36,7 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
       - name: Deploy to itch.io via Butler
-        uses: manleydev/butler-publish-itchio-action@master
+        uses: manleydev/butler-publish-itchio-action@483157ebeeeb440e2fdc9f162f3fcfc27028c0ef
         env:
           BUTLER_CREDENTIALS: ${{ secrets.BUTLER_CREDENTIALS }}
           CHANNEL: android

--- a/.github/workflows/deploy-to-itch.yml
+++ b/.github/workflows/deploy-to-itch.yml
@@ -42,7 +42,9 @@ jobs:
 
       - name: Install Butler
         run: |
-          curl --proto '=https' --tlsv1.2 -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
+          curl --proto '=https' --tlsv1.2 -L -o butler.zip \
+            https://github.com/itchio/butler/releases/download/v15.27.0/butler-linux-amd64.zip
+          echo "b78ca81ed566c2daa54d68b7e300dd32888168163212293909ce90f16e0ec75d  butler.zip" | sha256sum -c
           unzip butler.zip
           chmod +x butler
 

--- a/.github/workflows/deploy-to-itch.yml
+++ b/.github/workflows/deploy-to-itch.yml
@@ -35,11 +35,13 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
+      - name: Install Butler
+        run: |
+          curl -L -o butler.zip https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default
+          unzip butler.zip
+          chmod +x butler
+
       - name: Deploy to itch.io via Butler
-        uses: manleydev/butler-publish-itchio-action@483157ebeeeb440e2fdc9f162f3fcfc27028c0ef
+        run: ./butler push app/build/outputs/apk/release/ ${{ secrets.ITCH_USER }}/${{ secrets.ITCH_GAME }}:android
         env:
-          BUTLER_CREDENTIALS: ${{ secrets.BUTLER_CREDENTIALS }}
-          CHANNEL: android
-          ITCH_GAME: ${{ secrets.ITCH_GAME }}
-          ITCH_USER: ${{ secrets.ITCH_USER }}
-          PACKAGE: app/build/outputs/apk/release/
+          BUTLER_API_KEY: ${{ secrets.BUTLER_CREDENTIALS }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,9 +60,25 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    signingConfigs {
+        create("release") {
+            val keystorePath = System.getenv("KEYSTORE_PATH")
+            val keystorePassword = System.getenv("KEYSTORE_PASSWORD")
+            val keyAlias = System.getenv("KEY_ALIAS")
+            val keyPassword = System.getenv("KEY_PASSWORD")
+            if (keystorePath != null && keystorePassword != null && keyAlias != null && keyPassword != null) {
+                storeFile = file(keystorePath)
+                storePassword = keystorePassword
+                this.keyAlias = keyAlias
+                this.keyPassword = keyPassword
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = true
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"


### PR DESCRIPTION
## Summary

This PR implements a Continuous Deployment pipeline that automatically builds a signed Android APK and publishes it to the project's itch.io page whenever a commit is pushed to \`main\` or a new GitHub Release is published.

## Changes

### New: \`.github/workflows/deploy-to-itch.yml\`

A dedicated CD workflow with the following stages:

1. **Checkout & JDK 21 setup** — mirrors the existing CI configuration.
2. **Decode Keystore** — base64-decodes \`KEYSTORE_FILE\` via an \`env:\` variable (not inline secret expansion) to avoid secret leakage in shell logs.
3. **Build signed Release APK** — runs \`./gradlew assembleRelease\` with signing credentials injected through environment variables.
4. **Install Butler (pinned)** — downloads butler \`v15.27.0\` from the official GitHub release URL (not the mutable \`LATEST\` endpoint), enforces HTTPS with \`--proto '=https' --tlsv1.2\`, and verifies the SHA256 checksum before execution.
5. **Deploy to itch.io** — pushes the APK to itch.io on the \`android\` channel using \`BUTLER_API_KEY\`. \`ITCH_USER\` and \`ITCH_GAME\` are passed via \`env:\` to avoid direct secret expansion in the \`run\` command.

### Updated: \`app/build.gradle.kts\`

Added a \`signingConfigs.release\` block that reads \`KEYSTORE_PATH\`, \`KEYSTORE_PASSWORD\`, \`KEY_ALIAS\`, and \`KEY_PASSWORD\` from environment variables. Previously the signing secrets were passed to Gradle but never consumed, resulting in an unsigned release APK.

### Updated: \`.github/workflows/ci.yml\`

Applied the same signing and keystore handling improvements to the existing release artifact upload job.

## Required repository secrets

| Secret | Purpose |
|---|---|
| \`BUTLER_CREDENTIALS\` | itch.io API key (already configured) |
| \`ITCH_USER\` | itch.io username |
| \`ITCH_GAME\` | itch.io game slug |
| \`KEYSTORE_FILE\` | Base64-encoded Android keystore |
| \`KEYSTORE_PASSWORD\` | Keystore password |
| \`KEY_ALIAS\` | Key alias |
| \`KEY_PASSWORD\` | Key password |

## Trigger conditions

| Event | Triggers deploy? |
|---|---|
| Push to \`main\` | Yes |
| GitHub Release published | Yes |
| Push to other branches | No |
| Pull requests | No |

## Security notes

- No secrets are expanded inline in \`run:\` blocks — all are passed through \`env:\` and referenced as shell variables.
- Butler binary is pinned to \`v15.27.0\` with SHA256 verification; the workflow fails before execution if the checksum doesn't match.
- HTTPS is strictly enforced on the butler download (\`--proto '=https' --tlsv1.2\`).
- No \`.aab\` (Android App Bundle) is produced or uploaded — itch.io requires a standard \`.apk\`.

Closes #383