### PR TITLE
fix: use Base64 MIME decoder for keystore secret

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,7 +70,7 @@ android {
             if (keystoreB64 != null && keystorePassword != null && keyAlias != null && keyPassword != null) {
                 val keystoreFile = layout.buildDirectory.file("tmp/signing/keystore.jks").get().asFile
                 keystoreFile.parentFile.mkdirs()
-                keystoreFile.writeBytes(Base64.getDecoder().decode(keystoreB64.trim()))
+                keystoreFile.writeBytes(Base64.getMimeDecoder().decode(keystoreB64))
                 storeFile = keystoreFile
                 storePassword = keystorePassword
                 this.keyAlias = keyAlias


### PR DESCRIPTION
## Problem

`./gradlew assembleRelease` fails in CI during signing config evaluation:

```
* Where:
Build file 'app/build.gradle.kts' line: 73
* What went wrong:
Input byte array has incorrect ending byte at 3692
```

## Root cause

Line 73 decoded the `KEYSTORE_FILE` secret with `Base64.getDecoder()` — the *basic* RFC 4648 decoder, which rejects any whitespace inside the input. The secret is line-wrapped base64 (as produced by `base64` without `-w0`), so the decoder hits a newline mid-stream and throws. `.trim()` only strips leading/trailing whitespace, not interior newlines.

## Fix

Use `Base64.getMimeDecoder()`, which ignores embedded newlines/whitespace — robust regardless of how the secret was encoded.

Closes #387
