### PR TITLE
fix: surface private domain errors from /user/queue/errors (#381)

### DIFF
--- a/app/src/main/java/com/machikoro/client/MainActivity.kt
+++ b/app/src/main/java/com/machikoro/client/MainActivity.kt
@@ -227,6 +227,14 @@ class MainActivity : ComponentActivity() {
                 }
             }
 
+            // Generic domain rejections on /user/queue/errors (e.g. NOT_YOUR_TURN,
+            // server #428): surface the server's message as a toast.
+            LaunchedEffect(Unit) {
+                gameScreenViewModel.domainErrors.collect { error ->
+                    Toast.makeText(context, error.userMessage, Toast.LENGTH_LONG).show()
+                }
+            }
+
             // Debug End-game (#191): surface End-game button failures as a snackbar.
             LaunchedEffect(Unit) {
                 gameScreenViewModel.debugEndGameErrors.collect { message ->

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -121,6 +121,9 @@ class OkHttpWebSocketClient(
     override val accusationErrors: SharedFlow<String>
         get() = mutableAccusationErrors.asSharedFlow()
 
+    override val domainErrors: SharedFlow<ClientError.WebSocket>
+        get() = mutableDomainErrors.asSharedFlow()
+
     override val chatMessages: SharedFlow<ChatMessageState>
         get() = mutableChatMessages.asSharedFlow()
 
@@ -173,6 +176,10 @@ class OkHttpWebSocketClient(
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
     private val mutableAccusationErrors = MutableSharedFlow<String>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    private val mutableDomainErrors = MutableSharedFlow<ClientError.WebSocket>(
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
@@ -685,6 +692,7 @@ class OkHttpWebSocketClient(
                 handleCoinDeltas(json)
                 handleAccusationResult(json)
                 handleAccusationError(json)
+                handlePrivateError(json)
                 handleChatMessage(json)
                 parseGameAction(json).let { (phase, activePlayerId) ->
                     phase?.let { mutableGamePhase.value = it }
@@ -984,6 +992,21 @@ class OkHttpWebSocketClient(
         if (json.optString("code") != INVALID_ACCUSATION_CODE) return
         val message = json.optString("message").takeIf { it.isNotBlank() } ?: "Invalid accusation"
         mutableAccusationErrors.tryEmit(message)
+    }
+
+    /**
+     * Surfaces a generic private domain rejection delivered on /user/queue/errors
+     * (server #428), e.g. NOT_YOUR_TURN. These arrive as a bare WebSocketErrorDto
+     * with top-level `code`/`message` and no `type`, which distinguishes them from
+     * the WebSocketMessage envelopes used for broadcasts. Codes with a dedicated
+     * flow (INVALID_ACCUSATION -> accusationErrors) are left to their handlers to
+     * avoid double-surfacing.
+     */
+    private fun handlePrivateError(json: JSONObject) {
+        if (json.optString("type").isNotBlank()) return
+        val code = json.optString("code")
+        if (code.isBlank() || code == INVALID_ACCUSATION_CODE) return
+        mutableDomainErrors.tryEmit(WsErrorParser.parse(json))
     }
 
     private fun handleChatMessage(json: JSONObject) {

--- a/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WebSocketClient.kt
@@ -75,6 +75,11 @@ interface WebSocketClient {
     // across a reconnect. Carries the server's message, for a toast.
     val accusationErrors: SharedFlow<String>
 
+    // One-shot generic domain rejections delivered on the private /user/queue/errors
+    // (server #428), e.g. NOT_YOUR_TURN. For a toast. Codes with a dedicated flow
+    // (accusations, lobby joins) are excluded and handled by those flows.
+    val domainErrors: SharedFlow<ClientError.WebSocket>
+
     // Fires when the server rejects the STOMP CONNECT for auth reasons (token
     // missing / invalid / server-side cleared). The UI layer is responsible for
     // calling SessionManager.signOut() and surfacing a "session expired"

--- a/app/src/main/java/com/machikoro/client/network/websocket/WsErrorParser.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/WsErrorParser.kt
@@ -9,9 +9,13 @@ object WsErrorParser {
         val payload = json.optJSONObject("payload")
         val serverCode = payload?.optString("errorCode").orEmpty()
             .ifBlank { payload?.optString("code").orEmpty() }
+            // Top-level code: the WebSocketErrorDto sent to /user/queue/errors (server #428).
+            .ifBlank { json.optString("code") }
             .ifBlank { "UNKNOWN" }
         val userMessage = json.optString("content")
             .ifBlank { payload?.optString("message").orEmpty() }
+            // Top-level message: same WebSocketErrorDto shape (server #428).
+            .ifBlank { json.optString("message") }
             .ifBlank { ClientError.UNKNOWN_USER_MESSAGE }
         return ClientError.WebSocket(serverCode = serverCode, userMessage = userMessage)
     }

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import com.machikoro.client.domain.model.state.AccusationResult
 import com.machikoro.client.domain.model.state.triggeredEstablishmentCountForCurrentRoll
+import com.machikoro.client.network.error.ClientError
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -74,6 +75,10 @@ class GameScreenViewModel(
     /** One-shot server-side accusation rejection (#280) for a toast — pass-through. */
     val accusationErrors: SharedFlow<String>
         get() = webSocketClient.accusationErrors
+
+    /** One-shot generic domain rejection (e.g. NOT_YOUR_TURN, server #428) for a toast — pass-through. */
+    val domainErrors: SharedFlow<ClientError.WebSocket>
+        get() = webSocketClient.domainErrors
 
     /**
      * True until the local player has accused someone this turn — mirrors the

--- a/app/src/test/java/com/machikoro/client/network/websocket/FakeWebSocketClient.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/FakeWebSocketClient.kt
@@ -176,6 +176,7 @@ class FakeWebSocketClient : WebSocketClient {
         MutableSharedFlow(extraBufferCapacity = 1)
     override val coinDeltas: SharedFlow<Int> = MutableSharedFlow(extraBufferCapacity = 1)
     override val accusationErrors: SharedFlow<String> = MutableSharedFlow(extraBufferCapacity = 1)
+    override val domainErrors: SharedFlow<ClientError.WebSocket> = MutableSharedFlow(extraBufferCapacity = 1)
 
     var leaveLobbyGameId: Int? = null
         private set

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -3732,6 +3732,56 @@ class OkHttpWebSocketClientTest {
     }
 
     @Test
+    fun privateDomainErrorFrameEmitsDomainError() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        val errors = mutableListOf<ClientError.WebSocket>()
+        client.domainErrors.onEach { errors += it }.launchIn(backgroundScope)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        runCurrent()
+
+        // Bare WebSocketErrorDto delivered on /user/queue/errors (server #428):
+        // top-level code/message, no envelope `type`.
+        factory.simulateText(
+            gameActionFrame(
+                """{"code":"NOT_YOUR_TURN","message":"It is not your turn",""" +
+                    """"timestamp":1714000000000,"context":{}}"""
+            )
+        )
+        runCurrent()
+
+        assertEquals(1, errors.size)
+        assertEquals("NOT_YOUR_TURN", errors.first().serverCode)
+        assertEquals("It is not your turn", errors.first().userMessage)
+    }
+
+    @Test
+    fun invalidAccusationDoesNotEmitDomainError() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        val errors = mutableListOf<ClientError.WebSocket>()
+        client.domainErrors.onEach { errors += it }.launchIn(backgroundScope)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        runCurrent()
+
+        // INVALID_ACCUSATION has a dedicated flow (accusationErrors); it must not
+        // also surface on the generic domainErrors flow (no double-surfacing).
+        factory.simulateText(
+            gameActionFrame(
+                """{"code":"INVALID_ACCUSATION","message":"You can only accuse once per turn",""" +
+                    """"timestamp":1714000000000,"context":{}}"""
+            )
+        )
+        runCurrent()
+
+        assertTrue(errors.isEmpty())
+    }
+
+    @Test
     fun accusationResultAppliesTheEmbeddedStateSnapshot() {
         val factory = FakeWebSocketFactory()
         val client = newClient(factory)

--- a/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/WebSocketClientTest.kt
@@ -65,6 +65,7 @@ class DummyWebSocketClient : WebSocketClient {
     override val accusationResults: SharedFlow<com.machikoro.client.domain.model.state.AccusationResult> = MutableSharedFlow(extraBufferCapacity = 1)
     override val coinDeltas: SharedFlow<Int> = MutableSharedFlow(extraBufferCapacity = 1)
     override val accusationErrors: SharedFlow<String> = MutableSharedFlow(extraBufferCapacity = 1)
+    override val domainErrors: SharedFlow<ClientError.WebSocket> = MutableSharedFlow(extraBufferCapacity = 1)
     override val chatMessages: SharedFlow<ChatMessageState> = MutableSharedFlow(extraBufferCapacity = 1)
 
     override fun connect() {}

--- a/app/src/test/java/com/machikoro/client/network/websocket/WsErrorParserTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/WsErrorParserTest.kt
@@ -57,6 +57,20 @@ class WsErrorParserTest {
     }
 
     @Test
+    fun parseReadsTopLevelCodeAndMessageFromWebSocketErrorDto() {
+        // Bare WebSocketErrorDto sent on /user/queue/errors (server #428): no
+        // envelope `type`, no nested payload — code/message are top-level.
+        val json = JSONObject(
+            """{"code":"NOT_YOUR_TURN","message":"It is not your turn","timestamp":1714000000000,"context":{}}"""
+        )
+
+        val error = WsErrorParser.parse(json)
+
+        assertEquals("NOT_YOUR_TURN", error.serverCode)
+        assertEquals("It is not your turn", error.userMessage)
+    }
+
+    @Test
     fun parseHandlesMissingPayload() {
         val json = JSONObject("""{"type":"ERROR","content":"Unexpected failure"}""")
 

--- a/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/home/HomeScreenViewModelTest.kt
@@ -312,6 +312,7 @@ class HomeScreenViewModelTest {
             MutableSharedFlow(extraBufferCapacity = 1)
         override val coinDeltas: SharedFlow<Int> = MutableSharedFlow(extraBufferCapacity = 1)
         override val accusationErrors: SharedFlow<String> = MutableSharedFlow(extraBufferCapacity = 1)
+        override val domainErrors: SharedFlow<ClientError.WebSocket> = MutableSharedFlow(extraBufferCapacity = 1)
         override fun connect() { connectCalled = true }
         override fun disconnect() { disconnectCalled = true }
         override fun rollDice(diceCount: Int) = Unit


### PR DESCRIPTION
Closes #381

## Context

Server PR [#428](https://github.com/SE2-Machi-Koro/Server/pull/428) fixed the global WebSocket exception handler so domain rejections (e.g. `NOT_YOUR_TURN`) are actually delivered to the caller on `/user/queue/errors` instead of being logged server-side and silently dropped.

The client already subscribes to `/user/queue/errors` (subscription id `user-errors`), but it did not parse or surface what the server now sends, so generic domain errors were silently ignored on the client even after the server fix.

## Problem — payload-shape mismatch

The server sends a bare `WebSocketErrorDto` with **top-level** fields and **no `type`**:

```json
{ "code": "NOT_YOUR_TURN", "message": "It is not your turn", "timestamp": 1714000000000, "context": {} }
```

But the MESSAGE dispatch mostly assumed the broadcast envelope shape (`type == "ERROR"`, nested `payload.code` / `payload.message`):

- `WsErrorParser.parse` read `payload.errorCode` / `payload.code` and `content` / `payload.message` — not the top-level fields, so a `NOT_YOUR_TURN` frame parsed as `UNKNOWN` with a generic message.
- `handleLobbyError` / `parsePurchaseFailure` require `type == "ERROR"`, so they skipped the raw DTO entirely.
- Only `handleAccusationError` read top-level `code`, and only for `INVALID_ACCUSATION`.

## Changes

1. **`WsErrorParser.parse`** now also reads **top-level** `code` and `message` (the `WebSocketErrorDto` contract), while staying backward-compatible with the nested-`payload` broadcast shape.
2. **New sink `domainErrors: SharedFlow<ClientError.WebSocket>`** on `WebSocketClient` / `OkHttpWebSocketClient`, fed by a new `handlePrivateError` that matches frames with **no `type`** and a top-level `code`. `INVALID_ACCUSATION` is excluded because it already has a dedicated `accusationErrors` flow — this avoids double-surfacing.
3. **Routing precedence**: `handlePrivateError` only fires for envelope-less frames (`type` blank), so private error frames are never mis-handled by the topic/broadcast handlers, and broadcast envelopes never leak into `domainErrors`.
4. **`GameScreenViewModel`** exposes `domainErrors` as a pass-through; **`MainActivity`** collects it and shows the server's message as a toast.

## Tests

- `WsErrorParserTest`: parsing a bare `WebSocketErrorDto` yields `serverCode = NOT_YOUR_TURN`, `message = "It is not your turn"`.
- `OkHttpWebSocketClientTest`:
  - `privateDomainErrorFrameEmitsDomainError` — a `NOT_YOUR_TURN` frame is surfaced on `domainErrors`.
  - `invalidAccusationDoesNotEmitDomainError` — `INVALID_ACCUSATION` is **not** surfaced on `domainErrors` (still handled by `accusationErrors`).
- Updated the other `WebSocketClient` test doubles (`WebSocketClientTest`, `HomeScreenViewModelTest`) to implement the new member.

All websocket and home-VM unit tests pass locally (`./gradlew testDebugUnitTest`).

## Acceptance criteria

- [x] Ending a turn out of order yields a parsed error with `serverCode = NOT_YOUR_TURN`, `message = "It is not your turn"`, surfaced to the user.
- [x] Existing `INVALID_ACCUSATION` and lobby-join error handling unchanged.

## Design note

The issue flagged an alternative: have the **server** wrap the error in a `WebSocketMessage` envelope (`type=ERROR`, `payload={code,message,context}`) to match the broadcast shape, avoiding a client parser change. The docs repo treats `/user/queue/errors` as a `WebSocketErrorDto`, so this PR adapts the client. If the team prefers a uniform envelope, that can be done server-side instead.