### PR TITLE
411 feat animate newly purchased landmarks before ending the purchase phase

### DIFF
--- a/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
+++ b/app/src/main/java/com/machikoro/client/domain/model/state/GameScreenState.kt
@@ -32,6 +32,8 @@ data class GameScreenState(
     val pendingPurchaseItemType: String? = null,
     // Keeps button feedback tied to the specific item that was bought or failed.
     val purchaseFeedbackItemType: String? = null,
+    // Distinguishes landmark reveals from regular establishment purchase feedback.
+    val purchaseFeedbackType: PurchaseType? = null,
     // Short feedback text shown in the shop for pending, success, or retryable errors.
     val purchaseMessage: String? = null,
     val isRolling: Boolean = false,
@@ -99,6 +101,7 @@ data class GameScreenState(
             selectedPurchaseItemType = null,
             pendingPurchaseItemType = null,
             purchaseFeedbackItemType = null,
+            purchaseFeedbackType = null,
             purchaseMessage = null,
             isRolling = false,
             requestedDiceCount = 1,

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreen.kt
@@ -541,25 +541,30 @@ fun GameScreen(
                     }
 
                     else if (state.isBuyingPhase) {
-                        var delayShop = 0L
+                        LaunchedEffect(
+                            state.isBuyingPhase,
+                            state.isActivePlayer,
+                            state.purchaseState
+                        ) {
+                            val canAutoSkip =
+                                state.isBuyingPhase &&
+                                    state.isActivePlayer &&
+                                    state.purchaseState != PurchaseState.PENDING &&
+                                    state.purchaseState != PurchaseState.SUCCESS
 
-                    LaunchedEffect(state.isBuyingPhase) {
-                        if(state.isBuyingPhase) {
-                            delayShop = 5000L
-                            delay(delayShop)
-                            if(state.purchaseState != PurchaseState.SUCCESS
-                                || state.purchaseState != PurchaseState.PENDING) {
+                            if (canAutoSkip) {
+                                delay(SHOP_VIEW_DELAY)
                                 onTurnFlowAction()
-                            } else if(state.purchaseState == PurchaseState.SUCCESS) delayShop = 0L
-                        } else delayShop = 0L
-                    }
-                            BuyingPhaseShop(
-                                state = state,
-                                items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
-                                onPurchaseClick = onPurchaseClick,
-                                recommendedCardType = cheatRecommendation,
-                                modifier = Modifier.align(Alignment.Center)
-                            )
+                            }
+                        }
+
+                        BuyingPhaseShop(
+                            state = state,
+                            items = state.shopItems.ifEmpty { ShopCatalog.defaultItems },
+                            onPurchaseClick = onPurchaseClick,
+                            recommendedCardType = cheatRecommendation,
+                            modifier = Modifier.align(Alignment.Center)
+                        )
                     }
 
                     else if (state.gamePhase == GamePhase.RESOLVE_EFFECTS) {

--- a/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/GameScreenViewModel.kt
@@ -516,6 +516,7 @@ class GameScreenViewModel(
             state.copy(
                 selectedPurchaseItemType = item.type,
                 purchaseFeedbackItemType = null,
+                purchaseFeedbackType = null,
                 purchaseMessage = null
             )
         }
@@ -545,6 +546,7 @@ class GameScreenViewModel(
                 selectedPurchaseItemType = item.type,
                 pendingPurchaseItemType = item.type,
                 purchaseFeedbackItemType = item.type,
+                purchaseFeedbackType = item.purchaseType,
                 purchaseMessage = "Buying ${item.displayName}..."
             )
         }
@@ -614,6 +616,7 @@ class GameScreenViewModel(
                         selectedPurchaseItemType = null,
                         pendingPurchaseItemType = null,
                         purchaseFeedbackItemType = event.itemType,
+                        purchaseFeedbackType = event.purchaseType,
                         purchaseMessage = "${event.itemType.toDisplayName()} bought"
                     )
                 }
@@ -642,6 +645,7 @@ class GameScreenViewModel(
                 pendingPurchaseItemType = null,
                 selectedPurchaseItemType = null,
                 purchaseFeedbackItemType = null,
+                purchaseFeedbackType = null,
                 purchaseMessage = null
             )
         }

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/PlayerCards.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/PlayerCards.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.border
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -42,6 +43,8 @@ import com.machikoro.client.domain.model.state.PlayerCardState
 import com.machikoro.client.domain.model.state.PlayerLandmarkState
 import com.machikoro.client.R
 import com.machikoro.client.ui.shared.BasicText
