### PR TITLE
ci: fix release signing — pass keystore base64 to Gradle, drop redundant decode step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,15 +65,10 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Decode Keystore
-        env:
-          KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
-        run: echo "$KEYSTORE_FILE" | base64 -d > keystore.jks
-
       - name: Build Release APK
         run: ./gradlew assembleRelease
         env:
-          KEYSTORE_PATH: ${{ github.workspace }}/keystore.jks
+          KEYSTORE_FILE: ${{ secrets.KEYSTORE_FILE }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}


### PR DESCRIPTION
## Problem

The release `deploy` job was failing in two ways (same root cause):

- `base64: invalid input` in the `Decode Keystore` step
- `keystore password was incorrect` during `packageRelease`

The signing config in `app/build.gradle.kts` already decodes the `KEYSTORE_FILE` base64 secret itself (via `Base64.getMimeDecoder()`) and writes the keystore. But the workflow:

1. still ran a **redundant** `base64 -d` shell step that choked on wrapped/whitespace base64 (`base64: invalid input`), killing the job before the build; and
2. passed `KEYSTORE_PATH` to `assembleRelease`, which the current Gradle config **ignores** — it reads `KEYSTORE_FILE`, which was never passed to that step.

## Fix

- Remove the redundant `Decode Keystore` step.
- Pass `KEYSTORE_FILE` directly to the `Build Release APK` step so the tolerant Gradle decoder handles it.

## Note

This is the workflow half of the fix. The signing keystore secrets (`KEYSTORE_FILE`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`) were also regenerated, since the previous `KEYSTORE_FILE` secret was malformed base64. With clean secrets + this change, the next push to `main` should sign and upload the release APK.

Closes #391
