### PR TITLE
fix: added auto phase change

### DIFF
--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.automirrored.filled.Chat
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
@@ -86,6 +86,8 @@ import kotlinx.coroutines.delay
 // delays
 private val OWN_CARDS_VIEW_DELAY = 10000L
 private val MARKETPLACE_VIEW_DELAY = 10000L
+private val SHOP_VIEW_DELAY = 15000L
+
 
 
 // offsets
@@ -157,7 +159,7 @@ fun GameScreen(
 
     val phaseTimerTime =
         when {
-            state.isBuyingPhase && state.purchaseState != PurchaseState.SUCCESS  -> 30
+            state.isBuyingPhase && state.purchaseState != PurchaseState.SUCCESS  -> (SHOP_VIEW_DELAY / 1000).toInt()
             state.gamePhase == GamePhase.ROLL_DICE -> 20
             // Matches the actual auto-advance dwell so the countdown the player sees
             // is the real time until RESOLVE_EFFECTS ends, not a longer, unrelated number.
@@ -455,6 +457,18 @@ fun GameScreen(
                     }
 
                     else if (state.isBuyingPhase) {
+                        var delayShop = 0L
+
+                    LaunchedEffect(state.isBuyingPhase) {
+                        if(state.isBuyingPhase) {
+                            delayShop = 5000L
+                            delay(delayShop)
+                            if(state.purchaseState != PurchaseState.SUCCESS
+                                || state.purchaseState != PurchaseState.PENDING) {
+                                onTurnFlowAction()
+                            }
+                        } else delayShop = 0L
+                    }
                             BuyingPhaseShop(
                                 state = state,
                                 items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.Chat
+import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
@@ -466,7 +466,7 @@ fun GameScreen(
                             if(state.purchaseState != PurchaseState.SUCCESS
                                 || state.purchaseState != PurchaseState.PENDING) {
                                 onTurnFlowAction()
-                            }
+                            } else if(state.purchaseState == PurchaseState.SUCCESS) delayShop = 0L
                         } else delayShop = 0L
                     }
                             BuyingPhaseShop(


### PR DESCRIPTION
after entering buying phase delay starts and checks if purchased is pending or finished, if not skips automaticly