+import com.machikoro.client.ui.shared.AnimatedItem
+import com.machikoro.client.ui.shared.AnimationType
 import com.machikoro.client.ui.theme.TextBlueDark
 
 
@@ -169,6 +172,86 @@ private fun LandmarkDisplay(
         height = height,
         modifier = modifier
     )
+}
+
+internal data class LandmarkPurchaseRevealUi(
+    val landmarks: List<PlayerLandmarkState>,
+    val title: String,
+    val message: String,
+)
+
+internal fun GameScreenState.landmarkPurchaseRevealUi(
+    purchasedLandmark: LandmarkType,
+): LandmarkPurchaseRevealUi {
+    val activePlayer = players.firstOrNull { it.isActivePlayer }
+    val activePlayerId = activePlayer?.id?.toIntOrNull()
+    val landmarksByType = playerLandmarks[activePlayerId]
+        .orEmpty()
+        .associateBy { it.landmarkType }
+
+    val landmarks = LandmarkType.entries.map { landmarkType ->
+        val landmark = landmarksByType[landmarkType]
+            ?: PlayerLandmarkState(landmarkType = landmarkType, isBuilt = false)
+
+        if (landmarkType == purchasedLandmark) {
+            landmark.copy(isBuilt = true)
+        } else {
+            landmark
+        }
+    }
+    val allLandmarksBuilt = landmarks.all { it.isBuilt }
+    val playerName = activePlayer?.displayName ?: "Player"
+
+    return LandmarkPurchaseRevealUi(
+        landmarks = landmarks,
+        title = if (isActivePlayer) "Your landmarks" else "$playerName's landmarks",
+        message = when {
+            allLandmarksBuilt && isActivePlayer -> "You won!"
+            allLandmarksBuilt -> "$playerName wins!"
+            isActivePlayer -> "You are closer to winning!"
+            else -> "$playerName is closer to winning!"
+        }
+    )
+}
+
+@Composable
+internal fun LandmarkPurchaseReveal(
+    state: GameScreenState,
+    purchasedLandmark: LandmarkType,
+    modifier: Modifier = Modifier,
+) {
+    val reveal = state.landmarkPurchaseRevealUi(purchasedLandmark)
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        BasicText(reveal.title)
+        BasicText(reveal.message)
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            reveal.landmarks.forEach { landmark ->
+                if (landmark.landmarkType == purchasedLandmark) {
+                    AnimatedItem(
+                        delayMillis = 250,
+                        animationType = AnimationType.Bounce
+                    ) {
+                        LandmarkDisplay(
+                            item = landmark,
+                            width = 155.dp,
+                            height = 175.dp
+                        )
+                    }
+                } else {
+                    LandmarkDisplay(
+                        item = landmark,
+                        width = 155.dp,
+                        height = 175.dp
+                    )
+                }
+            }
+        }
+    }
 }
 
 @Composable
@@ -344,5 +427,34 @@ private fun PlayerCardsDisplayPreview() {
                 )
             )
         )
+    )
+}
+
+@Preview(showBackground = true, widthDp = 915, heightDp = 430)
+@Composable
+private fun LandmarkPurchaseRevealPreview() {
+    LandmarkPurchaseReveal(
+        state = GameScreenState.initial().copy(
+            myUserId = 42,
+            activePlayerId = 42,
+            players = listOf(
+                com.machikoro.client.domain.model.state.PlayerCoinState(
+                    id = "1",
+                    displayName = "Player 1",
+                    coins = 4,
+                    isCurrentPlayer = true,
+                    isActivePlayer = true
+                )
+            ),
+            playerLandmarks = mapOf(
+                1 to listOf(
+                    PlayerLandmarkState(LandmarkType.TRAIN_STATION, isBuilt = true),
+                    PlayerLandmarkState(LandmarkType.SHOPPING_MALL, isBuilt = false),
+                    PlayerLandmarkState(LandmarkType.AMUSEMENT_PARK, isBuilt = false),
+                    PlayerLandmarkState(LandmarkType.RADIO_TOWER, isBuilt = false)
+                )
+            )
+        ),
+        purchasedLandmark = LandmarkType.SHOPPING_MALL
     )
 }

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/PlayerCards.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/PlayerCards.kt
@@ -249,6 +249,8 @@ internal fun LandmarkPurchaseReveal(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
+        BasicText("${reveal.title} - ${reveal.message}")
+
         BoxWithConstraints(
             modifier = Modifier.fillMaxWidth(),
             contentAlignment = Alignment.Center
@@ -283,7 +285,6 @@ internal fun LandmarkPurchaseReveal(
                 }
             }
         }
