### PR TITLE
329 parse incoming chat messages

### DIFF
--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -1013,9 +1013,11 @@ class OkHttpWebSocketClient(
         if (json.optString("type") != "CHAT") return //ignore messages of other types
         // Flexible detection: the server might put message/sender in the top-level or under payload.
         val payload = json.optJSONObject("payload")
+        val gameId = payload?.optString("gameId") ?: json.optString("gameId")
+        if (gameId != mutableActiveGameId.value.toString()) return //ignore messages for other games
         val msg = payload?.optString("message") ?: json.optString("content")
         if (msg.isBlank()) return
-        val sender = payload?.optString("sender") ?: json.optString("sender") ?: json.optString("username")
+        val sender = payload?.optString("sender") ?: json.optString("sender").takeIf { it.isNotBlank() }  ?: json.optString("username")
         if (sender.isBlank()) return
 
         Log.d(TAG, "Received chat message from $sender: $msg")

--- a/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
+++ b/app/src/main/java/com/machikoro/client/network/websocket/OkHttpWebSocketClient.kt
@@ -1013,11 +1013,11 @@ class OkHttpWebSocketClient(
         if (json.optString("type") != "CHAT") return //ignore messages of other types
         // Flexible detection: the server might put message/sender in the top-level or under payload.
         val payload = json.optJSONObject("payload")
-        val gameId = payload?.optString("gameId") ?: json.optString("gameId")
+        val gameId = payload?.optString("gameId").takeIf{ it?.isNotBlank() == true } ?: json.optString("gameId")
         if (gameId != mutableActiveGameId.value.toString()) return //ignore messages for other games
-        val msg = payload?.optString("message") ?: json.optString("content")
+        val msg = payload?.optString("message").takeIf{ it?.isNotBlank() == true } ?: json.optString("content")
         if (msg.isBlank()) return
-        val sender = payload?.optString("sender") ?: json.optString("sender").takeIf { it.isNotBlank() }  ?: json.optString("username")
+        val sender = payload?.optString("sender").takeIf{ it?.isNotBlank() == true } ?: json.optString("sender").takeIf { it.isNotBlank() }  ?: json.optString("username")
         if (sender.isBlank()) return
 
         Log.d(TAG, "Received chat message from $sender: $msg")

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -3815,10 +3815,11 @@ class OkHttpWebSocketClientTest {
         client.connect()
         factory.simulateOpen()
         factory.simulateText(connectedFrame())
+        factory.simulateText(gameStartedFrame(gameId = 7))
         runCurrent()
 
         // server sends chat under payload
-        val chatJson = """{"type":"CHAT","sender":"server","payload":{"sender":"alice","message":"hello"}}"""
+        val chatJson = """{"type":"CHAT", "sender":"server","payload":{"sender":"alice","message":"hello","gameId":"7"}}"""
         factory.simulateText(gameActionFrame(chatJson))
         runCurrent()
 
@@ -3833,12 +3834,13 @@ class OkHttpWebSocketClientTest {
         client.connect()
         factory.simulateOpen()
         factory.simulateText(connectedFrame())
+        factory.simulateText(gameStartedFrame(gameId = 7))
         val received = mutableListOf<ChatMessageState>()
         client.chatMessages.onEach { received += it }.launchIn(backgroundScope)
         runCurrent()
 
         // server sends message and sender at top-level
-        val chatJson = """{"type":"CHAT","sender":"bob","content":"hey"}"""
+        val chatJson = """{"type":"CHAT","gameId":"7","sender":"bob","content":"hey"}"""
         factory.simulateText(gameActionFrame(chatJson))
         runCurrent()
 
@@ -3853,6 +3855,7 @@ class OkHttpWebSocketClientTest {
         client.connect()
         factory.simulateOpen()
         factory.simulateText(connectedFrame())
+        factory.simulateText(gameStartedFrame(gameId = 7))
         val received = mutableListOf<ChatMessageState>()
         client.chatMessages.onEach { received += it }.launchIn(backgroundScope)
         runCurrent()
@@ -3863,12 +3866,12 @@ class OkHttpWebSocketClientTest {
         assertTrue(received.isEmpty())
 
         // valid JSON but no message
-        factory.simulateText(gameActionFrame("""{"type":"CHAT","sender":"carol","payload":{}}"""))
+        factory.simulateText(gameActionFrame("""{"type":"CHAT","sender":"carol","gameId":"7", "payload":{}}"""))
         runCurrent()
         assertTrue(received.isEmpty())
 
         // blank sender
-        factory.simulateText(gameActionFrame("""{"type":"CHAT","sender":"","content":"hi"}"""))
+        factory.simulateText(gameActionFrame("""{"type":"CHAT","sender":"","content":"hi", "gameId":"7"}"""))
         runCurrent()
         assertTrue(received.isEmpty())
     }
@@ -3901,7 +3904,85 @@ class OkHttpWebSocketClientTest {
 
         assertTrue(factory.socket.sentMessages.isEmpty())
     }
+    @Test
+    fun nonChatMessageDoesNotEmitChatMessage() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
 
+        val received = mutableListOf<ChatMessageState>()
+        client.chatMessages.onEach { received += it }.launchIn(backgroundScope)
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        factory.simulateText(gameStartedFrame(gameId = 7))
+        runCurrent()
+
+        factory.simulateText(
+            gameActionFrame(
+                """{
+                "type":"CHAT",
+                "gameId":"99",
+                "sender":"alice",
+                "content":"hello"
+            }"""
+            )
+        )
+
+        runCurrent()
+
+        assertTrue(received.isEmpty())
+    }
+    @Test
+    fun chatMessageForDifferentGameIsIgnored() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+
+        val received = mutableListOf<ChatMessageState>()
+        client.chatMessages.onEach { received += it }.launchIn(backgroundScope)
+
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+
+        // active game = 7
+        factory.simulateText(gameStartedFrame(gameId = 7))
+
+        factory.simulateText(
+            gameActionFrame(
+                """{
+                "type":"CHAT",
+                "gameId":"99",
+                "sender":"alice",
+                "content":"hello"
+            }"""
+            )
+        )
+        runCurrent()
+
+        assertTrue(received.isEmpty())
+    }
+    @Test
+    fun chatFallsBackToUsernameWhenSenderMissing() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        factory.simulateText(gameStartedFrame(gameId = 7))
+        val received = mutableListOf<ChatMessageState>()
+        client.chatMessages.onEach { received += it }.launchIn(backgroundScope)
+        runCurrent()
+
+        // server sends message and sender at top-level
+        val chatJson = """{"type":"CHAT","gameId":"7","username":"bob","content":"hey"}"""
+        factory.simulateText(gameActionFrame(chatJson))
+        runCurrent()
+
+        assertEquals(1, received.size)
+        assertEquals("bob", received.first().sender)
+        assertEquals("hey", received.first().message)
+    }
     private fun newClient(
         factory: FakeWebSocketFactory,
         sessionStateHolder: SessionStateHolder = FakeSessionStateHolder(DEFAULT_SESSION),

--- a/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
+++ b/app/src/test/java/com/machikoro/client/network/websocket/OkHttpWebSocketClientTest.kt
@@ -3849,6 +3849,27 @@ class OkHttpWebSocketClientTest {
         assertEquals("hey", received.first().message)
     }
     @Test
+    fun fallBackToTopLevelFieldsWhenPayloadIsEmpty() = runTest {
+        val factory = FakeWebSocketFactory()
+        val client = newClient(factory)
+        client.connect()
+        factory.simulateOpen()
+        factory.simulateText(connectedFrame())
+        factory.simulateText(gameStartedFrame(gameId = 7))
+        val received = mutableListOf<ChatMessageState>()
+        client.chatMessages.onEach { received += it }.launchIn(backgroundScope)
+        runCurrent()
+
+        // server sends message and sender at top-level
+        val chatJson = """{"type":"CHAT","gameId":"7","sender":"bob","content":"hey","payload":{}}"""
+        factory.simulateText(gameActionFrame(chatJson))
+        runCurrent()
+
+        assertEquals(1, received.size)
+        assertEquals("bob", received.first().sender)
+        assertEquals("hey", received.first().message)
+    }
+    @Test
     fun malformedOrBlankChatMessageDoesNotEmit() = runTest {
         val factory = FakeWebSocketFactory()
         val client = newClient(factory)
@@ -3921,8 +3942,8 @@ class OkHttpWebSocketClientTest {
         factory.simulateText(
             gameActionFrame(
                 """{
-                "type":"CHAT",
-                "gameId":"99",
+                "type":"ACCUSATION_RESULT",
+                "gameId":"7",
                 "sender":"alice",
                 "content":"hello"
             }"""


### PR DESCRIPTION
### Summary
Added an ID check to the chat Message parser `handleChatMessage`
Fixed the `username` fallback when `sender` is missing
Added and adjusted chat tests to include and account for the changes