### PR TITLE
fix: resolve effects after same-total Radio Tower reroll (#405)

### DIFF
--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
@@ -199,8 +199,17 @@ class GameScreenViewModel(
             // #346: drives the non-active player's roll/reroll animation. Bumped
             // only on a real DICE_ROLLED/DICE_REROLLED frame, so a same-turn reroll
             // animates while the snapshot collapse ([x, y] -> [total]) does not.
+            //
+            // #405: the tick also ends the local "rolling" state. A Radio Tower
+            // reroll that lands the same total as the previous roll does not change
+            // diceResult, so the diceResult collector above never fires and never
+            // clears isRolling — leaving the active player stuck in RESOLVE_EFFECTS
+            // (auto-resolve gates on !isRolling) until the roll timeout. Clearing it
+            // here, off the always-bumped tick, treats every DICE_REROLLED frame as a
+            // roll completion regardless of whether the numbers changed.
             webSocketClient.diceRollTick.collect { tick ->
-                mutableState.update { it.copy(diceRollTick = tick) }
+                cancelPendingRollTimeout()
+                mutableState.update { it.copy(diceRollTick = tick, isRolling = false) }
             }
         }
         viewModelScope.launch {

--- a/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
@@ -1798,6 +1798,48 @@ class GameScreenViewModelTest {
     }
 
     @Test
+    fun rerollAutoResolvesEffectsWhenServerReturnsDifferentDice() = runTest {
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 42)
+        fakeClient.enterRadioTowerRerollDecision() // emits diceResult listOf(6)
+        advanceUntilIdle()
+        assertEquals(0, fakeClient.resolveEffectsCallCount)
+
+        viewModel.rerollDice(diceCount = 1)
+        runCurrent()
+        // Server broadcasts DICE_REROLLED with a different total.
+        fakeClient.emitDiceResult(listOf(3))
+        advanceUntilIdle()
+
+        assertEquals(1, fakeClient.resolveEffectsCallCount)
+    }
+
+    @Test
+    fun rerollAutoResolvesEffectsWhenServerReturnsSameDice() = runTest {
+        // #405: a Radio Tower reroll that lands the same total as the previous roll
+        // does not change diceResult, so isRolling must still be cleared off the
+        // dice-roll tick — otherwise the active player is stuck in RESOLVE_EFFECTS
+        // (auto-resolve never fires) until the roll timeout.
+        val fakeClient = FakeWebSocketClient()
+        val viewModel = viewModel(fakeClient, userId = 42)
+        fakeClient.enterRadioTowerRerollDecision() // emits diceResult listOf(6)
+        advanceUntilIdle()
+        assertEquals(0, fakeClient.resolveEffectsCallCount)
+
+        viewModel.rerollDice(diceCount = 1)
+        runCurrent()
+        // Server broadcasts DICE_REROLLED with the same total: diceResult unchanged,
+        // only the tick bumps.
+        fakeClient.emitDiceResult(listOf(6))
+        runCurrent()
+        advanceTimeBy(GameScreenViewModel.DEFAULT_RESOLVE_EFFECTS_DWELL_MS + 1)
+        runCurrent()
+
+        assertFalse(viewModel.state.value.isRolling)
+        assertEquals(1, fakeClient.resolveEffectsCallCount)
+    }
+
+    @Test
     fun resolveEffectsDoesNotAutoSendForNonActivePlayer() = runTest {
         val fakeClient = FakeWebSocketClient()
         viewModel(fakeClient, userId = 1)

--- a/docs/websocket-protocol.md
+++ b/docs/websocket-protocol.md
@@ -64,7 +64,11 @@ During `RESOLVE_EFFECTS`, the active player may additionally send
 `/app/game.rerollDice` (#326) when they have built a `RADIO_TOWER` and a roll
 already exists this turn. The client gates this to the active player with a
 Radio Tower and limits it to once per turn (renewed on turn rotation); the
-server stays authoritative for the once-per-turn rule and the result.
+server stays authoritative for the once-per-turn rule and the result. The
+`DICE_REROLLED` broadcast is treated as a roll completion even when it lands the
+same total as the previous roll (#405), so the client always leaves the rolling
+state and auto-advances `RESOLVE_EFFECTS` rather than waiting on the roll
+timeout.
 
 ## Handled Message Types
 


### PR DESCRIPTION
Closes #405

## Summary

After a Radio Tower reroll the game could get stuck in the **Resolve Effects** phase: the active player never auto-advanced and the dice stayed in their "rolling" state until the 10s safety timeout fired.

Issue #405 describes this as the frontend handling `DICE_ROLLED` but not `DICE_REROLLED`. In this Android client both events arrive as the same `ROLL_DICE` message and are already parsed identically (snapshot + dice result), and resolve-effects auto-advances off phase state — so the happy path (a reroll that changes the total) already worked. The real gap is narrower and was reproduced with a failing test before fixing:

## Root cause

`diceResult` is a `StateFlow`, which conflates equal values. A reroll that lands the **same total** as the previous roll (e.g. rolled `[6]`, rerolled `[6]`) does not change `diceResult`, so the `diceResult` collector — the only place that cleared `isRolling` and cancelled the pending roll timeout — never fired.

Auto-resolve gates on `!isRolling` (`shouldAutoResolveEffects`), so with `isRolling` stuck `true` the active player never sent `/app/game.resolveEffects` and the game hung in `RESOLVE_EFFECTS` until `DICE_ROLL_TIMEOUT_MS` (10s) eventually cleared `isRolling`.

## Fix

Clear `isRolling` and cancel the pending roll timeout off the **`diceRollTick`** signal instead. The tick is bumped on every genuine `DICE_ROLLED`/`DICE_REROLLED` frame (always, regardless of whether the numbers changed), so every reroll is now treated as a roll completion and auto-resolve fires immediately — same-total rerolls included.

The existing `diceResult` collector still updates the displayed result; the tick collector now owns ending the rolling state.

## Changes

- `GameScreenViewModel.kt` — clear `isRolling` + cancel pending roll timeout in the `diceRollTick` collector.
- `GameScreenViewModelTest.kt` — two regression tests:
  - `rerollAutoResolvesEffectsWhenServerReturnsDifferentDice` (guards the previously-working path)
  - `rerollAutoResolvesEffectsWhenServerReturnsSameDice` (reproduces #405; fails on the old code, passes now)
- `docs/websocket-protocol.md` — document that `DICE_REROLLED` is treated as a roll completion even on an unchanged total.

## Testing

- Added test fails on `main` and passes with the fix.
- `./gradlew :app:testDebugUnitTest` — full unit suite green.