-        BasicText("${reveal.title} - ${reveal.message}")
     }
 }
 

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/PlayerCards.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/PlayerCards.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.border
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -182,6 +183,12 @@ internal data class LandmarkPurchaseRevealUi(
     val message: String,
 )
 
+internal fun landmarkRevealCardWidth(
+    availableWidth: Dp,
+    spacing: Dp = 8.dp,
+): Dp = ((availableWidth - spacing * 3) / 4)
+    .coerceIn(1.dp, 155.dp)
+
 internal fun GameScreenState.landmarkPurchaseRevealUi(
     purchasedLandmark: LandmarkType,
 ): LandmarkPurchaseRevealUi {
@@ -226,32 +233,41 @@ internal fun LandmarkPurchaseReveal(
     val reveal = state.landmarkPurchaseRevealUi(purchasedLandmark)
 
     Column(
-        modifier = modifier,
+        modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            reveal.landmarks.forEach { landmark ->
-                if (
-                    landmark.landmarkType == purchasedLandmark &&
-                    animatePurchasedLandmark
-                ) {
-                    AnimatedItem(
-                        delayMillis = 250,
-                        animationType = AnimationType.Bounce
+        BoxWithConstraints(
+            modifier = Modifier.fillMaxWidth(),
+            contentAlignment = Alignment.Center
+        ) {
+            val spacing = 8.dp
+            val cardWidth = landmarkRevealCardWidth(maxWidth, spacing)
+            val cardHeight = cardWidth * (175f / 155f)
+
+            Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
+                reveal.landmarks.forEach { landmark ->
+                    if (
+                        landmark.landmarkType == purchasedLandmark &&
+                        animatePurchasedLandmark
                     ) {
+                        AnimatedItem(
+                            delayMillis = 250,
+                            animationType = AnimationType.Bounce
+                        ) {
+                            LandmarkDisplay(
+                                item = landmark,
+                                width = cardWidth,
+                                height = cardHeight
+                            )
+                        }
+                    } else {
                         LandmarkDisplay(
                             item = landmark,
-                            width = 155.dp,
-                            height = 175.dp
+                            width = cardWidth,
+                            height = cardHeight
                         )
                     }
-                } else {
-                    LandmarkDisplay(
-                        item = landmark,
-                        width = 155.dp,
-                        height = 175.dp
-                    )
                 }
             }
         }

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/PlayerCards.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/PlayerCards.kt
@@ -221,6 +221,7 @@ internal fun GameScreenState.landmarkPurchaseRevealUi(
         }
     }
     val allLandmarksBuilt = landmarks.all { it.isBuilt }
+    val remainingLandmarks = landmarks.count { !it.isBuilt }
     val playerName = activePlayer?.displayName ?: "Player"
 
     return LandmarkPurchaseRevealUi(
@@ -229,6 +230,10 @@ internal fun GameScreenState.landmarkPurchaseRevealUi(
         message = when {
             allLandmarksBuilt && isActivePlayer -> "You won!"
             allLandmarksBuilt -> "$playerName wins!"
+            remainingLandmarks == 1 && isActivePlayer ->
+                "Only 1 landmark left - keep going!"
+            remainingLandmarks == 1 ->
+                "$playerName has almost finished!"
             isActivePlayer -> "You are closer to winning!"
             else -> "$playerName is closer to winning!"
         }
@@ -249,7 +254,7 @@ internal fun LandmarkPurchaseReveal(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        BasicText("${reveal.title} - ${reveal.message}")
+        BasicText("${reveal.title}: ${reveal.message}")
 
         BoxWithConstraints(
             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/PlayerCards.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/PlayerCards.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -170,6 +171,7 @@ private fun LandmarkDisplay(
         drawableResId = drawableForPlayerLandmark(item),
         width = width,
         height = height,
+        contentScale = ContentScale.FillBounds,
         modifier = modifier
     )
 }
@@ -219,6 +221,7 @@ internal fun LandmarkPurchaseReveal(
     state: GameScreenState,
     purchasedLandmark: LandmarkType,
     modifier: Modifier = Modifier,
+    animatePurchasedLandmark: Boolean = !LocalInspectionMode.current,
 ) {
     val reveal = state.landmarkPurchaseRevealUi(purchasedLandmark)
 
@@ -227,11 +230,12 @@ internal fun LandmarkPurchaseReveal(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        BasicText(reveal.title)
-        BasicText(reveal.message)
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             reveal.landmarks.forEach { landmark ->
-                if (landmark.landmarkType == purchasedLandmark) {
+                if (
+                    landmark.landmarkType == purchasedLandmark &&
+                    animatePurchasedLandmark
+                ) {
                     AnimatedItem(
                         delayMillis = 250,
                         animationType = AnimationType.Bounce
@@ -251,6 +255,7 @@ internal fun LandmarkPurchaseReveal(
                 }
             }
         }
+        BasicText("${reveal.title} - ${reveal.message}")
     }
 }
 
@@ -288,11 +293,12 @@ internal fun CardArtImage(
     height: Dp,
     modifier: Modifier = Modifier,
     alpha: Float = 1f,
+    contentScale: ContentScale = ContentScale.Fit,
 ) {
     Image(
         painter = painterResource(id = drawableResId),
         contentDescription = null,
-        contentScale = ContentScale.Fit,
+        contentScale = contentScale,
         modifier = modifier
             .width(width)
             .height(height)
@@ -455,6 +461,7 @@ private fun LandmarkPurchaseRevealPreview() {
                 )
             )
         ),
-        purchasedLandmark = LandmarkType.SHOPPING_MALL
+        purchasedLandmark = LandmarkType.SHOPPING_MALL,
+        animatePurchasedLandmark = true
     )
 }

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
@@ -72,17 +72,32 @@ internal fun BuyingPhaseShop(
 ) {
     // displays purchased card after SUCCESS
     if(state.purchaseState == PurchaseState.SUCCESS) {
-        state.purchaseFeedbackItemType?.let {
-            AnimatedItem(
-                delayMillis = 0,
-                animationType = AnimationType.Bounce
-            ) {
-                PurchaseDisplay(
-                    modifier = Modifier.offset(y = -30.dp),
-                    drawable = drawableForPlayerCard(it),
-                    name = state.activePlayerUsername,
-                    isActive = state.isActivePlayer
-                )
+        val purchasedLandmark = state.purchaseFeedbackItemType?.let { itemType ->
+            runCatching { LandmarkType.valueOf(itemType) }.getOrNull()
+        }
+
+        if (
+            state.purchaseFeedbackType == PurchaseType.LANDMARK &&
+            purchasedLandmark != null
+        ) {
+            LandmarkPurchaseReveal(
+                state = state,
+                purchasedLandmark = purchasedLandmark,
+                modifier = Modifier.offset(y = (-30).dp)
+            )
+        } else {
+            state.purchaseFeedbackItemType?.let {
+                AnimatedItem(
+                    delayMillis = 0,
+                    animationType = AnimationType.Bounce
+                ) {
+                    PurchaseDisplay(
+                        modifier = Modifier.offset(y = -30.dp),
+                        drawable = drawableForPlayerCard(it),
+                        name = state.activePlayerUsername,
+                        isActive = state.isActivePlayer
+                    )
+                }
             }
         }
     } else {

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
@@ -500,6 +500,29 @@ private fun GameScreenLandmarkPurchaseSuccessPreview() {
 
 @Preview(showBackground = true, widthDp = 915, heightDp = 430)
 @Composable
+private fun GameScreenLandmarkAlmostWonPreview() {
+    ClientTheme {
+        GameScreen(
+            state = previewBuyingPhaseState().copy(
+                gamePhase = GamePhase.BUY_OR_BUILD,
+                purchaseState = PurchaseState.SUCCESS,
+                purchaseFeedbackItemType = LandmarkType.AMUSEMENT_PARK.name,
+                purchaseFeedbackType = PurchaseType.LANDMARK,
+                playerLandmarks = mapOf(
+                    1 to listOf(
+                        PlayerLandmarkState(LandmarkType.TRAIN_STATION, isBuilt = true),
+                        PlayerLandmarkState(LandmarkType.SHOPPING_MALL, isBuilt = true),
+                        PlayerLandmarkState(LandmarkType.AMUSEMENT_PARK, isBuilt = false),
+                        PlayerLandmarkState(LandmarkType.RADIO_TOWER, isBuilt = false),
+                    )
+                )
+            )
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 915, heightDp = 430)
+@Composable
 private fun GameScreenNotActivePlayerPreview() {
     ClientTheme {
         GameScreen(

--- a/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
+++ b/app/src/main/java/com/machikoro/client/ui/game/ui/Shop.kt
@@ -83,7 +83,7 @@ internal fun BuyingPhaseShop(
             LandmarkPurchaseReveal(
                 state = state,
                 purchasedLandmark = purchasedLandmark,
-                modifier = Modifier.offset(y = (-30).dp)
+                modifier = Modifier.offset(y = 21.dp)
             )
         } else {
             state.purchaseFeedbackItemType?.let {
@@ -469,6 +469,21 @@ private fun GameScreenPurchaseSuccessPreview() {
                 gamePhase = GamePhase.BUY_OR_BUILD,
                 purchaseState = PurchaseState.SUCCESS,
                 purchaseFeedbackItemType = CardType.BAKERY.name
+            )
+        )
+    }
+}
+
+@Preview(showBackground = true, widthDp = 915, heightDp = 430)
+@Composable
+private fun GameScreenLandmarkPurchaseSuccessPreview() {
+    ClientTheme {
+        GameScreen(
+            state = previewBuyingPhaseState().copy(
+                gamePhase = GamePhase.BUY_OR_BUILD,
+                purchaseState = PurchaseState.SUCCESS,
+                purchaseFeedbackItemType = LandmarkType.SHOPPING_MALL.name,
+                purchaseFeedbackType = PurchaseType.LANDMARK
             )
         )
     }

--- a/app/src/test/java/com/machikoro/client/domain/model/state/GameScreenStateTest.kt
+++ b/app/src/test/java/com/machikoro/client/domain/model/state/GameScreenStateTest.kt
@@ -25,6 +25,7 @@ class GameScreenStateTest {
         assertEquals(null, state.selectedPurchaseItemType)
         assertEquals(null, state.pendingPurchaseItemType)
         assertEquals(null, state.purchaseFeedbackItemType)
+        assertEquals(null, state.purchaseFeedbackType)
         assertEquals(null, state.purchaseMessage)
         assertEquals(false, state.isBuyingPhase)
     }

--- a/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/GameScreenViewModelTest.kt
@@ -876,6 +876,7 @@ class GameScreenViewModelTest {
         assertNull(viewModel.state.value.selectedPurchaseItemType)
         assertNull(viewModel.state.value.pendingPurchaseItemType)
         assertEquals("BAKERY", viewModel.state.value.purchaseFeedbackItemType)
+        assertEquals(PurchaseType.ESTABLISHMENT, viewModel.state.value.purchaseFeedbackType)
         assertEquals("Bakery bought", viewModel.state.value.purchaseMessage)
     }
 
@@ -900,6 +901,7 @@ class GameScreenViewModelTest {
 
         assertEquals(PurchaseState.SUCCESS, viewModel.state.value.purchaseState)
         assertEquals("BAKERY", viewModel.state.value.purchaseFeedbackItemType)
+        assertEquals(PurchaseType.ESTABLISHMENT, viewModel.state.value.purchaseFeedbackType)
         assertEquals("Bakery bought", viewModel.state.value.purchaseMessage)
         assertNull(fakeClient.endedTurnGameId)
     }

--- a/app/src/test/java/com/machikoro/client/ui/game/ui/LandmarkPurchaseRevealTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/ui/LandmarkPurchaseRevealTest.kt
@@ -1,5 +1,6 @@
 package com.machikoro.client.ui.game.ui
 
+import androidx.compose.ui.unit.dp
 import com.machikoro.client.domain.enums.LandmarkType
 import com.machikoro.client.domain.model.state.GameScreenState
 import com.machikoro.client.domain.model.state.PlayerCoinState
@@ -9,6 +10,16 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class LandmarkPurchaseRevealTest {
+    @Test
+    fun landmarkCardsUseNormalSizeWhenEnoughWidthIsAvailable() {
+        assertEquals(155.dp, landmarkRevealCardWidth(700.dp))
+    }
+
+    @Test
+    fun landmarkCardsShrinkEquallyToFitNarrowLayouts() {
+        assertEquals(119.dp, landmarkRevealCardWidth(500.dp))
+    }
+
     @Test
     fun activePlayerRevealShowsAllLandmarksAndBuildsPurchasedLandmark() {
         val state = state(

--- a/app/src/test/java/com/machikoro/client/ui/game/ui/LandmarkPurchaseRevealTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/ui/LandmarkPurchaseRevealTest.kt
@@ -53,6 +53,36 @@ class LandmarkPurchaseRevealTest {
     }
 
     @Test
+    fun activePlayerWithOneLandmarkLeftGetsEncouragement() {
+        val state = state(
+            myUserId = 42,
+            landmarks = listOf(
+                PlayerLandmarkState(LandmarkType.TRAIN_STATION, isBuilt = true),
+                PlayerLandmarkState(LandmarkType.SHOPPING_MALL, isBuilt = true)
+            )
+        )
+
+        val reveal = state.landmarkPurchaseRevealUi(LandmarkType.AMUSEMENT_PARK)
+
+        assertEquals("Only 1 landmark left - keep going!", reveal.message)
+    }
+
+    @Test
+    fun passivePlayerSeesWhenActivePlayerHasAlmostFinished() {
+        val state = state(
+            myUserId = 7,
+            landmarks = listOf(
+                PlayerLandmarkState(LandmarkType.TRAIN_STATION, isBuilt = true),
+                PlayerLandmarkState(LandmarkType.SHOPPING_MALL, isBuilt = true)
+            )
+        )
+
+        val reveal = state.landmarkPurchaseRevealUi(LandmarkType.AMUSEMENT_PARK)
+
+        assertEquals("Player 1 has almost finished!", reveal.message)
+    }
+
+    @Test
     fun finalLandmarkShowsCompletionMessage() {
         val state = state(
             myUserId = 42,

--- a/app/src/test/java/com/machikoro/client/ui/game/ui/LandmarkPurchaseRevealTest.kt
+++ b/app/src/test/java/com/machikoro/client/ui/game/ui/LandmarkPurchaseRevealTest.kt
@@ -1,0 +1,78 @@
+package com.machikoro.client.ui.game.ui
+
+import com.machikoro.client.domain.enums.LandmarkType
+import com.machikoro.client.domain.model.state.GameScreenState
+import com.machikoro.client.domain.model.state.PlayerCoinState
+import com.machikoro.client.domain.model.state.PlayerLandmarkState
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LandmarkPurchaseRevealTest {
+    @Test
+    fun activePlayerRevealShowsAllLandmarksAndBuildsPurchasedLandmark() {
+        val state = state(
+            myUserId = 42,
+            landmarks = listOf(
+                PlayerLandmarkState(LandmarkType.TRAIN_STATION, isBuilt = true)
+            )
+        )
+
+        val reveal = state.landmarkPurchaseRevealUi(LandmarkType.SHOPPING_MALL)
+
+        assertEquals("Your landmarks", reveal.title)
+        assertEquals("You are closer to winning!", reveal.message)
+        assertEquals(LandmarkType.entries, reveal.landmarks.map { it.landmarkType })
+        assertTrue(
+            reveal.landmarks.first { it.landmarkType == LandmarkType.SHOPPING_MALL }.isBuilt
+        )
+    }
+
+    @Test
+    fun passivePlayerRevealNamesTheActivePlayer() {
+        val state = state(
+            myUserId = 7,
+            landmarks = emptyList()
+        )
+
+        val reveal = state.landmarkPurchaseRevealUi(LandmarkType.AMUSEMENT_PARK)
+
+        assertEquals("Player 1's landmarks", reveal.title)
+        assertEquals("Player 1 is closer to winning!", reveal.message)
+    }
+
+    @Test
+    fun finalLandmarkShowsCompletionMessage() {
+        val state = state(
+            myUserId = 42,
+            landmarks = LandmarkType.entries.map {
+                PlayerLandmarkState(
+                    landmarkType = it,
+                    isBuilt = it != LandmarkType.RADIO_TOWER
+                )
+            }
+        )
+
+        val reveal = state.landmarkPurchaseRevealUi(LandmarkType.RADIO_TOWER)
+
+        assertEquals("You won!", reveal.message)
+        assertTrue(reveal.landmarks.all { it.isBuilt })
+    }
+
+    private fun state(
+        myUserId: Int,
+        landmarks: List<PlayerLandmarkState>,
+    ): GameScreenState = GameScreenState.initial().copy(
+        myUserId = myUserId,
+        activePlayerId = 42,
+        players = listOf(
+            PlayerCoinState(
+                id = "100",
+                displayName = "Player 1",
+                coins = 10,
+                isActivePlayer = true
+            )
+        ),
+        playerLandmarks = mapOf(100 to landmarks)
+    )
+}


### PR DESCRIPTION
Adds a landmark purchase reveal before the purchase phase ends.

- Shows all four player landmarks after a landmark purchase
- Animates the newly purchased landmark
- Supports active and passive player views
- Shows a winner message when all landmarks are built
- Adds GameScreen previews and tests
- Improves card sizing, spacing, and timer visibility