### PR TITLE
ci: fix butler binary path in itch.io deploy

### DIFF
--- a/.github/workflows/deploy-to-itch.yml
+++ b/.github/workflows/deploy-to-itch.yml
@@ -41,11 +41,13 @@ jobs:
             https://github.com/itchio/butler/releases/download/v15.27.0/butler-linux-amd64.zip
           echo "b78ca81ed566c2daa54d68b7e300dd32888168163212293909ce90f16e0ec75d  butler.zip" | sha256sum -c
           unzip butler.zip
-          chmod +x butler
+          # v15.27.0 extracts the binary into a linux-amd64/ subdirectory
+          chmod +x ./linux-amd64/butler
+          echo "$GITHUB_WORKSPACE/linux-amd64" >> "$GITHUB_PATH"
 
       - name: Deploy to itch.io via Butler
         env:
           BUTLER_API_KEY: ${{ secrets.BUTLER_CREDENTIALS }}
           ITCH_USER: ${{ secrets.ITCH_USER }}
           ITCH_GAME: ${{ secrets.ITCH_GAME }}
-        run: ./butler push app/build/outputs/apk/release/ "$ITCH_USER/$ITCH_GAME:android"
+        run: butler push app/build/outputs/apk/release/ "$ITCH_USER/$ITCH_GAME:android"


### PR DESCRIPTION
## Problem

The `Deploy to itch.io` workflow fails at the **Install Butler** step:

```
chmod: cannot access 'butler': No such file or directory
Error: Process completed with exit code 1.
```

`butler-linux-amd64.zip` (v15.27.0) extracts the binary into a `linux-amd64/` subdirectory (`inflating: linux-amd64/butler`), but the step ran `chmod +x butler` against the working directory, where no `butler` exists. The later `./butler push` would have failed the same way.

## Fix

- `chmod +x ./linux-amd64/butler` (the real path)
- add `linux-amd64/` to `$GITHUB_PATH` so the deploy step finds `butler` on PATH
- call `butler push` instead of `./butler push`

## Note

This workflow also builds the signed release APK and already passes `KEYSTORE_FILE` correctly, so it benefits from the signing secrets fixed alongside #390.

Closes #393
