### PR TITLE
fix: clamp dice roll to one die without a Train Station (#399)

### DIFF
--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
@@ -338,9 +338,13 @@ class GameScreenViewModel(
         // the dice animation stuck in the rolling state.
         if (mutableState.value.isRolling) return
 
-        mutableState.update { it.copy(isRolling = true, requestedDiceCount = diceCount) }
+        // A player without a built Train Station may only roll a single die. Clamp
+        // here so a stale requested count (e.g. carried over from an earlier two-dice
+        // roll) can never reach the server and trigger NO_TRAIN_STATION (#399).
+        val effectiveDiceCount = if (mutableState.value.hasTrainStation) diceCount else 1
+        mutableState.update { it.copy(isRolling = true, requestedDiceCount = effectiveDiceCount) }
         startRollTimeout(expectedPhase = GamePhase.ROLL_DICE)
-        webSocketClient.rollDice(diceCount)
+        webSocketClient.rollDice(effectiveDiceCount)
     }
 
     /**

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
@@ -256,7 +256,9 @@ fun DiceSection(
     // Active player uses frozen/selected count; snapshot only stores total so diceResult.size is unreliable after reconnect.
     // Non-active player uses the count captured from the live ROLL_DICE message (before snapshot overwrites it).
     val animationDiceCount = if (state.isActivePlayer) {
-        frozenDiceCount ?: selectedDiceCount ?: state.requestedDiceCount
+        // Without a Train Station the player can only roll one die, so never spin
+        // two even if a stale requested count lingers from an earlier turn (#399).
+        if (state.hasTrainStation) frozenDiceCount ?: selectedDiceCount ?: state.requestedDiceCount else 1
     } else {
         localAnimationDiceCount
     }
@@ -389,7 +391,8 @@ fun DiceSection(
             ) {
                 // Roll button: only when server has no result yet and we are in ROLL_DICE
                 if (state.gamePhase == GamePhase.ROLL_DICE && state.diceResult == null) {
-                    val chosen = frozenDiceCount ?: selectedDiceCount ?: state.requestedDiceCount
+                    val chosen =
+                        if (state.hasTrainStation) frozenDiceCount ?: selectedDiceCount ?: state.requestedDiceCount else 1
                     ActionButton(
                         onClick = {
                             SoundManager.play(GameSound.DICE_ROLL)

--- a/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
@@ -259,6 +259,51 @@ class GameScreenViewModelTest {
     }
 
     @Test
+    fun rollDiceClampsToOneDieWhenActivePlayerHasNoTrainStation() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 42)
+
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
+        fakeClient.emitGamePhase(GamePhase.ROLL_DICE)
+        fakeClient.emitActivePlayerId(42)
+        fakeClient.emitPlayers(
+            listOf(PlayerCoinState(id = "42", displayName = "me", coins = 3, isActivePlayer = true))
+        )
+        fakeClient.emitPlayerLandmarks(
+            mapOf(42 to listOf(PlayerLandmarkState(LandmarkType.TRAIN_STATION, isBuilt = false)))
+        )
+        advanceUntilIdle()
+
+        // Player asks (or a stale count asks) for two dice without a Train Station (#399).
+        viewModel.rollDice(diceCount = 2)
+
+        assertEquals(1, fakeClient.lastRolledDiceCount)
+        assertEquals(1, viewModel.state.value.requestedDiceCount)
+    }
+
+    @Test
+    fun rollDiceForwardsTwoDiceWhenActivePlayerHasTrainStation() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 42)
+
+        fakeClient.emitGameStatus(GameStatus.IN_PROGRESS)
+        fakeClient.emitGamePhase(GamePhase.ROLL_DICE)
+        fakeClient.emitActivePlayerId(42)
+        fakeClient.emitPlayers(
+            listOf(PlayerCoinState(id = "42", displayName = "me", coins = 3, isActivePlayer = true))
+        )
+        fakeClient.emitPlayerLandmarks(
+            mapOf(42 to listOf(PlayerLandmarkState(LandmarkType.TRAIN_STATION, isBuilt = true)))
+        )
+        advanceUntilIdle()
+
+        viewModel.rollDice(diceCount = 2)
+
+        assertEquals(2, fakeClient.lastRolledDiceCount)
+        assertEquals(2, viewModel.state.value.requestedDiceCount)
+    }
+
+    @Test
     fun rollDiceIsIgnoredWhenPhaseIsNotRollDice() = runTest {
         val fakeClient = FakeWebSocketClient()
         val viewModel = viewModel(fakeClient, userId = 42)


### PR DESCRIPTION
## Summary


When the active player has **no built Train Station**, rolling a single die wrongly:
- animated **two** dice during the roll, and
- triggered a server error: `NO_TRAIN_STATION` — *"You need a Train Station to roll two dice!"* (`ROLL_FAILED`).

## Root cause

The 1/2 dice-count selector in `DiceSection` is only shown when the player `hasTrainStation`. For a player without one, `selectedDiceCount`/`frozenDiceCount` stay `null`, so both the roll request and the rolling animation fall back to `state.requestedDiceCount`.

`requestedDiceCount` is set on every `rollDice(diceCount)` call and is **never reset back to 1** at the start of a turn (it persists in the ViewModel/state). A stale value of `2` (e.g. carried over from an earlier two-dice roll) therefore leaked into a single-die turn, causing:
- `chosen = 2` → `onRollDice(2)` → server `NO_TRAIN_STATION`, and
- `animationDiceCount = 2` → two dice spin in the UI.

The server (`DiceService`) is correct by the rules — it only requires a Train Station when the resolved dice count is 2 — so the fix belongs on the client.

## Fix

Clamp the effective dice count to **1** whenever the active player has no built Train Station:

- **`GameScreenViewModel.rollDice`** (network boundary): compute `effectiveDiceCount = if (hasTrainStation) diceCount else 1` and use it for both `requestedDiceCount` and `webSocketClient.rollDice(...)`. The server can never receive an illegal two-dice request.
- **`DiceSection`** (animation/selection): the active player's `animationDiceCount` and the roll button's `chosen` value resolve to `1` when there is no Train Station, so only a single die ever spins.

Defense in depth across both layers; a player **with** a Train Station is unaffected and can still choose 1 or 2.

## Tests

Added `GameScreenViewModelTest` coverage:
- `rollDiceClampsToOneDieWhenActivePlayerHasNoTrainStation` — a two-dice request without a Train Station is clamped to 1 (and `requestedDiceCount` becomes 1).
- `rollDiceForwardsTwoDiceWhenActivePlayerHasTrainStation` — with a built Train Station, two dice are still forwarded.