### PR TITLE
fix: keep dice rolling UI pending until server response

### DIFF
--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Dice.kt
@@ -259,6 +259,7 @@ fun DiceSection(
     } else {
         localAnimationDiceCount
     }
+    val showRollingAnimation = isAnimating || (state.isActivePlayer && state.isRolling)
 
     LaunchedEffect(state.diceResult) {
         if (state.diceResult == null) {
@@ -298,7 +299,7 @@ fun DiceSection(
         modifier = modifier.padding(bottom = 32.dp)
     ) {
         when {
-            isAnimating -> {
+            showRollingAnimation -> {
                 Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
                     repeat(animationDiceCount) {
                         DiceAnimationDisplay(animating = true)
@@ -341,7 +342,7 @@ fun DiceSection(
         }
         if (state.isActivePlayer &&
             state.gameStatus == GameStatus.IN_PROGRESS &&
-            !isAnimating
+            !showRollingAnimation
         ) {
             // Roll controls only appear during the actual rolling phase
             if (state.gamePhase == GamePhase.ROLL_DICE && state.hasTrainStation) {
@@ -384,12 +385,13 @@ fun DiceSection(
                         if (state.hasTrainStation) frozenDiceCount ?: selectedDiceCount ?: state.requestedDiceCount else 1
                     ActionButton(
                         onClick = {
+                            if (state.isRolling) return@ActionButton
                             SoundManager.play(GameSound.DICE_ROLL)
                             frozenDiceCount = chosen
                             isAnimating = true
                             onRollDice(chosen)
                         },
-                        enabled = true,
+                        enabled = !state.isRolling,
                         label = "Roll " + (if (chosen > 1) "Two Dice" else "One Die"),
                         modifier = Modifier.semantics {
                             contentDescription = "Roll Dice"
@@ -403,13 +405,14 @@ fun DiceSection(
                     val rerollCount = frozenDiceCount ?: state.diceResult?.size ?: 1
                     ActionButton(
                         onClick = {
+                            if (state.isRolling) return@ActionButton
                             SoundManager.play(GameSound.DICE_ROLL)
                             hasRerolled = true
                             frozenDiceCount = rerollCount
                             isAnimating = true
                             onReroll(rerollCount)
                         },
-                        enabled = true,
+                        enabled = !state.isRolling,
                         label = "Roll Dice Again",
                         modifier = Modifier.semantics {
                             contentDescription = "Reroll Dice"


### PR DESCRIPTION
**PR Description**

Fixes the dice roll UI getting stuck in a retry-like flow where the “Roll Dice” button could appear again while the first roll request was still pending.

**What Was Added**

- The dice section now treats `state.isRolling` as part of the visible rolling state.
- While a roll or reroll request is pending, the UI keeps showing the dice rolling animation.
- The normal roll and reroll buttons are disabled/guarded while `state.isRolling` is true.

**Expected Behavior Now**

When the active player taps “Roll Dice”:

- The dice animation starts immediately.
- The UI no longer returns to dice selection just because the short local animation finished.
- The player cannot accidentally trigger additional roll requests while the first one is still pending.
- The animation stays visible until:
  - the server sends a dice result,
  - the server changes the game phase,
  - or the existing 10-second timeout clears the pending roll state.

For Radio Tower rerolls, “Roll Dice Again” follows the same pending-state behavior and cannot be spammed while waiting for the server response.
